### PR TITLE
Add support for marketing tenure

### DIFF
--- a/src/schemas/v1/material-facts.json
+++ b/src/schemas/v1/material-facts.json
@@ -115,6 +115,17 @@
       "title": "Summary description",
       "type": "string"
     },
+    "marketingTenure": {
+      "title": "Type of tenure being marketed",
+      "type": "string",
+      "enum": [
+        "Commonhold",
+        "Freehold",
+        "Leasehold",
+        "Share of Freehold",
+        "Shared Ownership"
+      ]
+    },
     "media": {
       "title": "Media",
       "type": "array",

--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -373,6 +373,17 @@
             },
             "summaryDescription": {
               "title": "Summary description",
+              "type": "string",
+              "enum": [
+                "Commonhold",
+                "Freehold",
+                "Leasehold",
+                "Share of Freehold",
+                "Shared Ownership"
+              ]
+            },
+            "marketingTenure": {
+              "title": "Type of tenure being marketed",
               "type": "string"
             },
             "media": {

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -295,6 +295,17 @@
               "title": "Summary description",
               "type": "string"
             },
+            "marketingTenure": {
+              "title": "Type of tenure being marketed",
+              "type": "string",
+              "enum": [
+                "Commonhold",
+                "Freehold",
+                "Leasehold",
+                "Share of Freehold",
+                "Shared Ownership"
+              ]
+            },
             "media": {
               "title": "Media",
               "type": "array",

--- a/src/schemas/v2/skeleton.json
+++ b/src/schemas/v2/skeleton.json
@@ -62,6 +62,7 @@
         "priceQualifier": {}
       },
       "summaryDescription": {},
+      "marketingTenure": {},
       "media": {
         "mediaType": {},
         "mediaUrl": {},


### PR DESCRIPTION
Properties are typically marketed with their type of overall tenure: Freehold, Leasehold, Share of Freehold, Shared Ownership, Commonhold. The schema stores tenures for each title being sold, but the overall tenure as it's marketed on Rightmove for example, isn't explicitly stored and has to be inferred.

