### PR TITLE
Add a disposal property to describe the method of sale

### DIFF
--- a/src/schemas/v1/material-facts.json
+++ b/src/schemas/v1/material-facts.json
@@ -114,6 +114,8 @@
           "type": "string",
           "enum": [
             "Auction",
+            "Formal tender",
+            "Informal tender",
             "Modern Method of Auction",
             "Private treaty"
           ]

--- a/src/schemas/v1/material-facts.json
+++ b/src/schemas/v1/material-facts.json
@@ -108,6 +108,15 @@
             "Offers in region of",
             "Sale by tender"
           ]
+        },
+        "disposal": {
+          "title": "Disposal",
+          "type": "string",
+          "enum": [
+            "Auction",
+            "Modern Method of Auction",
+            "Private treaty"
+          ]
         }
       }
     },

--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -374,6 +374,8 @@
                   "type": "string",
                   "enum": [
                     "Auction",
+                    "Formal tender",
+                    "Informal tender",
                     "Modern Method of Auction",
                     "Private treaty"
                   ]

--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -368,6 +368,15 @@
                     "Offers in region of",
                     "Sale by tender"
                   ]
+                },
+                "disposal": {
+                  "title": "Disposal",
+                  "type": "string",
+                  "enum": [
+                    "Auction",
+                    "Modern Method of Auction",
+                    "Private treaty"
+                  ]
                 }
               }
             },

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -288,6 +288,15 @@
                     "Offers in region of",
                     "Sale by tender"
                   ]
+                },
+                "disposal": {
+                  "title": "Disposal",
+                  "type": "string",
+                  "enum": [
+                    "Auction",
+                    "Modern Method of Auction",
+                    "Private treaty"
+                  ]
                 }
               }
             },

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -294,10 +294,11 @@
                   "type": "string",
                   "enum": [
                     "Auction",
+                    "Formal tender",
+                    "Informal tender",
                     "Modern Method of Auction",
                     "Private treaty"
                   ]
-                }
               }
             },
             "summaryDescription": {

--- a/src/schemas/v2/skeleton.json
+++ b/src/schemas/v2/skeleton.json
@@ -59,7 +59,8 @@
       },
       "priceInformation": {
         "price": {},
-        "priceQualifier": {}
+        "priceQualifier": {},
+        "disposal": {}
       },
       "summaryDescription": {},
       "media": {


### PR DESCRIPTION
The schema doesn't describe the way in which the property is being sold. Although it's most commonly through private treaty, other methods such as auction should be made clear to buyers. The options added are:

- `Private treaty`
- `Auction`
- `Modern Method of Auction`
- `Formal tender`
- `Informal tender`

I understand that formal/informal tender are very uncommon and have been included to be comprehensive, but could be omitted.

The `disposal` property has been added under `priceInformation` as it seems tangental, otherwise it could be set at a different level.