### PR TITLE
Fix typo in housing titles

### DIFF
--- a/src/schemas/v1/searches/local-searches-required.json
+++ b/src/schemas/v1/searches/local-searches-required.json
@@ -441,7 +441,7 @@
             },
             "housing": {
               "con29RRef": "3.7(d)",
-              "title": "(housing;",
+              "title": "housing;",
               "$ref": "#/$defs/yesNoDetailIfYes"
             },
             "highways": {

--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -34068,7 +34068,7 @@
                                         },
                                         "housing": {
                                           "con29RRef": "3.7(d)",
-                                          "title": "(housing;",
+                                          "title": "housing;",
                                           "type": "object",
                                           "properties": {
                                             "yesNo": {

--- a/src/schemas/v2/overlays/con29R.json
+++ b/src/schemas/v2/overlays/con29R.json
@@ -1450,7 +1450,7 @@
                                         },
                                         "housing": {
                                           "con29RRef": "3.7(d)",
-                                          "title": "(housing;",
+                                          "title": "housing;",
                                           "discriminator": {
                                             "propertyName": "yesNo"
                                           },

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -30594,7 +30594,7 @@
                                           ]
                                         },
                                         "housing": {
-                                          "title": "(housing;",
+                                          "title": "housing;",
                                           "type": "object",
                                           "properties": {
                                             "yesNo": {


### PR DESCRIPTION
This fixes a small typo in titles for `housing` properties within local searches (CON29R).

Closes #76