### PR TITLE
replace `oneOf` with `anyOf` in school rating

### DIFF
--- a/src/schemas/v2/combined.json
+++ b/src/schemas/v2/combined.json
@@ -633,7 +633,7 @@
                     "discriminator": {
                       "propertyName": "ofstedRating"
                     },
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "ofstedRating": {

--- a/src/schemas/v2/pdtf-transaction.json
+++ b/src/schemas/v2/pdtf-transaction.json
@@ -572,7 +572,7 @@
                         }
                       }
                     },
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "ofstedRating": {

--- a/src/utils/extractOverlay.js
+++ b/src/utils/extractOverlay.js
@@ -64,6 +64,15 @@ const flattenSkeleton = (schema) => {
       }
     });
   }
+  if (schema.anyOf) {
+    schema.anyOf.forEach((aAnyOf) => {
+      if (aAnyOf.properties) {
+        Object.entries(aAnyOf.properties).forEach(([key, value]) => {
+          returnStructure[key] = flattenSkeleton(value);
+        });
+      }
+    });
+  }
   if (schema.items) {
     returnStructure = flattenSkeleton(schema.items);
   }


### PR DESCRIPTION
we have an enum value `Other` to the field `Ofsted rating` in school,
we added a `oneOf` construct to provide, value for the other rating. 
we experienced problems using this construct, giving validation errors, as `oneOf` cannot be used with `arrayObjects` where two items satisfy different oneOf conditions. 
we changed oneOf to a more Lenient `anyOf` condition.