### PR TITLE
added propertyPack/materialFacts/energyEfficiency/certificate/validUntilDate & removed min_max for heading under googleStreetView

### DIFF
--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -295,9 +295,7 @@
                   "properties": {
                     "heading": {
                       "title": "The heading for the google streetview camera",
-                      "type": "number",
-                      "minimum": 0,
-                      "maximum": 360
+                      "type": "number"
                     },
                     "pitch": {
                       "title": "The pitch for the google streetview camera",
@@ -8449,6 +8447,10 @@
                     },
                     "uprn": {
                       "type": "integer"
+                    },
+                    "validUntillDate": {
+                      "type": "string",
+                      "format": "date"
                     },
                     "wallsDescription": {
                       "type": "string"

--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -290,29 +290,31 @@
                   }
                 },
                 "googleStreetViewPOV": {
-                  "title": "Street View to render street nearby property in Google Street View ",
+                  "title": "Street View to render street nearby property in Google Street View",
                   "type": "object",
                   "properties": {
                     "heading": {
-                      "title": "The heading for the google streetview camera",
-                      "type": "number"
+                      "title": "The heading for the Google Street View camera",
+                      "type": "number",
+                      "minimum": -360,
+                      "maximum": 360
                     },
                     "pitch": {
-                      "title": "The pitch for the google streetview camera",
+                      "title": "The pitch for the Google Street View camera",
                       "type": "number"
                     },
                     "zoom": {
-                      "title": "The zoom level for the google streetview camera",
+                      "title": "The zoom level for the Google Street View camera",
                       "type": "number"
                     },
                     "lat": {
-                      "title": "The latitude for the google streetview camera",
+                      "title": "The latitude for the Google Street View camera",
                       "type": "number",
                       "minimum": -90,
                       "maximum": 90
                     },
                     "lng": {
-                      "title": "The longitude for the google streetview camera",
+                      "title": "The longitude for the Google Street View camera",
                       "type": "number",
                       "minimum": -180,
                       "maximum": 180
@@ -8447,10 +8449,6 @@
                     },
                     "uprn": {
                       "type": "integer"
-                    },
-                    "validUntillDate": {
-                      "type": "string",
-                      "format": "date"
                     },
                     "wallsDescription": {
                       "type": "string"

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -218,9 +218,7 @@
                   "properties": {
                     "heading": {
                       "title": "The heading for the google streetview camera",
-                      "type": "number",
-                      "minimum": 0,
-                      "maximum": 360
+                      "type": "number"
                     },
                     "pitch": {
                       "title": "The pitch for the google streetview camera",
@@ -7425,6 +7423,10 @@
                     },
                     "uprn": {
                       "type": "integer"
+                    },
+                    "validUntillDate": {
+                      "type": "string",
+                      "format": "date"
                     },
                     "wallsDescription": {
                       "type": "string"

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -213,29 +213,31 @@
                   }
                 },
                 "googleStreetViewPOV": {
-                  "title": "Street View to render street nearby property in Google Street View ",
+                  "title": "Street View to render street nearby property in Google Street View",
                   "type": "object",
                   "properties": {
                     "heading": {
-                      "title": "The heading for the google streetview camera",
-                      "type": "number"
+                      "title": "The heading for the Google Street View camera",
+                      "type": "number",
+                      "minimum": -360,
+                      "maximum": 360
                     },
                     "pitch": {
-                      "title": "The pitch for the google streetview camera",
+                      "title": "The pitch for the Google Street View camera",
                       "type": "number"
                     },
                     "zoom": {
-                      "title": "The zoom level for the google streetview camera",
+                      "title": "The zoom level for the Google Street View camera",
                       "type": "number"
                     },
                     "lat": {
-                      "title": "The latitude for the google streetview camera",
+                      "title": "The latitude for the Google Street View camera",
                       "type": "number",
                       "minimum": -90,
                       "maximum": 90
                     },
                     "lng": {
-                      "title": "The longitude for the google streetview camera",
+                      "title": "The longitude for the Google Street View camera",
                       "type": "number",
                       "minimum": -180,
                       "maximum": 180
@@ -7423,10 +7425,6 @@
                     },
                     "uprn": {
                       "type": "integer"
-                    },
-                    "validUntillDate": {
-                      "type": "string",
-                      "format": "date"
                     },
                     "wallsDescription": {
                       "type": "string"

--- a/src/schemas/v2/skeleton.json
+++ b/src/schemas/v2/skeleton.json
@@ -1103,6 +1103,7 @@
           "unheatedCorridorLength": {},
           "uprnSource": {},
           "uprn": {},
+          "validUntillDate": {},
           "wallsDescription": {},
           "wallsEnergyEff": {},
           "wallsEnvEff": {},

--- a/src/schemas/v2/skeleton.json
+++ b/src/schemas/v2/skeleton.json
@@ -1103,7 +1103,6 @@
           "unheatedCorridorLength": {},
           "uprnSource": {},
           "uprn": {},
-          "validUntillDate": {},
           "wallsDescription": {},
           "wallsEnergyEff": {},
           "wallsEnvEff": {},


### PR DESCRIPTION
1. I have introduced the "validUntilDate" key within the certificate structure. This addition serves to include the expiration date, which is a significant attribute for a valid EPC certificate. The "validUntilDate" attribute aligns with other attributes present in the certificate. To provide a visual reference, I have attached a screenshot of an EPC certificate below.
<img width="920" alt="Screenshot 2023-08-03 at 11 02 23 AM" src="https://github.com/Property-Data-Trust-Framework/schemas/assets/16436042/da3cfb16-94f7-4d67-81ff-24c5a1a62564">

2.I have eliminated the range specifications (0 to 360) from the "googleStreetView/heading" parameter. This adjustment is in response to our anticipation of negative values. In this context, negative values symbolize adjustments in the view for the property in an anticlockwise direction. Ordinarily, adjustments are made in a clockwise manner from the street view, thus positive numbers are typically encountered.