### PR TITLE
Update "titlePlanAccurate" to be "yesNoDetailIfNo"

### DIFF
--- a/schemas/pdtf-1.0.0.json
+++ b/schemas/pdtf-1.0.0.json
@@ -1513,7 +1513,7 @@
                   "baspiRef": "B2.4",
                   "RDSRef": "Tenure/BoundaryDifferences,Tenure/CadastralMapOfParcels",
                   "title": "Does the title plan for the property accurately show the extent of the land and property which you are selling?",
-                  "$ref": "#/$defs/yesNoDetailIfYes"
+                  "$ref": "#/$defs/yesNoDetailIfNo"
                 },
                 "flyingFreehold": {
                   "baspiRef": "B2.5",


### PR DESCRIPTION
The field`/propertyPack/additionalLegalInformation/aboutTheProperty/titlePlanAccurate` should require additional details if its `yesNo` property is `"No"`.

<img width="656" alt="Screenshot 2021-11-12 at 17 41 34" src="https://user-images.githubusercontent.com/9892048/141511460-37b55bca-fd94-41e0-8b4c-7616b513e3e9.png">