### PR TITLE
Standardize Key Casing to CamelCase

### DIFF
--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -697,7 +697,7 @@
                     "entryNumber": "3",
                     "infills": {
                       "chargeDate": "2020-11-03",
-                      "ChargeParty": "Barclays Bank UK PLC"
+                      "chargeParty": "Barclays Bank UK PLC"
                     },
                     "subRegisterCode": "B",
                     "entryText": "RESTRICTION: No disposition of the registered estate by the proprietor of the registered estate is to be registered without a written consent signed by the proprietor for the time being of the Charge dated 3 November 2020 in favour of Barclays Bank UK PLC referred to in the Charges Register."
@@ -712,7 +712,7 @@
                 "subRegisterCode": "B",
                 "entryNumber": "2",
                 "infills": {
-                  "Date": "2020-11-03",
+                  "date": "2020-11-03",
                   "amount": "£1,260,000"
                 },
                 "registrationDate": "2020-11-24"

--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -382,7 +382,7 @@
       "connectivity": {
         "telephone": {
           "yesNo": "Yes",
-          "supplier": "EE"
+          "supplier": "ee"
         },
         "cableSatelliteTV": {
           "yesNo": "Yes",
@@ -617,185 +617,185 @@
         "titleNumber": "HD221222",
         "titleExtents": "{'type':'Polygon','coordinates':[[[-2.5787833768108985,51.48576273335823],[-2.578739952913823,51.48580251052463],[-2.578631396439736,51.48575988696783],[-2.578605326085179,51.48574832663401],[-2.578513422397467,51.48571281401381],[-2.578493883879733,51.48570526761721],[-2.578529455342914,51.48567092421916],[-2.578534427612858,51.485665504755744],[-2.578553966121065,51.485673051145575],[-2.5786436981835235,51.48570767529821],[-2.578671214351269,51.48571967806404],[-2.5787833768108985,51.48576273335823]]]}",
         "registerExtract": {
-          "OCSummaryData": {
-            "Title": {
-              "TitleNumber": "HD221222",
-              "ClassOfTitleCode": "10",
-              "TitleRegistrationDetails": {
-                "LatestEditionDate": "2020-11-24",
-                "RegistrationDate": "1991-11-11",
-                "DistrictName": "ST ALBANS",
-                "PostcodeZone": {
-                  "Postcode": "AL3 5AF"
+          "ocSummaryData": {
+            "title": {
+              "titleNumber": "HD221222",
+              "classOfTitleCode": "10",
+              "titleRegistrationDetails": {
+                "latestEditionDate": "2020-11-24",
+                "registrationDate": "1991-11-11",
+                "districtName": "ST ALBANS",
+                "postcodeZone": {
+                  "postcode": "AL3 5AF"
                 },
-                "LandRegistryOfficeName": "Leicester Office",
-                "AdministrativeArea": "HERTFORDSHIRE"
+                "landRegistryOfficeName": "Leicester Office",
+                "administrativeArea": "HERTFORDSHIRE"
               },
-              "CommonholdIndicator": "false"
+              "commonholdIndicator": "false"
             },
-            "OfficialCopyDateTime": "2021-12-16T08:39:52",
-            "PropertyAddress": {
-              "PostcodeZone": {
-                "Postcode": "AL3 5AF"
+            "officialCopyDateTime": "2021-12-16T08:39:52",
+            "propertyAddress": {
+              "postcodeZone": {
+                "postcode": "AL3 5AF"
               },
-              "AddressLine": {
-                "Line": ["47 Park Road", "Harpenden"]
+              "addressLine": {
+                "line": ["47 Park Road", "Harpenden"]
               }
             },
-            "Proprietorship": {
-              "RegisteredProprietorParty": [
+            "proprietorship": {
+              "registeredProprietorParty": [
                 {
-                  "PrivateIndividual": {
-                    "Name": {
-                      "SurnameName": "Hetherington-Smythe",
-                      "ForenamesName": "Peter Ronald"
+                  "privateIndividual": {
+                    "name": {
+                      "surnameName": "Hetherington-Smythe",
+                      "forenamesName": "Peter Ronald"
                     }
                   },
-                  "Address": {
-                    "PostcodeZone": {
-                      "Postcode": "AL3 5AF"
+                  "address": {
+                    "postcodeZone": {
+                      "postcode": "AL3 5AF"
                     },
-                    "AddressLine": {
-                      "Line": ["47 Park Road", "Harpenden"]
+                    "addressLine": {
+                      "line": ["47 Park Road", "Harpenden"]
                     }
                   }
                 },
                 {
-                  "Address": {
-                    "AddressLine": {
-                      "Line": ["47 Park Road", "Harpenden"]
+                  "address": {
+                    "addressLine": {
+                      "line": ["47 Park Road", "Harpenden"]
                     },
-                    "PostcodeZone": {
-                      "Postcode": "AL3 5AF"
+                    "postcodeZone": {
+                      "postcode": "AL3 5AF"
                     }
                   },
-                  "PrivateIndividual": {
-                    "Name": {
-                      "ForenamesName": "Clarissa Jane",
-                      "SurnameName": "Hetherington-Smythe"
+                  "privateIndividual": {
+                    "name": {
+                      "forenamesName": "Clarissa Jane",
+                      "surnameName": "Hetherington-Smythe"
                     }
                   }
                 }
               ],
-              "CurrentProprietorshipDate": "2020-11-24"
+              "currentProprietorshipDate": "2020-11-24"
             },
-            "EditionDate": "2020-11-24",
-            "DocumentDetails": {
-              "Document": {
-                "EntryNumber": ["B3", "C2", "C3", "C4"],
-                "PlanOnlyIndicator": "false",
-                "RegisterDescription": "Charge",
-                "DocumentType": "50",
-                "DocumentDate": "2020-11-03"
+            "editionDate": "2020-11-24",
+            "documentDetails": {
+              "document": {
+                "entryNumber": ["B3", "C2", "C3", "C4"],
+                "planOnlyIndicator": "false",
+                "registerDescription": "Charge",
+                "documentType": "50",
+                "documentDate": "2020-11-03"
               }
             },
-            "RestrictionDetails": {
-              "RestrictionEntry": {
-                "ChargeRestriction": {
-                  "ChargeID": "1",
-                  "EntryDetails": {
-                    "EntryNumber": "3",
-                    "Infills": {
-                      "ChargeDate": "2020-11-03",
+            "restrictionDetails": {
+              "restrictionEntry": {
+                "chargeRestriction": {
+                  "chargeID": "1",
+                  "entryDetails": {
+                    "entryNumber": "3",
+                    "infills": {
+                      "chargeDate": "2020-11-03",
                       "ChargeParty": "Barclays Bank UK PLC"
                     },
-                    "SubRegisterCode": "B",
-                    "EntryText": "RESTRICTION: No disposition of the registered estate by the proprietor of the registered estate is to be registered without a written consent signed by the proprietor for the time being of the Charge dated 3 November 2020 in favour of Barclays Bank UK PLC referred to in the Charges Register."
+                    "subRegisterCode": "B",
+                    "entryText": "RESTRICTION: No disposition of the registered estate by the proprietor of the registered estate is to be registered without a written consent signed by the proprietor for the time being of the Charge dated 3 November 2020 in favour of Barclays Bank UK PLC referred to in the Charges Register."
                   },
-                  "RestrictionTypeCode": "30"
+                  "restrictionTypeCode": "30"
                 }
               }
             },
-            "PricePaidEntry": {
-              "EntryDetails": {
-                "EntryText": "The price stated to have been paid on 3 November 2020 was £1,100,000.",
-                "SubRegisterCode": "B",
-                "EntryNumber": "2",
-                "Infills": {
+            "pricePaidEntry": {
+              "entryDetails": {
+                "entryText": "The price stated to have been paid on 3 November 2020 was £1,100,000.",
+                "subRegisterCode": "B",
+                "entryNumber": "2",
+                "infills": {
                   "Date": "2020-11-03",
-                  "Amount": "£1,260,000"
+                  "amount": "£1,260,000"
                 },
-                "RegistrationDate": "2020-11-24"
+                "registrationDate": "2020-11-24"
               }
             },
-            "Charge": {
-              "ChargeEntry": {
-                "RegisteredCharge": {
-                  "EntryDetails": {
-                    "SubRegisterCode": "C",
-                    "RegistrationDate": "2020-11-24",
-                    "EntryText": "REGISTERED CHARGE dated 3 November 2020.",
-                    "Infills": {
-                      "ChargeDate": "2020-11-03"
+            "charge": {
+              "chargeEntry": {
+                "registeredCharge": {
+                  "entryDetails": {
+                    "subRegisterCode": "C",
+                    "registrationDate": "2020-11-24",
+                    "entryText": "REGISTERED CHARGE dated 3 November 2020.",
+                    "infills": {
+                      "chargeDate": "2020-11-03"
                     },
-                    "EntryNumber": "2"
+                    "entryNumber": "2"
                   }
                 },
-                "ChargeDate": "2020-11-03",
-                "ChargeID": "1",
-                "ChargeProprietor": {
-                  "ChargeeParty": {
-                    "Organization": {
+                "chargeDate": "2020-11-03",
+                "chargeID": "1",
+                "chargeProprietor": {
+                  "chargeeParty": {
+                    "organization": {
                       "Name": "Barclays Bank UK PLC"
                     },
-                    "Address": {
-                      "AddressLine": {
-                        "Line": ["P.O. Box 187", "Leeds"]
+                    "address": {
+                      "addressLine": {
+                        "line": ["P.O. Box 187", "Leeds"]
                       },
-                      "PostcodeZone": {
-                        "Postcode": "LS11 1AN"
+                      "postcodeZone": {
+                        "postcode": "LS11 1AN"
                       }
                     }
                   },
-                  "EntryDetails": {
-                    "SubRegisterCode": "C",
-                    "RegistrationDate": "2020-11-24",
-                    "EntryNumber": "3",
-                    "EntryText": "Proprietor: BARCLAYS BANK UK PLC (Co. Regn. No. 9740322) of P.O. Box 187, Leeds LS11 1AN."
+                  "entryDetails": {
+                    "subRegisterCode": "C",
+                    "registrationDate": "2020-11-24",
+                    "entryNumber": "3",
+                    "entryText": "Proprietor: BARCLAYS BANK UK PLC (Co. Regn. No. 9740322) of P.O. Box 187, Leeds LS11 1AN."
                   }
                 }
               }
             },
-            "RegisterEntryIndicators": {
-              "UnidentifiedEntryIndicator": "false",
-              "SubChargeIndicator": "false",
-              "DiscountChargeIndicator": "false",
-              "ChargeIndicator": "true",
-              "PropertyDescriptionNotesIndicator": "false",
-              "ChargeRelatedRestrictionIndicator": "false",
-              "BankruptcyIndicator": "false",
-              "MultipleChargeIndicator": "false",
-              "HomeRightsChangeOfAddressIndicator": "false",
-              "CCBIIndicator": "false",
-              "AgreedNoticeIndicator": "false",
-              "VendorsLienIndicator": "false",
-              "RightOfPreEmptionIndicator": "false",
-              "CreditorsNoticeIndicator": "false",
-              "CautionIndicator": "false",
-              "ChargeRestrictionIndicator": "true",
-              "ScheduleOfLeasesIndicator": "false",
-              "UnilateralNoticeIndicator": "false",
-              "DeathOfProprietorIndicator": "false",
-              "RentChargeIndicator": "false",
-              "EquitableChargeIndicator": "false",
-              "ChargeeIndicator": "true",
-              "DeedOfPostponementIndicator": "false",
-              "NonChargeRestrictionIndicator": "false",
-              "GreenOutEntryIndicator": "false",
-              "UnilateralNoticeBeneficiaryIndicator": "false",
-              "NotedChargeIndicator": "false",
-              "PricePaidIndicator": "true",
-              "HomeRightsIndicator": "false",
-              "LeaseHoldTitleIndicator": "false"
+            "registerEntryIndicators": {
+              "unidentifiedEntryIndicator": "false",
+              "subChargeIndicator": "false",
+              "discountChargeIndicator": "false",
+              "chargeIndicator": "true",
+              "propertyDescriptionNotesIndicator": "false",
+              "chargeRelatedRestrictionIndicator": "false",
+              "bankruptcyIndicator": "false",
+              "multipleChargeIndicator": "false",
+              "homeRightsChangeOfAddressIndicator": "false",
+              "ccbiIndicator": "false",
+              "agreedNoticeIndicator": "false",
+              "vendorsLienIndicator": "false",
+              "rightOfPreEmptionIndicator": "false",
+              "creditorsNoticeIndicator": "false",
+              "cautionIndicator": "false",
+              "chargeRestrictionIndicator": "true",
+              "scheduleOfLeasesIndicator": "false",
+              "unilateralNoticeIndicator": "false",
+              "deathOfProprietorIndicator": "false",
+              "rentChargeIndicator": "false",
+              "equitableChargeIndicator": "false",
+              "chargeeIndicator": "true",
+              "deedOfPostponementIndicator": "false",
+              "nonChargeRestrictionIndicator": "false",
+              "greenOutEntryIndicator": "false",
+              "unilateralNoticeBeneficiaryIndicator": "false",
+              "notedChargeIndicator": "false",
+              "pricePaidIndicator": "true",
+              "homeRightsIndicator": "false",
+              "leaseHoldTitleIndicator": "false"
             }
           },
-          "OCRegisterData": {
-            "ChargesRegister": {
-              "RegisterEntry": [
+          "ocRegisterData": {
+            "chargesRegister": {
+              "registerEntry": [
                 {
-                  "EntryNumber": "1",
-                  "EntryType": "Restrictive Covenants/Stipulations - Deed",
-                  "EntryText": [
+                  "entryNumber": "1",
+                  "entryType": "Restrictive Covenants/Stipulations - Deed",
+                  "entryText": [
                     "A Conveyance of the land in this title dated 7 June 1946 made between (1) Jesse Catton (Vendor) and (2) Henry Dick Goodman Cunnold (Purchaser) contains the following covenants:-",
                     "\"THE Purchaser for himself his successors in title and assigns and to the intent that this covenant will run with the land but not so that the Purchaser is liable after he has parted with the same hereby covenants with the Vendor and his successors in title that he the Purchaser and his successors in title will observe and perform the covenants contained in the Schedule hereto.",
                     "THE SCHEDULE before referred to",
@@ -805,69 +805,69 @@
                     "(4)  That only one such dwellinghouse shall be on the said piece of land.\"",
                     "NOTE: The North Eastern boundary of the land in this title is marked \"T\""
                   ],
-                  "EntryDate": "1991-11-11"
+                  "entryDate": "1991-11-11"
                 },
                 {
-                  "EntryText": "REGISTERED CHARGE dated 3 November 2020.",
-                  "EntryType": "Registered Charges",
-                  "EntryDate": "2020-11-24",
-                  "EntryNumber": "2"
+                  "entryText": "REGISTERED CHARGE dated 3 November 2020.",
+                  "entryType": "Registered Charges",
+                  "entryDate": "2020-11-24",
+                  "entryNumber": "2"
                 },
                 {
-                  "EntryNumber": "3",
-                  "EntryDate": "2020-11-24",
-                  "EntryType": "Chargee",
-                  "EntryText": "Proprietor: BARCLAYS BANK UK PLC (Co. Regn. No. 9740322) of P.O. Box 187, Leeds LS11 1AN."
+                  "entryNumber": "3",
+                  "entryDate": "2020-11-24",
+                  "entryType": "Chargee",
+                  "entryText": "Proprietor: BARCLAYS BANK UK PLC (Co. Regn. No. 9740322) of P.O. Box 187, Leeds LS11 1AN."
                 },
                 {
-                  "EntryType": "Obligation",
-                  "EntryDate": "2020-11-24",
-                  "EntryNumber": "4",
-                  "EntryText": "The proprietor of the Charge dated 3 November 2020 referred to above is under an obligation to make further advances. These advances will have priority to the extent afforded by section 49(3) Land Registration Act 2002."
+                  "entryType": "Obligation",
+                  "entryDate": "2020-11-24",
+                  "entryNumber": "4",
+                  "entryText": "The proprietor of the Charge dated 3 November 2020 referred to above is under an obligation to make further advances. These advances will have priority to the extent afforded by section 49(3) Land Registration Act 2002."
                 }
               ]
             },
-            "PropertyRegister": {
-              "DistrictDetails": {
-                "EntryText": "HERTFORDSHIRE : ST ALBANS"
+            "propertyRegister": {
+              "districtDetails": {
+                "entryText": "HERTFORDSHIRE : ST ALBANS"
               },
-              "RegisterEntry": [
+              "registerEntry": [
                 {
-                  "EntryType": "Property Description",
-                  "EntryNumber": "1",
-                  "EntryText": "The Freehold land shown edged with red on the plan of the above Title filed at the Registry and being 47 Park Road, Harpenden (AL3 5AF).",
-                  "EntryDate": "1991-11-11"
+                  "entryType": "Property Description",
+                  "entryNumber": "1",
+                  "entryText": "The Freehold land shown edged with red on the plan of the above Title filed at the Registry and being 47 Park Road, Harpenden (AL3 5AF).",
+                  "entryDate": "1991-11-11"
                 },
                 {
-                  "EntryNumber": "2",
-                  "EntryText": [
+                  "entryNumber": "2",
+                  "entryText": [
                     "The Conveyance dated 7 June 1946 referred to in the Charges Register contains the following provision:-",
                     "\"IT IS hereby declared that the Purchaser shall not be entitled to any right of light or air which will restrict the free use of the adjoining property of the Vendor for building or other purpose.\""
                   ],
-                  "EntryDate": "1991-11-11",
-                  "EntryType": "Provisions"
+                  "entryDate": "1991-11-11",
+                  "entryType": "Provisions"
                 }
               ]
             },
-            "ProprietorshipRegister": {
-              "RegisterEntry": [
+            "proprietorshipRegister": {
+              "registerEntry": [
                 {
-                  "EntryDate": "2020-11-24",
-                  "EntryText": "PROPRIETOR: PETER RONALD HETHERINGTON-SMYTH and CLARISSA JANE HETHERINGTON-SMYTH of 47 Park Road, Harpenden AL3 5AF.",
-                  "EntryType": "Proprietor",
-                  "EntryNumber": "1"
+                  "entryDate": "2020-11-24",
+                  "entryText": "PROPRIETOR: PETER RONALD HETHERINGTON-SMYTH and CLARISSA JANE HETHERINGTON-SMYTH of 47 Park Road, Harpenden AL3 5AF.",
+                  "entryType": "Proprietor",
+                  "entryNumber": "1"
                 },
                 {
-                  "EntryText": "The price stated to have been paid on 3 November 2020 was £1,260,000.",
-                  "EntryType": "Price Paid",
-                  "EntryDate": "2020-11-24",
-                  "EntryNumber": "2"
+                  "entryText": "The price stated to have been paid on 3 November 2020 was £1,260,000.",
+                  "entryType": "Price Paid",
+                  "entryDate": "2020-11-24",
+                  "entryNumber": "2"
                 },
                 {
-                  "EntryNumber": "3",
-                  "EntryDate": "2020-11-24",
-                  "EntryType": "Charge Restriction - B Register",
-                  "EntryText": "RESTRICTION: No disposition of the registered estate by the proprietor of the registered estate is to be registered without a written consent signed by the proprietor for the time being of the Charge dated 3 November 2020 in favour of Barclays Bank UK PLC referred to in the Charges Register."
+                  "entryNumber": "3",
+                  "entryDate": "2020-11-24",
+                  "entryType": "Charge Restriction - B Register",
+                  "entryText": "RESTRICTION: No disposition of the registered estate by the proprietor of the registered estate is to be registered without a written consent signed by the proprietor for the time being of the Charge dated 3 November 2020 in favour of Barclays Bank UK PLC referred to in the Charges Register."
                 }
               ]
             }

--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -382,7 +382,7 @@
       "connectivity": {
         "telephone": {
           "yesNo": "Yes",
-          "supplier": "ee"
+          "supplier": "EE"
         },
         "cableSatelliteTV": {
           "yesNo": "Yes",
@@ -736,7 +736,7 @@
                 "chargeProprietor": {
                   "chargeeParty": {
                     "organization": {
-                      "Name": "Barclays Bank UK PLC"
+                      "name": "Barclays Bank UK PLC"
                     },
                     "address": {
                       "addressLine": {

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -92,7 +92,7 @@
                 "type": "string"
               },
               "postcode": {
-                "title": "postcode",
+                "title": "Postcode",
                 "type": "string",
                 "minLength": 1
               }
@@ -254,7 +254,7 @@
                   "ta10Ref": "0.1.5",
                   "baspiRef": "A1.1.5",
                   "piqRef": "A1.1.5",
-                  "title": "postcode",
+                  "title": "Postcode",
                   "type": "string",
                   "minLength": 1
                 }
@@ -773,7 +773,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "postcode",
+                                "title": "Postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -989,7 +989,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "postcode",
+                                "title": "Postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -1315,7 +1315,7 @@
                                               },
                                               "postcode": {
                                                 "baspiRef": "A1.5.4.1.2.5",
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1413,7 +1413,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1535,7 +1535,7 @@
                                               },
                                               "postcode": {
                                                 "baspiRef": "A1.5.5.1.2.5",
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1642,7 +1642,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1923,7 +1923,7 @@
                                                       "type": "string"
                                                     },
                                                     "postcode": {
-                                                      "title": "postcode",
+                                                      "title": "Postcode",
                                                       "type": "string",
                                                       "minLength": 1
                                                     }
@@ -3658,7 +3658,7 @@
                                                   "postcode": {
                                                     "baspiRef": "A1.5.4.1.2.5",
                                                     "ta7Ref": "4.1a.6",
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3759,7 +3759,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3865,7 +3865,7 @@
                                                   },
                                                   "postcode": {
                                                     "ta7Ref": "4.1b.6",
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3996,7 +3996,7 @@
                                                   "postcode": {
                                                     "baspiRef": "A1.5.5.1.2.5",
                                                     "ta7Ref": "4.1c.6",
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4105,7 +4105,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4210,7 +4210,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4475,7 +4475,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "postcode",
+                                                          "title": "Postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4769,7 +4769,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "postcode",
+                                                          "title": "Postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4985,7 +4985,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -25325,7 +25325,7 @@
                             },
                             "postcode": {
                               "baspiRef": "B7.2.3.5",
-                              "title": "postcode",
+                              "title": "Postcode",
                               "type": "string",
                               "minLength": 1
                             }

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -32,7 +32,7 @@
         "baspiRequired": ["name", "email", "role"],
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "type": "object",
             "baspiRequired": ["firstName", "lastName"],
             "properties": {
@@ -745,7 +745,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "Name"
+                        "title": "name"
                       },
                       "contact": {
                         "type": "object",
@@ -912,7 +912,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "title": "Name",
+                        "title": "name",
                         "type": "string"
                       },
                       "transportType": {
@@ -956,7 +956,7 @@
                     "title": "Healthcare service",
                     "properties": {
                       "name": {
-                        "title": "Name",
+                        "title": "name",
                         "type": "string"
                       },
                       "typeOfHealthCare": {
@@ -12097,7 +12097,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "1.16",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -13493,7 +13493,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "2.11",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -14688,7 +14688,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "4.8",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15188,7 +15188,7 @@
                             "properties": {
                               "itemName": {
                                 "ta10Ref": "5.8",
-                                "title": "Name",
+                                "title": "name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -15682,7 +15682,7 @@
                             "properties": {
                               "itemName": {
                                 "ta10Ref": "5.19",
-                                "title": "Name",
+                                "title": "name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -16180,7 +16180,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "6.8",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -16673,7 +16673,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "7.8",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -17470,7 +17470,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "8.13",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -17974,7 +17974,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "11.1",
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -30124,7 +30124,7 @@
                                   "properties": {
                                     "privateIndividual": {
                                       "type": "object",
-                                      "oc1Required": ["Name"],
+                                      "oc1Required": ["name"],
                                       "properties": {
                                         "name": {
                                           "type": "object",
@@ -30174,7 +30174,7 @@
                                     },
                                     "organization": {
                                       "type": "object",
-                                      "oc1Required": ["Name"],
+                                      "oc1Required": ["name"],
                                       "properties": {
                                         "name": {
                                           "type": "string"
@@ -30323,7 +30323,7 @@
                                 "properties": {
                                   "privateIndividual": {
                                     "type": "object",
-                                    "oc1Required": ["Name"],
+                                    "oc1Required": ["name"],
                                     "properties": {
                                       "name": {
                                         "type": "object",
@@ -30373,7 +30373,7 @@
                                   },
                                   "organization": {
                                     "type": "object",
-                                    "oc1Required": ["Name"],
+                                    "oc1Required": ["name"],
                                     "properties": {
                                       "name": {
                                         "type": "string"
@@ -30526,7 +30526,7 @@
                                   "properties": {
                                     "privateIndividual": {
                                       "type": "object",
-                                      "oc1Required": ["Name"],
+                                      "oc1Required": ["name"],
                                       "properties": {
                                         "name": {
                                           "type": "object",
@@ -30576,7 +30576,7 @@
                                     },
                                     "organization": {
                                       "type": "object",
-                                      "oc1Required": ["Name"],
+                                      "oc1Required": ["name"],
                                       "properties": {
                                         "name": {
                                           "type": "string"
@@ -30725,7 +30725,7 @@
                                 "properties": {
                                   "privateIndividual": {
                                     "type": "object",
-                                    "oc1Required": ["Name"],
+                                    "oc1Required": ["name"],
                                     "properties": {
                                       "name": {
                                         "type": "object",
@@ -30775,7 +30775,7 @@
                                   },
                                   "organization": {
                                     "type": "object",
-                                    "oc1Required": ["Name"],
+                                    "oc1Required": ["name"],
                                     "properties": {
                                       "name": {
                                         "type": "string"
@@ -30952,7 +30952,7 @@
                                     "properties": {
                                       "privateIndividual": {
                                         "type": "object",
-                                        "oc1Required": ["Name"],
+                                        "oc1Required": ["name"],
                                         "properties": {
                                           "name": {
                                             "type": "object",
@@ -31004,7 +31004,7 @@
                                       },
                                       "organization": {
                                         "type": "object",
-                                        "oc1Required": ["Name"],
+                                        "oc1Required": ["name"],
                                         "properties": {
                                           "name": {
                                             "type": "string"
@@ -31682,7 +31682,7 @@
                                                 "properties": {
                                                   "privateIndividual": {
                                                     "type": "object",
-                                                    "oc1Required": ["Name"],
+                                                    "oc1Required": ["name"],
                                                     "properties": {
                                                       "name": {
                                                         "type": "object",
@@ -31738,7 +31738,7 @@
                                                   },
                                                   "organization": {
                                                     "type": "object",
-                                                    "oc1Required": ["Name"],
+                                                    "oc1Required": ["name"],
                                                     "properties": {
                                                       "name": {
                                                         "type": "string"
@@ -31903,7 +31903,7 @@
                                               "properties": {
                                                 "privateIndividual": {
                                                   "type": "object",
-                                                  "oc1Required": ["Name"],
+                                                  "oc1Required": ["name"],
                                                   "properties": {
                                                     "name": {
                                                       "type": "object",
@@ -31959,7 +31959,7 @@
                                                 },
                                                 "organization": {
                                                   "type": "object",
-                                                  "oc1Required": ["Name"],
+                                                  "oc1Required": ["name"],
                                                   "properties": {
                                                     "name": {
                                                       "type": "string"
@@ -32257,7 +32257,7 @@
                                                             "privateIndividual": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Name"
+                                                                "name"
                                                               ],
                                                               "properties": {
                                                                 "name": {
@@ -32315,7 +32315,7 @@
                                                             "organization": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Name"
+                                                                "name"
                                                               ],
                                                               "properties": {
                                                                 "name": {
@@ -32482,7 +32482,7 @@
                                                           "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -32540,7 +32540,7 @@
                                                           "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -32844,7 +32844,7 @@
                                                           "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -32902,7 +32902,7 @@
                                                           "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -33069,7 +33069,7 @@
                                                         "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -33127,7 +33127,7 @@
                                                         "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -33432,7 +33432,7 @@
                                               "properties": {
                                                 "privateIndividual": {
                                                   "type": "object",
-                                                  "oc1Required": ["Name"],
+                                                  "oc1Required": ["name"],
                                                   "properties": {
                                                     "name": {
                                                       "type": "object",
@@ -33488,7 +33488,7 @@
                                                 },
                                                 "organization": {
                                                   "type": "object",
-                                                  "oc1Required": ["Name"],
+                                                  "oc1Required": ["name"],
                                                   "properties": {
                                                     "name": {
                                                       "type": "string"
@@ -33653,7 +33653,7 @@
                                             "properties": {
                                               "privateIndividual": {
                                                 "type": "object",
-                                                "oc1Required": ["Name"],
+                                                "oc1Required": ["name"],
                                                 "properties": {
                                                   "name": {
                                                     "type": "object",
@@ -33709,7 +33709,7 @@
                                               },
                                               "organization": {
                                                 "type": "object",
-                                                "oc1Required": ["Name"],
+                                                "oc1Required": ["name"],
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
@@ -33999,7 +33999,7 @@
                                                           "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -34057,7 +34057,7 @@
                                                           "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -34224,7 +34224,7 @@
                                                         "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -34282,7 +34282,7 @@
                                                         "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -34581,7 +34581,7 @@
                                                         "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -34639,7 +34639,7 @@
                                                         "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -34805,7 +34805,7 @@
                                                     "properties": {
                                                       "privateIndividual": {
                                                         "type": "object",
-                                                        "oc1Required": ["Name"],
+                                                        "oc1Required": ["name"],
                                                         "properties": {
                                                           "name": {
                                                             "type": "object",
@@ -34861,7 +34861,7 @@
                                                       },
                                                       "organization": {
                                                         "type": "object",
-                                                        "oc1Required": ["Name"],
+                                                        "oc1Required": ["name"],
                                                         "properties": {
                                                           "name": {
                                                             "type": "string"

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -29805,7 +29805,7 @@
                         "properties": {
                           "multipleTitleIndicator": {
                             "type": "string",
-                            "enum": ["2", "moreThan2"]
+                            "enum": ["2", "MoreThan2"]
                           },
                           "entryDetails": {
                             "type": "object",

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -92,7 +92,7 @@
                 "type": "string"
               },
               "postcode": {
-                "title": "Postcode",
+                "title": "postcode",
                 "type": "string",
                 "minLength": 1
               }
@@ -254,7 +254,7 @@
                   "ta10Ref": "0.1.5",
                   "baspiRef": "A1.1.5",
                   "piqRef": "A1.1.5",
-                  "title": "Postcode",
+                  "title": "postcode",
                   "type": "string",
                   "minLength": 1
                 }
@@ -773,7 +773,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "Postcode",
+                                "title": "postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -989,7 +989,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "Postcode",
+                                "title": "postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -1315,7 +1315,7 @@
                                               },
                                               "postcode": {
                                                 "baspiRef": "A1.5.4.1.2.5",
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1413,7 +1413,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1535,7 +1535,7 @@
                                               },
                                               "postcode": {
                                                 "baspiRef": "A1.5.5.1.2.5",
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1642,7 +1642,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1923,7 +1923,7 @@
                                                       "type": "string"
                                                     },
                                                     "postcode": {
-                                                      "title": "Postcode",
+                                                      "title": "postcode",
                                                       "type": "string",
                                                       "minLength": 1
                                                     }
@@ -3658,7 +3658,7 @@
                                                   "postcode": {
                                                     "baspiRef": "A1.5.4.1.2.5",
                                                     "ta7Ref": "4.1a.6",
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3759,7 +3759,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3865,7 +3865,7 @@
                                                   },
                                                   "postcode": {
                                                     "ta7Ref": "4.1b.6",
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3996,7 +3996,7 @@
                                                   "postcode": {
                                                     "baspiRef": "A1.5.5.1.2.5",
                                                     "ta7Ref": "4.1c.6",
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4105,7 +4105,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4210,7 +4210,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -4475,7 +4475,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "Postcode",
+                                                          "title": "postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4769,7 +4769,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "Postcode",
+                                                          "title": "postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4985,7 +4985,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -20412,100 +20412,100 @@
                       "title": "Mobile predicted coverage per Ofcom Connected Nations",
                       "type": "object",
                       "properties": {
-                        "EEVoiceOutdoor": {
+                        "eeVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "EEVoiceOutdoorNo4g": {
+                        "eeVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "EEVoiceIndoor": {
+                        "eeVoiceIndoor": {
                           "type": "integer"
                         },
-                        "EEVoiceIndoorNo4g": {
+                        "eeVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "EEDataOutdoor": {
+                        "eeDataOutdoor": {
                           "type": "integer"
                         },
-                        "EEDataOutdoorNo4g": {
+                        "eeDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "EEDataIndoor": {
+                        "eeDataIndoor": {
                           "type": "integer"
                         },
-                        "EEDataIndoorNo4g": {
+                        "eeDataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "H3VoiceOutdoor": {
+                        "h3VoiceOutdoor": {
                           "type": "integer"
                         },
-                        "H3VoiceOutdoorNo4g": {
+                        "h3VoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "H3VoiceIndoor": {
+                        "h3VoiceIndoor": {
                           "type": "integer"
                         },
-                        "H3VoiceIndoorNo4g": {
+                        "h3VoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "H3DataOutdoor": {
+                        "h3DataOutdoor": {
                           "type": "integer"
                         },
-                        "H3DataOutdoorNo4g": {
+                        "h3DataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "H3DataIndoor": {
+                        "h3DataIndoor": {
                           "type": "integer"
                         },
-                        "H3DataIndoorNo4g": {
+                        "h3DataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "TFVoiceOutdoor": {
+                        "tfVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "TFVoiceOutdoorNo4g": {
+                        "tfVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "TFVoiceIndoor": {
+                        "tfVoiceIndoor": {
                           "type": "integer"
                         },
-                        "TFVoiceIndoorNo4g": {
+                        "tfVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "TFDataOutdoor": {
+                        "tfDataOutdoor": {
                           "type": "integer"
                         },
-                        "TFDataOutdoorNo4g": {
+                        "tfDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "TFDataIndoor": {
+                        "tfDataIndoor": {
                           "type": "integer"
                         },
-                        "TFDataIndoorNo4g": {
+                        "tfDataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "VOVoiceOutdoor": {
+                        "voVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "VOVoiceOutdoorNo4g": {
+                        "voVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "VOVoiceIndoor": {
+                        "voVoiceIndoor": {
                           "type": "integer"
                         },
-                        "VOVoiceIndoorNo4g": {
+                        "voVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "VODataOutdoor": {
+                        "voDataOutdoor": {
                           "type": "integer"
                         },
-                        "VODataOutdoorNo4g": {
+                        "voDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "VODataIndoor": {
+                        "voDataIndoor": {
                           "type": "integer"
                         },
-                        "VODataIndoorNo4g": {
+                        "voDataIndoorNo4g": {
                           "type": "integer"
                         }
                       }
@@ -25325,7 +25325,7 @@
                             },
                             "postcode": {
                               "baspiRef": "B7.2.3.5",
-                              "title": "Postcode",
+                              "title": "postcode",
                               "type": "string",
                               "minLength": 1
                             }
@@ -25492,45 +25492,45 @@
               "items": {
                 "type": "object",
                 "llc1Required": [
-                  "HMLRReference",
-                  "RegistrationDate",
-                  "Category",
-                  "Location",
-                  "LocationDominantBuilding"
+                  "hmlrReference",
+                  "registrationDate",
+                  "category",
+                  "location",
+                  "locationDominantBuilding"
                 ],
                 "properties": {
-                  "HMLRReference": {
+                  "hmlrReference": {
                     "type": "string"
                   },
-                  "OriginatingAuthority": {
+                  "originatingAuthority": {
                     "type": "string"
                   },
-                  "AuthorityReference": {
+                  "authorityReference": {
                     "type": "string"
                   },
-                  "CreationDate": {
+                  "creationDate": {
                     "type": "string",
                     "format": "date"
                   },
-                  "RegistrationDate": {
+                  "registrationDate": {
                     "type": "string",
                     "format": "date"
                   },
-                  "Category": {
+                  "category": {
                     "type": "string"
                   },
-                  "ChargeSubCategory": {
+                  "chargeSubCategory": {
                     "type": "string"
                   },
-                  "Law": {
+                  "law": {
                     "type": "string"
                   },
-                  "LegalDocument": {
+                  "legalDocument": {
                     "type": "string"
                   },
-                  "Location": {
+                  "location": {
                     "type": "object",
-                    "required": ["line1", "line2", "Postcode"],
+                    "required": ["line1", "line2", "postcode"],
                     "properties": {
                       "line1": {
                         "type": "string"
@@ -25538,14 +25538,14 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       }
                     }
                   },
-                  "LocationDominantBuilding": {
+                  "locationDominantBuilding": {
                     "type": "object",
-                    "required": ["line1", "line2", "Postcode"],
+                    "required": ["line1", "line2", "postcode"],
                     "properties": {
                       "line1": {
                         "type": "string"
@@ -25553,31 +25553,31 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       }
                     }
                   },
-                  "Description": {
+                  "description": {
                     "type": "string"
                   },
-                  "SourceOfInformation": {
+                  "sourceOfInformation": {
                     "type": "string"
                   },
-                  "AvailableDocument": {
+                  "availableDocument": {
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["Document"],
+                      "required": ["document"],
                       "properties": {
-                        "Document": {
+                        "document": {
                           "type": "string"
                         },
-                        "StartDate": {
+                        "startDate": {
                           "type": "string",
                           "format": "date"
                         },
-                        "EndDate": {
+                        "endDate": {
                           "type": "string",
                           "format": "date"
                         }
@@ -25585,15 +25585,15 @@
                     },
                     "minItems": 0
                   },
-                  "InterestInLand": {
+                  "interestInLand": {
                     "type": "string"
                   },
-                  "ApplicantName": {
+                  "applicantName": {
                     "type": "string"
                   },
-                  "ApplicantAddress": {
+                  "applicantAddress": {
                     "type": "object",
-                    "required": ["line1", "line2", "Postcode"],
+                    "required": ["line1", "line2", "postcode"],
                     "properties": {
                       "line1": {
                         "type": "string"
@@ -25601,67 +25601,67 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       },
-                      "Country": {
+                      "country": {
                         "type": "string"
                       }
                     }
                   },
-                  "ServientLandDevelopment": {
+                  "servientLandDevelopment": {
                     "type": "object",
-                    "required": ["Height", "CoversAllOrPartOfExtent"],
+                    "required": ["height", "coversAllOrPartOfExtent"],
                     "properties": {
-                      "Height": {
+                      "height": {
                         "type": "string"
                       },
-                      "CoversAllOrPartOfExtent": {
+                      "coversAllOrPartOfExtent": {
                         "type": "string"
                       }
                     }
                   },
-                  "Amount": {
+                  "amount": {
                     "type": "string"
                   },
-                  "InterestRate": {
+                  "interestRate": {
                     "type": "string"
                   },
-                  "LandSold": {
+                  "landSold": {
                     "type": "string"
                   },
-                  "WorksDone": {
+                  "worksDone": {
                     "type": "string"
                   },
-                  "AdvancePayment": {
+                  "advancePayment": {
                     "type": "string"
                   },
-                  "TotalCompensation": {
+                  "totalCompensation": {
                     "type": "string"
                   },
-                  "AgreedOrEstimated": {
+                  "agreedOrEstimated": {
                     "type": "string"
                   },
-                  "Adjoining": {
+                  "adjoining": {
                     "type": "boolean"
                   },
-                  "OtherData": {
+                  "otherData": {
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["DataLabel", "Data"],
+                      "required": ["dataLabel", "Data"],
                       "properties": {
-                        "DataLabel": {
+                        "dataLabel": {
                           "type": "string"
                         },
-                        "Data": {
+                        "data": {
                           "type": "string"
                         }
                       }
                     },
                     "minItems": 0
                   },
-                  "ChargeExtent": {
+                  "chargeExtent": {
                     "description": "Stringified GeoJSON, to support object dbs that don't support directly nested arrays",
                     "type": "string"
                   }
@@ -29777,55 +29777,55 @@
               "registerExtract": {
                 "title": "HMLR Official Copy Register Extract",
                 "type": "object",
-                "oc1Required": ["OCSummaryData", "OCRegisterData"],
+                "oc1Required": ["ocSummaryData", "ocRegisterData"],
                 "properties": {
-                  "OCSummaryData": {
+                  "ocSummaryData": {
                     "title": "Official Copy Summary Data",
                     "type": "object",
                     "oc1Required": [
-                      "OfficialCopyDateTime",
-                      "EditionDate",
-                      "PropertyAddress",
-                      "Title",
-                      "RegisterEntryIndicators",
-                      "Proprietorship"
+                      "officialCopyDateTime",
+                      "editionDate",
+                      "propertyAddress",
+                      "title",
+                      "registerEntryIndicators",
+                      "proprietorship"
                     ],
                     "properties": {
-                      "OfficialCopyDateTime": {
+                      "officialCopyDateTime": {
                         "type": "string",
                         "format": "date-time"
                       },
-                      "EditionDate": {
+                      "editionDate": {
                         "type": "string",
                         "format": "date"
                       },
-                      "PricePaidEntry": {
+                      "pricePaidEntry": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "MultipleTitleIndicator": {
+                          "multipleTitleIndicator": {
                             "type": "string",
-                            "enum": ["2", "MoreThan2"]
+                            "enum": ["2", "moreThan2"]
                           },
-                          "EntryDetails": {
+                          "entryDetails": {
                             "type": "object",
-                            "oc1Required": ["EntryNumber", "EntryText"],
+                            "oc1Required": ["entryNumber", "entryText"],
                             "properties": {
-                              "EntryNumber": {
+                              "entryNumber": {
                                 "type": "string"
                               },
-                              "EntryText": {
+                              "entryText": {
                                 "type": "string"
                               },
-                              "RegistrationDate": {
+                              "registrationDate": {
                                 "type": "string",
                                 "format": "date"
                               },
-                              "SubRegisterCode": {
+                              "subRegisterCode": {
                                 "type": "string",
                                 "enum": ["A", "B", "C", "D"]
                               },
-                              "ScheduleCode": {
+                              "scheduleCode": {
                                 "type": "string",
                                 "enum": [
                                   "0",
@@ -29844,30 +29844,30 @@
                                   "130"
                                 ]
                               },
-                              "Infills": {
+                              "infills": {
                                 "type": "object"
                               }
                             }
                           }
                         }
                       },
-                      "PropertyAddress": {
+                      "propertyAddress": {
                         "type": "object",
-                        "oc1Required": ["AddressLine"],
+                        "oc1Required": ["addressLine"],
                         "properties": {
-                          "PostcodeZone": {
+                          "postcodeZone": {
                             "type": "object",
-                            "oc1Required": ["Postcode"],
+                            "oc1Required": ["postcode"],
                             "properties": {
-                              "Postcode": {
+                              "postcode": {
                                 "type": "string"
                               }
                             }
                           },
-                          "AddressLine": {
+                          "addressLine": {
                             "type": "object",
                             "properties": {
-                              "Line": {
+                              "line": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
@@ -29878,19 +29878,19 @@
                           }
                         }
                       },
-                      "Title": {
+                      "title": {
                         "type": "object",
                         "oc1Required": [
-                          "TitleNumber",
-                          "ClassOfTitleCode",
-                          "CommonholdIndicator",
-                          "TitleRegistrationDetails"
+                          "titleNumber",
+                          "classOfTitleCode",
+                          "commonholdIndicator",
+                          "titleRegistrationDetails"
                         ],
                         "properties": {
-                          "TitleNumber": {
+                          "titleNumber": {
                             "type": "string"
                           },
-                          "ClassOfTitleCode": {
+                          "classOfTitleCode": {
                             "type": "string",
                             "enum": [
                               "10",
@@ -29908,42 +29908,42 @@
                               "130"
                             ]
                           },
-                          "CommonholdIndicator": {
+                          "commonholdIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "TitleRegistrationDetails": {
+                          "titleRegistrationDetails": {
                             "type": "object",
                             "oc1Required": [
-                              "DistrictName",
-                              "AdministrativeArea",
-                              "LandRegistryOfficeName",
-                              "LatestEditionDate"
+                              "districtName",
+                              "administrativeArea",
+                              "landRegistryOfficeName",
+                              "latestEditionDate"
                             ],
                             "properties": {
-                              "DistrictName": {
+                              "districtName": {
                                 "type": "string"
                               },
-                              "AdministrativeArea": {
+                              "administrativeArea": {
                                 "type": "string"
                               },
-                              "LandRegistryOfficeName": {
+                              "landRegistryOfficeName": {
                                 "type": "string"
                               },
-                              "LatestEditionDate": {
+                              "latestEditionDate": {
                                 "type": "string",
                                 "format": "date"
                               },
-                              "PostcodeZone": {
+                              "postcodeZone": {
                                 "type": "object",
-                                "oc1Required": ["Postcode"],
+                                "oc1Required": ["postcode"],
                                 "properties": {
-                                  "Postcode": {
+                                  "postcode": {
                                     "type": "string"
                                   }
                                 }
                               },
-                              "RegistrationDate": {
+                              "registrationDate": {
                                 "type": "string",
                                 "format": "date"
                               }
@@ -29951,205 +29951,205 @@
                           }
                         }
                       },
-                      "RegisterEntryIndicators": {
+                      "registerEntryIndicators": {
                         "type": "object",
                         "oc1Required": [
-                          "AgreedNoticeIndicator",
-                          "BankruptcyIndicator",
-                          "CautionIndicator",
-                          "CCBIIndicator",
-                          "ChargeeIndicator",
-                          "ChargeIndicator",
-                          "ChargeRelatedRestrictionIndicator",
-                          "ChargeRestrictionIndicator",
-                          "CreditorsNoticeIndicator",
-                          "DeathOfProprietorIndicator",
-                          "DeedOfPostponementIndicator",
-                          "DiscountChargeIndicator",
-                          "EquitableChargeIndicator",
-                          "GreenOutEntryIndicator",
-                          "HomeRightsChangeOfAddressIndicator",
-                          "HomeRightsIndicator",
-                          "LeaseHoldTitleIndicator",
-                          "MultipleChargeIndicator",
-                          "NonChargeRestrictionIndicator",
-                          "NotedChargeIndicator",
-                          "PricePaidIndicator",
-                          "PropertyDescriptionNotesIndicator",
-                          "RentChargeIndicator",
-                          "RightOfPreEmptionIndicator",
-                          "ScheduleOfLeasesIndicator",
-                          "SubChargeIndicator",
-                          "UnidentifiedEntryIndicator",
-                          "UnilateralNoticeBeneficiaryIndicator",
-                          "UnilateralNoticeIndicator",
-                          "VendorsLienIndicator"
+                          "agreedNoticeIndicator",
+                          "bankruptcyIndicator",
+                          "cautionIndicator",
+                          "ccbiIndicator",
+                          "chargeeIndicator",
+                          "chargeIndicator",
+                          "chargeRelatedRestrictionIndicator",
+                          "chargeRestrictionIndicator",
+                          "creditorsNoticeIndicator",
+                          "deathOfProprietorIndicator",
+                          "deedOfPostponementIndicator",
+                          "discountChargeIndicator",
+                          "equitableChargeIndicator",
+                          "greenOutEntryIndicator",
+                          "homeRightsChangeOfAddressIndicator",
+                          "homeRightsIndicator",
+                          "leaseHoldTitleIndicator",
+                          "multipleChargeIndicator",
+                          "nonChargeRestrictionIndicator",
+                          "notedChargeIndicator",
+                          "pricePaidIndicator",
+                          "propertyDescriptionNotesIndicator",
+                          "rentChargeIndicator",
+                          "rightOfPreEmptionIndicator",
+                          "scheduleOfLeasesIndicator",
+                          "subChargeIndicator",
+                          "unidentifiedEntryIndicator",
+                          "unilateralNoticeBeneficiaryIndicator",
+                          "unilateralNoticeIndicator",
+                          "vendorsLienIndicator"
                         ],
                         "properties": {
-                          "AgreedNoticeIndicator": {
+                          "agreedNoticeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "BankruptcyIndicator": {
+                          "bankruptcyIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "CautionIndicator": {
+                          "cautionIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "CCBIIndicator": {
+                          "ccbiIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "ChargeeIndicator": {
+                          "chargeeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "ChargeIndicator": {
+                          "chargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "ChargeRelatedRestrictionIndicator": {
+                          "chargeRelatedRestrictionIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "ChargeRestrictionIndicator": {
+                          "chargeRestrictionIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "CreditorsNoticeIndicator": {
+                          "creditorsNoticeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "DeathOfProprietorIndicator": {
+                          "deathOfProprietorIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "DeedOfPostponementIndicator": {
+                          "deedOfPostponementIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "DiscountChargeIndicator": {
+                          "discountChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "EquitableChargeIndicator": {
+                          "equitableChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "GreenOutEntryIndicator": {
+                          "greenOutEntryIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "HomeRightsChangeOfAddressIndicator": {
+                          "homeRightsChangeOfAddressIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "HomeRightsIndicator": {
+                          "homeRightsIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "LeaseHoldTitleIndicator": {
+                          "leaseHoldTitleIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "MultipleChargeIndicator": {
+                          "multipleChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "NonChargeRestrictionIndicator": {
+                          "nonChargeRestrictionIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "NotedChargeIndicator": {
+                          "notedChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "PricePaidIndicator": {
+                          "pricePaidIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "PropertyDescriptionNotesIndicator": {
+                          "propertyDescriptionNotesIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "RentChargeIndicator": {
+                          "rentChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "RightOfPreEmptionIndicator": {
+                          "rightOfPreEmptionIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "ScheduleOfLeasesIndicator": {
+                          "scheduleOfLeasesIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "SubChargeIndicator": {
+                          "subChargeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "UnidentifiedEntryIndicator": {
+                          "unidentifiedEntryIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "UnilateralNoticeBeneficiaryIndicator": {
+                          "unilateralNoticeBeneficiaryIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "UnilateralNoticeIndicator": {
+                          "unilateralNoticeIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           },
-                          "VendorsLienIndicator": {
+                          "vendorsLienIndicator": {
                             "type": "string",
                             "enum": ["true", "false"]
                           }
                         }
                       },
-                      "Proprietorship": {
+                      "proprietorship": {
                         "type": "object",
                         "properties": {
-                          "CurrentProprietorshipDate": {
+                          "currentProprietorshipDate": {
                             "type": "string",
                             "format": "date"
                           },
-                          "CautionerParty": {
+                          "cautionerParty": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "type": "object",
                                       "oc1Required": ["Name"],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "object",
-                                          "oc1Required": ["SurnameName"],
+                                          "oc1Required": ["surnameName"],
                                           "properties": {
-                                            "ForenamesName": {
+                                            "forenamesName": {
                                               "type": "string"
                                             },
-                                            "SurnameName": {
+                                            "surnameName": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
-                                                "oc1Required": ["SurnameName"],
+                                                "oc1Required": ["surnameName"],
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -30158,12 +30158,12 @@
                                             },
                                             {
                                               "type": "object",
-                                              "oc1Required": ["SurnameName"],
+                                              "oc1Required": ["surnameName"],
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -30172,35 +30172,35 @@
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "type": "object",
                                       "oc1Required": ["Name"],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "string"
                                         },
-                                        "CompanyRegistrationNumber": {
+                                        "companyRegistrationNumber": {
                                           "type": "string"
                                         }
                                       }
                                     },
-                                    "Address": {
+                                    "address": {
                                       "type": "object",
-                                      "oc1Required": ["AddressLine"],
+                                      "oc1Required": ["addressLine"],
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "type": "object",
-                                          "oc1Required": ["Postcode"],
+                                          "oc1Required": ["postcode"],
                                           "properties": {
-                                            "Postcode": {
+                                            "postcode": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "AddressLine": {
+                                        "addressLine": {
                                           "type": "object",
                                           "properties": {
-                                            "Line": {
+                                            "line": {
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -30211,14 +30211,14 @@
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "CharityName",
-                                        "CharityType"
+                                        "charityName",
+                                        "charityType"
                                       ],
                                       "properties": {
-                                        "CharityName": {
+                                        "charityName": {
                                           "oneOf": [
                                             {
                                               "type": "array",
@@ -30232,27 +30232,27 @@
                                             }
                                           ]
                                         },
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
-                                                "oc1Required": ["AddressLine"],
+                                                "oc1Required": ["addressLine"],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
-                                                    "oc1Required": ["Postcode"],
+                                                    "oc1Required": ["postcode"],
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -30267,21 +30267,21 @@
                                             },
                                             {
                                               "type": "object",
-                                              "oc1Required": ["AddressLine"],
+                                              "oc1Required": ["addressLine"],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
-                                                  "oc1Required": ["Postcode"],
+                                                  "oc1Required": ["postcode"],
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -30294,10 +30294,10 @@
                                             }
                                           ]
                                         },
-                                        "CharityType": {
+                                        "charityType": {
                                           "type": "object",
                                           "properties": {
-                                            "Value": {
+                                            "value": {
                                               "type": "string",
                                               "enum": ["C", "R", "S"]
                                             }
@@ -30305,13 +30305,13 @@
                                         }
                                       }
                                     },
-                                    "TradingName": {
+                                    "tradingName": {
                                       "type": "string"
                                     },
-                                    "PartyNumber": {
+                                    "partyNumber": {
                                       "type": "string"
                                     },
-                                    "PartyDescription": {
+                                    "partyDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -30321,34 +30321,34 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "type": "object",
                                     "oc1Required": ["Name"],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "object",
-                                        "oc1Required": ["SurnameName"],
+                                        "oc1Required": ["surnameName"],
                                         "properties": {
-                                          "ForenamesName": {
+                                          "forenamesName": {
                                             "type": "string"
                                           },
-                                          "SurnameName": {
+                                          "surnameName": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
-                                              "oc1Required": ["SurnameName"],
+                                              "oc1Required": ["surnameName"],
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -30357,12 +30357,12 @@
                                           },
                                           {
                                             "type": "object",
-                                            "oc1Required": ["SurnameName"],
+                                            "oc1Required": ["surnameName"],
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
@@ -30371,35 +30371,35 @@
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "type": "object",
                                     "oc1Required": ["Name"],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "string"
                                       },
-                                      "CompanyRegistrationNumber": {
+                                      "companyRegistrationNumber": {
                                         "type": "string"
                                       }
                                     }
                                   },
-                                  "Address": {
+                                  "address": {
                                     "type": "object",
-                                    "oc1Required": ["AddressLine"],
+                                    "oc1Required": ["addressLine"],
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "type": "object",
-                                        "oc1Required": ["Postcode"],
+                                        "oc1Required": ["postcode"],
                                         "properties": {
-                                          "Postcode": {
+                                          "postcode": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "AddressLine": {
+                                      "addressLine": {
                                         "type": "object",
                                         "properties": {
-                                          "Line": {
+                                          "line": {
                                             "type": "array",
                                             "items": {
                                               "type": "string"
@@ -30410,14 +30410,14 @@
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "CharityName",
-                                      "CharityType"
+                                      "charityName",
+                                      "charityType"
                                     ],
                                     "properties": {
-                                      "CharityName": {
+                                      "charityName": {
                                         "oneOf": [
                                           {
                                             "type": "array",
@@ -30431,27 +30431,27 @@
                                           }
                                         ]
                                       },
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
-                                              "oc1Required": ["AddressLine"],
+                                              "oc1Required": ["addressLine"],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
-                                                  "oc1Required": ["Postcode"],
+                                                  "oc1Required": ["postcode"],
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -30466,21 +30466,21 @@
                                           },
                                           {
                                             "type": "object",
-                                            "oc1Required": ["AddressLine"],
+                                            "oc1Required": ["addressLine"],
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "type": "object",
-                                                "oc1Required": ["Postcode"],
+                                                "oc1Required": ["postcode"],
                                                 "properties": {
-                                                  "Postcode": {
+                                                  "postcode": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "AddressLine": {
+                                              "addressLine": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Line": {
+                                                  "line": {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -30493,10 +30493,10 @@
                                           }
                                         ]
                                       },
-                                      "CharityType": {
+                                      "charityType": {
                                         "type": "object",
                                         "properties": {
-                                          "Value": {
+                                          "value": {
                                             "type": "string",
                                             "enum": ["C", "R", "S"]
                                           }
@@ -30504,54 +30504,54 @@
                                       }
                                     }
                                   },
-                                  "TradingName": {
+                                  "tradingName": {
                                     "type": "string"
                                   },
-                                  "PartyNumber": {
+                                  "partyNumber": {
                                     "type": "string"
                                   },
-                                  "PartyDescription": {
+                                  "partyDescription": {
                                     "type": "string"
                                   }
                                 }
                               }
                             ]
                           },
-                          "RegisteredProprietorParty": {
+                          "registeredProprietorParty": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "type": "object",
                                       "oc1Required": ["Name"],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "object",
-                                          "oc1Required": ["SurnameName"],
+                                          "oc1Required": ["surnameName"],
                                           "properties": {
-                                            "ForenamesName": {
+                                            "forenamesName": {
                                               "type": "string"
                                             },
-                                            "SurnameName": {
+                                            "surnameName": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
-                                                "oc1Required": ["SurnameName"],
+                                                "oc1Required": ["surnameName"],
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -30560,12 +30560,12 @@
                                             },
                                             {
                                               "type": "object",
-                                              "oc1Required": ["SurnameName"],
+                                              "oc1Required": ["surnameName"],
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -30574,35 +30574,35 @@
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "type": "object",
                                       "oc1Required": ["Name"],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "string"
                                         },
-                                        "CompanyRegistrationNumber": {
+                                        "companyRegistrationNumber": {
                                           "type": "string"
                                         }
                                       }
                                     },
-                                    "Address": {
+                                    "address": {
                                       "type": "object",
-                                      "oc1Required": ["AddressLine"],
+                                      "oc1Required": ["addressLine"],
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "type": "object",
-                                          "oc1Required": ["Postcode"],
+                                          "oc1Required": ["postcode"],
                                           "properties": {
-                                            "Postcode": {
+                                            "postcode": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "AddressLine": {
+                                        "addressLine": {
                                           "type": "object",
                                           "properties": {
-                                            "Line": {
+                                            "line": {
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -30613,14 +30613,14 @@
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "CharityName",
-                                        "CharityType"
+                                        "charityName",
+                                        "charityType"
                                       ],
                                       "properties": {
-                                        "CharityName": {
+                                        "charityName": {
                                           "oneOf": [
                                             {
                                               "type": "array",
@@ -30634,27 +30634,27 @@
                                             }
                                           ]
                                         },
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
-                                                "oc1Required": ["AddressLine"],
+                                                "oc1Required": ["addressLine"],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
-                                                    "oc1Required": ["Postcode"],
+                                                    "oc1Required": ["postcode"],
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -30669,21 +30669,21 @@
                                             },
                                             {
                                               "type": "object",
-                                              "oc1Required": ["AddressLine"],
+                                              "oc1Required": ["addressLine"],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
-                                                  "oc1Required": ["Postcode"],
+                                                  "oc1Required": ["postcode"],
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -30696,10 +30696,10 @@
                                             }
                                           ]
                                         },
-                                        "CharityType": {
+                                        "charityType": {
                                           "type": "object",
                                           "properties": {
-                                            "Value": {
+                                            "value": {
                                               "type": "string",
                                               "enum": ["C", "R", "S"]
                                             }
@@ -30707,13 +30707,13 @@
                                         }
                                       }
                                     },
-                                    "TradingName": {
+                                    "tradingName": {
                                       "type": "string"
                                     },
-                                    "PartyNumber": {
+                                    "partyNumber": {
                                       "type": "string"
                                     },
-                                    "PartyDescription": {
+                                    "partyDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -30723,34 +30723,34 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "type": "object",
                                     "oc1Required": ["Name"],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "object",
-                                        "oc1Required": ["SurnameName"],
+                                        "oc1Required": ["surnameName"],
                                         "properties": {
-                                          "ForenamesName": {
+                                          "forenamesName": {
                                             "type": "string"
                                           },
-                                          "SurnameName": {
+                                          "surnameName": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
-                                              "oc1Required": ["SurnameName"],
+                                              "oc1Required": ["surnameName"],
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -30759,12 +30759,12 @@
                                           },
                                           {
                                             "type": "object",
-                                            "oc1Required": ["SurnameName"],
+                                            "oc1Required": ["surnameName"],
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
@@ -30773,35 +30773,35 @@
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "type": "object",
                                     "oc1Required": ["Name"],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "string"
                                       },
-                                      "CompanyRegistrationNumber": {
+                                      "companyRegistrationNumber": {
                                         "type": "string"
                                       }
                                     }
                                   },
-                                  "Address": {
+                                  "address": {
                                     "type": "object",
-                                    "oc1Required": ["AddressLine"],
+                                    "oc1Required": ["addressLine"],
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "type": "object",
-                                        "oc1Required": ["Postcode"],
+                                        "oc1Required": ["postcode"],
                                         "properties": {
-                                          "Postcode": {
+                                          "postcode": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "AddressLine": {
+                                      "addressLine": {
                                         "type": "object",
                                         "properties": {
-                                          "Line": {
+                                          "line": {
                                             "type": "array",
                                             "items": {
                                               "type": "string"
@@ -30812,14 +30812,14 @@
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "CharityName",
-                                      "CharityType"
+                                      "charityName",
+                                      "charityType"
                                     ],
                                     "properties": {
-                                      "CharityName": {
+                                      "charityName": {
                                         "oneOf": [
                                           {
                                             "type": "array",
@@ -30833,27 +30833,27 @@
                                           }
                                         ]
                                       },
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
-                                              "oc1Required": ["AddressLine"],
+                                              "oc1Required": ["addressLine"],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
-                                                  "oc1Required": ["Postcode"],
+                                                  "oc1Required": ["postcode"],
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -30868,21 +30868,21 @@
                                           },
                                           {
                                             "type": "object",
-                                            "oc1Required": ["AddressLine"],
+                                            "oc1Required": ["addressLine"],
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "type": "object",
-                                                "oc1Required": ["Postcode"],
+                                                "oc1Required": ["postcode"],
                                                 "properties": {
-                                                  "Postcode": {
+                                                  "postcode": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "AddressLine": {
+                                              "addressLine": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Line": {
+                                                  "line": {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -30895,10 +30895,10 @@
                                           }
                                         ]
                                       },
-                                      "CharityType": {
+                                      "charityType": {
                                         "type": "object",
                                         "properties": {
-                                          "Value": {
+                                          "value": {
                                             "type": "string",
                                             "enum": ["C", "R", "S"]
                                           }
@@ -30906,13 +30906,13 @@
                                       }
                                     }
                                   },
-                                  "TradingName": {
+                                  "tradingName": {
                                     "type": "string"
                                   },
-                                  "PartyNumber": {
+                                  "partyNumber": {
                                     "type": "string"
                                   },
-                                  "PartyDescription": {
+                                  "partyDescription": {
                                     "type": "string"
                                   }
                                 }
@@ -30921,65 +30921,65 @@
                           }
                         }
                       },
-                      "Lease": {
+                      "lease": {
                         "type": "object",
-                        "oc1Required": ["LeaseEntry"],
+                        "oc1Required": ["leaseEntry"],
                         "properties": {
-                          "LeaseEntry": {
+                          "leaseEntry": {
                             "type": "array",
                             "items": {
                               "type": "object",
                               "oc1Required": [
-                                "LeaseTerm",
-                                "LeaseDate",
-                                "LeaseParty",
-                                "EntryDetails"
+                                "leaseTerm",
+                                "leaseDate",
+                                "leaseParty",
+                                "entryDetails"
                               ],
                               "properties": {
-                                "LeaseTerm": {
+                                "leaseTerm": {
                                   "type": "string"
                                 },
-                                "LeaseDate": {
+                                "leaseDate": {
                                   "type": "string"
                                 },
                                 "Rent": {
                                   "type": "string"
                                 },
-                                "LeaseParty": {
+                                "leaseParty": {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
-                                      "PrivateIndividual": {
+                                      "privateIndividual": {
                                         "type": "object",
                                         "oc1Required": ["Name"],
                                         "properties": {
-                                          "Name": {
+                                          "name": {
                                             "type": "object",
-                                            "oc1Required": ["SurnameName"],
+                                            "oc1Required": ["surnameName"],
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
                                           },
-                                          "Alias": {
+                                          "alias": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "SurnameName"
+                                                    "surnameName"
                                                   ],
                                                   "properties": {
-                                                    "ForenamesName": {
+                                                    "forenamesName": {
                                                       "type": "string"
                                                     },
-                                                    "SurnameName": {
+                                                    "surnameName": {
                                                       "type": "string"
                                                     }
                                                   }
@@ -30988,12 +30988,12 @@
                                               },
                                               {
                                                 "type": "object",
-                                                "oc1Required": ["SurnameName"],
+                                                "oc1Required": ["surnameName"],
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -31002,35 +31002,35 @@
                                           }
                                         }
                                       },
-                                      "Organization": {
+                                      "organization": {
                                         "type": "object",
                                         "oc1Required": ["Name"],
                                         "properties": {
-                                          "Name": {
+                                          "name": {
                                             "type": "string"
                                           },
-                                          "CompanyRegistrationNumber": {
+                                          "companyRegistrationNumber": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Address": {
+                                      "address": {
                                         "type": "object",
-                                        "oc1Required": ["AddressLine"],
+                                        "oc1Required": ["addressLine"],
                                         "properties": {
-                                          "PostcodeZone": {
+                                          "postcodeZone": {
                                             "type": "object",
-                                            "oc1Required": ["Postcode"],
+                                            "oc1Required": ["postcode"],
                                             "properties": {
-                                              "Postcode": {
+                                              "postcode": {
                                                 "type": "string"
                                               }
                                             }
                                           },
-                                          "AddressLine": {
+                                          "addressLine": {
                                             "type": "object",
                                             "properties": {
-                                              "Line": {
+                                              "line": {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
@@ -31041,14 +31041,14 @@
                                           }
                                         }
                                       },
-                                      "CharityDetails": {
+                                      "charityDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "CharityName",
-                                          "CharityType"
+                                          "charityName",
+                                          "charityType"
                                         ],
                                         "properties": {
-                                          "CharityName": {
+                                          "charityName": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -31062,31 +31062,31 @@
                                               }
                                             ]
                                           },
-                                          "CharityAddress": {
+                                          "charityAddress": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "oc1Required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ],
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -31101,21 +31101,21 @@
                                               },
                                               {
                                                 "type": "object",
-                                                "oc1Required": ["AddressLine"],
+                                                "oc1Required": ["addressLine"],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
-                                                    "oc1Required": ["Postcode"],
+                                                    "oc1Required": ["postcode"],
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -31128,10 +31128,10 @@
                                               }
                                             ]
                                           },
-                                          "CharityType": {
+                                          "charityType": {
                                             "type": "object",
                                             "properties": {
-                                              "Value": {
+                                              "value": {
                                                 "type": "string",
                                                 "enum": ["C", "R", "S"]
                                               }
@@ -31139,38 +31139,38 @@
                                           }
                                         }
                                       },
-                                      "TradingName": {
+                                      "tradingName": {
                                         "type": "string"
                                       },
-                                      "PartyNumber": {
+                                      "partyNumber": {
                                         "type": "string"
                                       },
-                                      "PartyDescription": {
+                                      "partyDescription": {
                                         "type": "string"
                                       }
                                     }
                                   },
                                   "minItems": 2
                                 },
-                                "EntryDetails": {
+                                "entryDetails": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -31189,7 +31189,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -31200,53 +31200,53 @@
                           }
                         }
                       },
-                      "RestrictionDetails": {
+                      "restrictionDetails": {
                         "type": "object",
-                        "oc1Required": ["RestrictionEntry"],
+                        "oc1Required": ["restrictionEntry"],
                         "properties": {
-                          "RestrictionEntry": {
+                          "restrictionEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ChargeRelatedRestriction": {
+                                    "chargeRelatedRestriction": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": ["0", "10", "20", "30"]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": ["A", "B", "C", "D"]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -31265,49 +31265,49 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "ChargeRestriction": {
+                                    "chargeRestriction": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": ["0", "10", "20", "30"]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": ["A", "B", "C", "D"]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -31326,49 +31326,49 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "NonChargeRestriction": {
+                                    "nonChargeRestriction": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": ["0", "10", "20", "30"]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": ["A", "B", "C", "D"]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -31387,7 +31387,7 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
@@ -31401,42 +31401,42 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ChargeRelatedRestriction": {
+                                  "chargeRelatedRestriction": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": ["0", "10", "20", "30"]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": ["A", "B", "C", "D"]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -31455,49 +31455,49 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "ChargeRestriction": {
+                                  "chargeRestriction": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": ["0", "10", "20", "30"]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": ["A", "B", "C", "D"]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -31516,49 +31516,49 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "NonChargeRestriction": {
+                                  "nonChargeRestriction": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": ["0", "10", "20", "30"]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": ["A", "B", "C", "D"]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -31577,7 +31577,7 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
@@ -31590,57 +31590,57 @@
                           }
                         }
                       },
-                      "Charge": {
+                      "charge": {
                         "type": "object",
-                        "oc1Required": ["ChargeEntry"],
+                        "oc1Required": ["chargeEntry"],
                         "properties": {
-                          "ChargeEntry": {
+                          "chargeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "RegisteredCharge",
-                                    "ChargeProprietor"
+                                    "registeredCharge",
+                                    "chargeProprietor"
                                   ],
                                   "properties": {
-                                    "ChargeID": {
+                                    "chargeID": {
                                       "type": "string"
                                     },
-                                    "ChargeDate": {
+                                    "chargeDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "RegisteredCharge": {
+                                    "registeredCharge": {
                                       "type": "object",
-                                      "oc1Required": ["EntryDetails"],
+                                      "oc1Required": ["entryDetails"],
                                       "properties": {
-                                        "MultipleTitleIndicator": {
+                                        "multipleTitleIndicator": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": ["A", "B", "C", "D"]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -31659,59 +31659,59 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "ChargeProprietor": {
+                                    "chargeProprietor": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "ChargeeParty",
-                                        "EntryDetails"
+                                        "chargeeParty",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "ChargeeParty": {
+                                        "chargeeParty": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PrivateIndividual": {
+                                                  "privateIndividual": {
                                                     "type": "object",
                                                     "oc1Required": ["Name"],
                                                     "properties": {
-                                                      "Name": {
+                                                      "name": {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "SurnameName"
+                                                          "surnameName"
                                                         ],
                                                         "properties": {
-                                                          "ForenamesName": {
+                                                          "forenamesName": {
                                                             "type": "string"
                                                           },
-                                                          "SurnameName": {
+                                                          "surnameName": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "Alias": {
+                                                      "alias": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ],
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
@@ -31721,13 +31721,13 @@
                                                           {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ],
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -31736,39 +31736,39 @@
                                                       }
                                                     }
                                                   },
-                                                  "Organization": {
+                                                  "organization": {
                                                     "type": "object",
                                                     "oc1Required": ["Name"],
                                                     "properties": {
-                                                      "Name": {
+                                                      "name": {
                                                         "type": "string"
                                                       },
-                                                      "CompanyRegistrationNumber": {
+                                                      "companyRegistrationNumber": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "Address": {
+                                                  "address": {
                                                     "type": "object",
                                                     "oc1Required": [
-                                                      "AddressLine"
+                                                      "addressLine"
                                                     ],
                                                     "properties": {
-                                                      "PostcodeZone": {
+                                                      "postcodeZone": {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "Postcode"
+                                                          "postcode"
                                                         ],
                                                         "properties": {
-                                                          "Postcode": {
+                                                          "postcode": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "AddressLine": {
+                                                      "addressLine": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Line": {
+                                                          "line": {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "string"
@@ -31779,14 +31779,14 @@
                                                       }
                                                     }
                                                   },
-                                                  "CharityDetails": {
+                                                  "charityDetails": {
                                                     "type": "object",
                                                     "oc1Required": [
-                                                      "CharityName",
-                                                      "CharityType"
+                                                      "charityName",
+                                                      "charityType"
                                                     ],
                                                     "properties": {
-                                                      "CharityName": {
+                                                      "charityName": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
@@ -31800,31 +31800,31 @@
                                                           }
                                                         ]
                                                       },
-                                                      "CharityAddress": {
+                                                      "charityAddress": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "AddressLine"
+                                                                "addressLine"
                                                               ],
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "Postcode"
+                                                                    "postcode"
                                                                   ],
                                                                   "properties": {
-                                                                    "Postcode": {
+                                                                    "postcode": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "AddressLine": {
+                                                                "addressLine": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Line": {
+                                                                    "line": {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "string"
@@ -31840,24 +31840,24 @@
                                                           {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -31870,10 +31870,10 @@
                                                           }
                                                         ]
                                                       },
-                                                      "CharityType": {
+                                                      "charityType": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Value": {
+                                                          "value": {
                                                             "type": "string",
                                                             "enum": [
                                                               "C",
@@ -31885,13 +31885,13 @@
                                                       }
                                                     }
                                                   },
-                                                  "TradingName": {
+                                                  "tradingName": {
                                                     "type": "string"
                                                   },
-                                                  "PartyNumber": {
+                                                  "partyNumber": {
                                                     "type": "string"
                                                   },
-                                                  "PartyDescription": {
+                                                  "partyDescription": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -31901,38 +31901,38 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "type": "object",
                                                   "oc1Required": ["Name"],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "object",
                                                       "oc1Required": [
-                                                        "SurnameName"
+                                                        "surnameName"
                                                       ],
                                                       "properties": {
-                                                        "ForenamesName": {
+                                                        "forenamesName": {
                                                           "type": "string"
                                                         },
-                                                        "SurnameName": {
+                                                        "surnameName": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ],
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -31942,13 +31942,13 @@
                                                         {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ],
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -31957,39 +31957,39 @@
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "type": "object",
                                                   "oc1Required": ["Name"],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "string"
                                                     },
-                                                    "CompanyRegistrationNumber": {
+                                                    "companyRegistrationNumber": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "oc1Required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ],
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -32000,14 +32000,14 @@
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "CharityName",
-                                                    "CharityType"
+                                                    "charityName",
+                                                    "charityType"
                                                   ],
                                                   "properties": {
-                                                    "CharityName": {
+                                                    "charityName": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
@@ -32021,31 +32021,31 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -32061,24 +32061,24 @@
                                                         {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -32091,10 +32091,10 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityType": {
+                                                    "charityType": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Value": {
+                                                        "value": {
                                                           "type": "string",
                                                           "enum": [
                                                             "C",
@@ -32106,41 +32106,41 @@
                                                     }
                                                   }
                                                 },
-                                                "TradingName": {
+                                                "tradingName": {
                                                   "type": "string"
                                                 },
-                                                "PartyNumber": {
+                                                "partyNumber": {
                                                   "type": "string"
                                                 },
-                                                "PartyDescription": {
+                                                "partyDescription": {
                                                   "type": "string"
                                                 }
                                               }
                                             }
                                           ]
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": ["A", "B", "C", "D"]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -32159,53 +32159,53 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "SubCharge": {
+                                    "subCharge": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "oc1Required": [
-                                              "RegisteredCharge",
-                                              "ChargeProprietor"
+                                              "registeredCharge",
+                                              "chargeProprietor"
                                             ],
                                             "properties": {
-                                              "ChargeDate": {
+                                              "chargeDate": {
                                                 "type": "string",
                                                 "format": "date"
                                               },
-                                              "RegisteredCharge": {
+                                              "registeredCharge": {
                                                 "type": "object",
-                                                "oc1Required": ["EntryDetails"],
+                                                "oc1Required": ["entryDetails"],
                                                 "properties": {
-                                                  "MultipleTitleIndicator": {
+                                                  "multipleTitleIndicator": {
                                                     "type": "string"
                                                   },
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "type": "object",
                                                     "oc1Required": [
-                                                      "EntryNumber",
-                                                      "EntryText"
+                                                      "entryNumber",
+                                                      "entryText"
                                                     ],
                                                     "properties": {
-                                                      "EntryNumber": {
+                                                      "entryNumber": {
                                                         "type": "string"
                                                       },
-                                                      "EntryText": {
+                                                      "entryText": {
                                                         "type": "string"
                                                       },
-                                                      "RegistrationDate": {
+                                                      "registrationDate": {
                                                         "type": "string",
                                                         "format": "date"
                                                       },
-                                                      "SubRegisterCode": {
+                                                      "subRegisterCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "A",
@@ -32214,7 +32214,7 @@
                                                           "D"
                                                         ]
                                                       },
-                                                      "ScheduleCode": {
+                                                      "scheduleCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "0",
@@ -32233,61 +32233,61 @@
                                                           "130"
                                                         ]
                                                       },
-                                                      "Infills": {
+                                                      "infills": {
                                                         "type": "object"
                                                       }
                                                     }
                                                   }
                                                 }
                                               },
-                                              "ChargeProprietor": {
+                                              "chargeProprietor": {
                                                 "type": "object",
                                                 "oc1Required": [
-                                                  "ChargeeParty",
-                                                  "EntryDetails"
+                                                  "chargeeParty",
+                                                  "entryDetails"
                                                 ],
                                                 "properties": {
-                                                  "ChargeeParty": {
+                                                  "chargeeParty": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PrivateIndividual": {
+                                                            "privateIndividual": {
                                                               "type": "object",
                                                               "oc1Required": [
                                                                 "Name"
                                                               ],
                                                               "properties": {
-                                                                "Name": {
+                                                                "name": {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ],
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "Alias": {
+                                                                "alias": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "SurnameName"
+                                                                          "surnameName"
                                                                         ],
                                                                         "properties": {
-                                                                          "ForenamesName": {
+                                                                          "forenamesName": {
                                                                             "type": "string"
                                                                           },
-                                                                          "SurnameName": {
+                                                                          "surnameName": {
                                                                             "type": "string"
                                                                           }
                                                                         }
@@ -32297,13 +32297,13 @@
                                                                     {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ],
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -32312,41 +32312,41 @@
                                                                 }
                                                               }
                                                             },
-                                                            "Organization": {
+                                                            "organization": {
                                                               "type": "object",
                                                               "oc1Required": [
                                                                 "Name"
                                                               ],
                                                               "properties": {
-                                                                "Name": {
+                                                                "name": {
                                                                   "type": "string"
                                                                 },
-                                                                "CompanyRegistrationNumber": {
+                                                                "companyRegistrationNumber": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Address": {
+                                                            "address": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "AddressLine"
+                                                                "addressLine"
                                                               ],
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "Postcode"
+                                                                    "postcode"
                                                                   ],
                                                                   "properties": {
-                                                                    "Postcode": {
+                                                                    "postcode": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "AddressLine": {
+                                                                "addressLine": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Line": {
+                                                                    "line": {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "string"
@@ -32357,14 +32357,14 @@
                                                                 }
                                                               }
                                                             },
-                                                            "CharityDetails": {
+                                                            "charityDetails": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "CharityName",
-                                                                "CharityType"
+                                                                "charityName",
+                                                                "charityType"
                                                               ],
                                                               "properties": {
-                                                                "CharityName": {
+                                                                "charityName": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
@@ -32378,31 +32378,31 @@
                                                                     }
                                                                   ]
                                                                 },
-                                                                "CharityAddress": {
+                                                                "charityAddress": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "AddressLine"
+                                                                          "addressLine"
                                                                         ],
                                                                         "properties": {
-                                                                          "PostcodeZone": {
+                                                                          "postcodeZone": {
                                                                             "type": "object",
                                                                             "oc1Required": [
-                                                                              "Postcode"
+                                                                              "postcode"
                                                                             ],
                                                                             "properties": {
-                                                                              "Postcode": {
+                                                                              "postcode": {
                                                                                 "type": "string"
                                                                               }
                                                                             }
                                                                           },
-                                                                          "AddressLine": {
+                                                                          "addressLine": {
                                                                             "type": "object",
                                                                             "properties": {
-                                                                              "Line": {
+                                                                              "line": {
                                                                                 "type": "array",
                                                                                 "items": {
                                                                                   "type": "string"
@@ -32418,24 +32418,24 @@
                                                                     {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "oc1Required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ],
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -32448,10 +32448,10 @@
                                                                     }
                                                                   ]
                                                                 },
-                                                                "CharityType": {
+                                                                "charityType": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Value": {
+                                                                    "value": {
                                                                       "type": "string",
                                                                       "enum": [
                                                                         "C",
@@ -32463,13 +32463,13 @@
                                                                 }
                                                               }
                                                             },
-                                                            "TradingName": {
+                                                            "tradingName": {
                                                               "type": "string"
                                                             },
-                                                            "PartyNumber": {
+                                                            "partyNumber": {
                                                               "type": "string"
                                                             },
-                                                            "PartyDescription": {
+                                                            "partyDescription": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -32479,40 +32479,40 @@
                                                       {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ],
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ],
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -32522,13 +32522,13 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -32537,41 +32537,41 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -32582,14 +32582,14 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -32603,31 +32603,31 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "oc1Required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ],
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -32643,24 +32643,24 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -32673,10 +32673,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -32688,37 +32688,37 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       }
                                                     ]
                                                   },
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "type": "object",
                                                     "oc1Required": [
-                                                      "EntryNumber",
-                                                      "EntryText"
+                                                      "entryNumber",
+                                                      "entryText"
                                                     ],
                                                     "properties": {
-                                                      "EntryNumber": {
+                                                      "entryNumber": {
                                                         "type": "string"
                                                       },
-                                                      "EntryText": {
+                                                      "entryText": {
                                                         "type": "string"
                                                       },
-                                                      "RegistrationDate": {
+                                                      "registrationDate": {
                                                         "type": "string",
                                                         "format": "date"
                                                       },
-                                                      "SubRegisterCode": {
+                                                      "subRegisterCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "A",
@@ -32727,7 +32727,7 @@
                                                           "D"
                                                         ]
                                                       },
-                                                      "ScheduleCode": {
+                                                      "scheduleCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "0",
@@ -32746,7 +32746,7 @@
                                                           "130"
                                                         ]
                                                       },
-                                                      "Infills": {
+                                                      "infills": {
                                                         "type": "object"
                                                       }
                                                     }
@@ -32760,39 +32760,39 @@
                                         {
                                           "type": "object",
                                           "oc1Required": [
-                                            "RegisteredCharge",
-                                            "ChargeProprietor"
+                                            "registeredCharge",
+                                            "chargeProprietor"
                                           ],
                                           "properties": {
-                                            "ChargeDate": {
+                                            "chargeDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "type": "object",
-                                              "oc1Required": ["EntryDetails"],
+                                              "oc1Required": ["entryDetails"],
                                               "properties": {
-                                                "MultipleTitleIndicator": {
+                                                "multipleTitleIndicator": {
                                                   "type": "string"
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ],
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -32801,7 +32801,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -32820,61 +32820,61 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "type": "object",
                                               "oc1Required": [
-                                                "ChargeeParty",
-                                                "EntryDetails"
+                                                "chargeeParty",
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ],
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ],
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -32884,13 +32884,13 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -32899,41 +32899,41 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -32944,14 +32944,14 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -32965,31 +32965,31 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "oc1Required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ],
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -33005,24 +33005,24 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -33035,10 +33035,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -33050,13 +33050,13 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -33066,40 +33066,40 @@
                                                     {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ],
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -33109,13 +33109,13 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ],
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -33124,41 +33124,41 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -33169,14 +33169,14 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -33190,31 +33190,31 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -33230,24 +33230,24 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ],
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -33260,10 +33260,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -33275,37 +33275,37 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ],
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -33314,7 +33314,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -33333,7 +33333,7 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
@@ -33351,46 +33351,46 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "RegisteredCharge",
-                                  "ChargeProprietor"
+                                  "registeredCharge",
+                                  "chargeProprietor"
                                 ],
                                 "properties": {
-                                  "ChargeID": {
+                                  "chargeID": {
                                     "type": "string"
                                   },
-                                  "ChargeDate": {
+                                  "chargeDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "RegisteredCharge": {
+                                  "registeredCharge": {
                                     "type": "object",
-                                    "oc1Required": ["EntryDetails"],
+                                    "oc1Required": ["entryDetails"],
                                     "properties": {
-                                      "MultipleTitleIndicator": {
+                                      "multipleTitleIndicator": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": ["A", "B", "C", "D"]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -33409,59 +33409,59 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "ChargeProprietor": {
+                                  "chargeProprietor": {
                                     "type": "object",
                                     "oc1Required": [
-                                      "ChargeeParty",
-                                      "EntryDetails"
+                                      "chargeeParty",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "ChargeeParty": {
+                                      "chargeeParty": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "type": "object",
                                                   "oc1Required": ["Name"],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "object",
                                                       "oc1Required": [
-                                                        "SurnameName"
+                                                        "surnameName"
                                                       ],
                                                       "properties": {
-                                                        "ForenamesName": {
+                                                        "forenamesName": {
                                                           "type": "string"
                                                         },
-                                                        "SurnameName": {
+                                                        "surnameName": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ],
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -33471,13 +33471,13 @@
                                                         {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ],
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -33486,39 +33486,39 @@
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "type": "object",
                                                   "oc1Required": ["Name"],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "string"
                                                     },
-                                                    "CompanyRegistrationNumber": {
+                                                    "companyRegistrationNumber": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "oc1Required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ],
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -33529,14 +33529,14 @@
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "CharityName",
-                                                    "CharityType"
+                                                    "charityName",
+                                                    "charityType"
                                                   ],
                                                   "properties": {
-                                                    "CharityName": {
+                                                    "charityName": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
@@ -33550,31 +33550,31 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -33590,24 +33590,24 @@
                                                         {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -33620,10 +33620,10 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityType": {
+                                                    "charityType": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Value": {
+                                                        "value": {
                                                           "type": "string",
                                                           "enum": [
                                                             "C",
@@ -33635,13 +33635,13 @@
                                                     }
                                                   }
                                                 },
-                                                "TradingName": {
+                                                "tradingName": {
                                                   "type": "string"
                                                 },
-                                                "PartyNumber": {
+                                                "partyNumber": {
                                                   "type": "string"
                                                 },
-                                                "PartyDescription": {
+                                                "partyDescription": {
                                                   "type": "string"
                                                 }
                                               }
@@ -33651,38 +33651,38 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "PrivateIndividual": {
+                                              "privateIndividual": {
                                                 "type": "object",
                                                 "oc1Required": ["Name"],
                                                 "properties": {
-                                                  "Name": {
+                                                  "name": {
                                                     "type": "object",
                                                     "oc1Required": [
-                                                      "SurnameName"
+                                                      "surnameName"
                                                     ],
                                                     "properties": {
-                                                      "ForenamesName": {
+                                                      "forenamesName": {
                                                         "type": "string"
                                                       },
-                                                      "SurnameName": {
+                                                      "surnameName": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "Alias": {
+                                                  "alias": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ],
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -33692,13 +33692,13 @@
                                                       {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "SurnameName"
+                                                          "surnameName"
                                                         ],
                                                         "properties": {
-                                                          "ForenamesName": {
+                                                          "forenamesName": {
                                                             "type": "string"
                                                           },
-                                                          "SurnameName": {
+                                                          "surnameName": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -33707,35 +33707,35 @@
                                                   }
                                                 }
                                               },
-                                              "Organization": {
+                                              "organization": {
                                                 "type": "object",
                                                 "oc1Required": ["Name"],
                                                 "properties": {
-                                                  "Name": {
+                                                  "name": {
                                                     "type": "string"
                                                   },
-                                                  "CompanyRegistrationNumber": {
+                                                  "companyRegistrationNumber": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "Address": {
+                                              "address": {
                                                 "type": "object",
-                                                "oc1Required": ["AddressLine"],
+                                                "oc1Required": ["addressLine"],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
-                                                    "oc1Required": ["Postcode"],
+                                                    "oc1Required": ["postcode"],
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -33746,14 +33746,14 @@
                                                   }
                                                 }
                                               },
-                                              "CharityDetails": {
+                                              "charityDetails": {
                                                 "type": "object",
                                                 "oc1Required": [
-                                                  "CharityName",
-                                                  "CharityType"
+                                                  "charityName",
+                                                  "charityType"
                                                 ],
                                                 "properties": {
-                                                  "CharityName": {
+                                                  "charityName": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
@@ -33767,31 +33767,31 @@
                                                       }
                                                     ]
                                                   },
-                                                  "CharityAddress": {
+                                                  "charityAddress": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -33807,24 +33807,24 @@
                                                       {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "AddressLine"
+                                                          "addressLine"
                                                         ],
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Postcode"
+                                                              "postcode"
                                                             ],
                                                             "properties": {
-                                                              "Postcode": {
+                                                              "postcode": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "AddressLine": {
+                                                          "addressLine": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Line": {
+                                                              "line": {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "string"
@@ -33837,10 +33837,10 @@
                                                       }
                                                     ]
                                                   },
-                                                  "CharityType": {
+                                                  "charityType": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Value": {
+                                                      "value": {
                                                         "type": "string",
                                                         "enum": ["C", "R", "S"]
                                                       }
@@ -33848,41 +33848,41 @@
                                                   }
                                                 }
                                               },
-                                              "TradingName": {
+                                              "tradingName": {
                                                 "type": "string"
                                               },
-                                              "PartyNumber": {
+                                              "partyNumber": {
                                                 "type": "string"
                                               },
-                                              "PartyDescription": {
+                                              "partyDescription": {
                                                 "type": "string"
                                               }
                                             }
                                           }
                                         ]
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": ["A", "B", "C", "D"]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -33901,53 +33901,53 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "SubCharge": {
+                                  "subCharge": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "RegisteredCharge",
-                                            "ChargeProprietor"
+                                            "registeredCharge",
+                                            "chargeProprietor"
                                           ],
                                           "properties": {
-                                            "ChargeDate": {
+                                            "chargeDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "type": "object",
-                                              "oc1Required": ["EntryDetails"],
+                                              "oc1Required": ["entryDetails"],
                                               "properties": {
-                                                "MultipleTitleIndicator": {
+                                                "multipleTitleIndicator": {
                                                   "type": "string"
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ],
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -33956,7 +33956,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -33975,61 +33975,61 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "type": "object",
                                               "oc1Required": [
-                                                "ChargeeParty",
-                                                "EntryDetails"
+                                                "chargeeParty",
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ],
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ],
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -34039,13 +34039,13 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -34054,41 +34054,41 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "oc1Required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ],
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -34099,14 +34099,14 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -34120,31 +34120,31 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "oc1Required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ],
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -34160,24 +34160,24 @@
                                                                   {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -34190,10 +34190,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -34205,13 +34205,13 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -34221,40 +34221,40 @@
                                                     {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ],
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -34264,13 +34264,13 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ],
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -34279,41 +34279,41 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -34324,14 +34324,14 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -34345,31 +34345,31 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -34385,24 +34385,24 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ],
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -34415,10 +34415,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -34430,37 +34430,37 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "oc1Required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ],
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -34469,7 +34469,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -34488,7 +34488,7 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
@@ -34502,43 +34502,43 @@
                                       {
                                         "type": "object",
                                         "oc1Required": [
-                                          "RegisteredCharge",
-                                          "ChargeProprietor"
+                                          "registeredCharge",
+                                          "chargeProprietor"
                                         ],
                                         "properties": {
-                                          "ChargeDate": {
+                                          "chargeDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "RegisteredCharge": {
+                                          "registeredCharge": {
                                             "type": "object",
-                                            "oc1Required": ["EntryDetails"],
+                                            "oc1Required": ["entryDetails"],
                                             "properties": {
-                                              "MultipleTitleIndicator": {
+                                              "multipleTitleIndicator": {
                                                 "type": "string"
                                               },
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "type": "object",
                                                 "oc1Required": [
-                                                  "EntryNumber",
-                                                  "EntryText"
+                                                  "entryNumber",
+                                                  "entryText"
                                                 ],
                                                 "properties": {
-                                                  "EntryNumber": {
+                                                  "entryNumber": {
                                                     "type": "string"
                                                   },
-                                                  "EntryText": {
+                                                  "entryText": {
                                                     "type": "string"
                                                   },
-                                                  "RegistrationDate": {
+                                                  "registrationDate": {
                                                     "type": "string",
                                                     "format": "date"
                                                   },
-                                                  "SubRegisterCode": {
+                                                  "subRegisterCode": {
                                                     "type": "string",
                                                     "enum": ["A", "B", "C", "D"]
                                                   },
-                                                  "ScheduleCode": {
+                                                  "scheduleCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "0",
@@ -34557,61 +34557,61 @@
                                                       "130"
                                                     ]
                                                   },
-                                                  "Infills": {
+                                                  "infills": {
                                                     "type": "object"
                                                   }
                                                 }
                                               }
                                             }
                                           },
-                                          "ChargeProprietor": {
+                                          "chargeProprietor": {
                                             "type": "object",
                                             "oc1Required": [
-                                              "ChargeeParty",
-                                              "EntryDetails"
+                                              "chargeeParty",
+                                              "entryDetails"
                                             ],
                                             "properties": {
-                                              "ChargeeParty": {
+                                              "chargeeParty": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ],
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ],
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -34621,13 +34621,13 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ],
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -34636,41 +34636,41 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "oc1Required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "oc1Required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ],
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -34681,14 +34681,14 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "oc1Required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -34702,31 +34702,31 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "oc1Required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ],
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -34742,24 +34742,24 @@
                                                                 {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ],
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -34772,10 +34772,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -34787,13 +34787,13 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
@@ -34803,38 +34803,38 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
-                                                      "PrivateIndividual": {
+                                                      "privateIndividual": {
                                                         "type": "object",
                                                         "oc1Required": ["Name"],
                                                         "properties": {
-                                                          "Name": {
+                                                          "name": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ],
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Alias": {
+                                                          "alias": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ],
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -34844,13 +34844,13 @@
                                                               {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ],
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
@@ -34859,39 +34859,39 @@
                                                           }
                                                         }
                                                       },
-                                                      "Organization": {
+                                                      "organization": {
                                                         "type": "object",
                                                         "oc1Required": ["Name"],
                                                         "properties": {
-                                                          "Name": {
+                                                          "name": {
                                                             "type": "string"
                                                           },
-                                                          "CompanyRegistrationNumber": {
+                                                          "companyRegistrationNumber": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "Address": {
+                                                      "address": {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "AddressLine"
+                                                          "addressLine"
                                                         ],
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "type": "object",
                                                             "oc1Required": [
-                                                              "Postcode"
+                                                              "postcode"
                                                             ],
                                                             "properties": {
-                                                              "Postcode": {
+                                                              "postcode": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "AddressLine": {
+                                                          "addressLine": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Line": {
+                                                              "line": {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "string"
@@ -34902,14 +34902,14 @@
                                                           }
                                                         }
                                                       },
-                                                      "CharityDetails": {
+                                                      "charityDetails": {
                                                         "type": "object",
                                                         "oc1Required": [
-                                                          "CharityName",
-                                                          "CharityType"
+                                                          "charityName",
+                                                          "charityType"
                                                         ],
                                                         "properties": {
-                                                          "CharityName": {
+                                                          "charityName": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
@@ -34923,31 +34923,31 @@
                                                               }
                                                             ]
                                                           },
-                                                          "CharityAddress": {
+                                                          "charityAddress": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "object",
                                                                   "oc1Required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "oc1Required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ],
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -34963,24 +34963,24 @@
                                                               {
                                                                 "type": "object",
                                                                 "oc1Required": [
-                                                                  "AddressLine"
+                                                                  "addressLine"
                                                                 ],
                                                                 "properties": {
-                                                                  "PostcodeZone": {
+                                                                  "postcodeZone": {
                                                                     "type": "object",
                                                                     "oc1Required": [
-                                                                      "Postcode"
+                                                                      "postcode"
                                                                     ],
                                                                     "properties": {
-                                                                      "Postcode": {
+                                                                      "postcode": {
                                                                         "type": "string"
                                                                       }
                                                                     }
                                                                   },
-                                                                  "AddressLine": {
+                                                                  "addressLine": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "Line": {
+                                                                      "line": {
                                                                         "type": "array",
                                                                         "items": {
                                                                           "type": "string"
@@ -34993,10 +34993,10 @@
                                                               }
                                                             ]
                                                           },
-                                                          "CharityType": {
+                                                          "charityType": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Value": {
+                                                              "value": {
                                                                 "type": "string",
                                                                 "enum": [
                                                                   "C",
@@ -35008,41 +35008,41 @@
                                                           }
                                                         }
                                                       },
-                                                      "TradingName": {
+                                                      "tradingName": {
                                                         "type": "string"
                                                       },
-                                                      "PartyNumber": {
+                                                      "partyNumber": {
                                                         "type": "string"
                                                       },
-                                                      "PartyDescription": {
+                                                      "partyDescription": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   }
                                                 ]
                                               },
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "type": "object",
                                                 "oc1Required": [
-                                                  "EntryNumber",
-                                                  "EntryText"
+                                                  "entryNumber",
+                                                  "entryText"
                                                 ],
                                                 "properties": {
-                                                  "EntryNumber": {
+                                                  "entryNumber": {
                                                     "type": "string"
                                                   },
-                                                  "EntryText": {
+                                                  "entryText": {
                                                     "type": "string"
                                                   },
-                                                  "RegistrationDate": {
+                                                  "registrationDate": {
                                                     "type": "string",
                                                     "format": "date"
                                                   },
-                                                  "SubRegisterCode": {
+                                                  "subRegisterCode": {
                                                     "type": "string",
                                                     "enum": ["A", "B", "C", "D"]
                                                   },
-                                                  "ScheduleCode": {
+                                                  "scheduleCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "0",
@@ -35061,7 +35061,7 @@
                                                       "130"
                                                     ]
                                                   },
-                                                  "Infills": {
+                                                  "infills": {
                                                     "type": "object"
                                                   }
                                                 }
@@ -35078,44 +35078,44 @@
                           }
                         }
                       },
-                      "AgreedNotice": {
+                      "agreedNotice": {
                         "type": "object",
-                        "oc1Required": ["AgreedNoticeEntry"],
+                        "oc1Required": ["agreedNoticeEntry"],
                         "properties": {
-                          "AgreedNoticeEntry": {
+                          "agreedNoticeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryDetails"],
+                                  "oc1Required": ["entryDetails"],
                                   "properties": {
-                                    "AgreedNoticeType": {
+                                    "agreedNoticeType": {
                                       "type": "string",
                                       "enum": ["10", "20"]
                                     },
-                                    "EntryDetails": {
+                                    "entryDetails": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ],
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": ["A", "B", "C", "D"]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -35134,7 +35134,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -35145,31 +35145,31 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryDetails"],
+                                "oc1Required": ["entryDetails"],
                                 "properties": {
-                                  "AgreedNoticeType": {
+                                  "agreedNoticeType": {
                                     "type": "string",
                                     "enum": ["10", "20"]
                                   },
-                                  "EntryDetails": {
+                                  "entryDetails": {
                                     "type": "object",
-                                    "oc1Required": ["EntryNumber", "EntryText"],
+                                    "oc1Required": ["entryNumber", "entryText"],
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": ["A", "B", "C", "D"]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -35188,7 +35188,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -35199,33 +35199,33 @@
                           }
                         }
                       },
-                      "Bankruptcy": {
+                      "bankruptcy": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35244,7 +35244,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35253,23 +35253,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35288,7 +35288,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -35297,33 +35297,33 @@
                           }
                         }
                       },
-                      "Caution": {
+                      "caution": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35342,7 +35342,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35351,23 +35351,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35386,7 +35386,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -35395,33 +35395,33 @@
                           }
                         }
                       },
-                      "DeedOfPostponement": {
+                      "deedOfPostponement": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35440,7 +35440,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35449,23 +35449,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35484,7 +35484,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -35493,33 +35493,33 @@
                           }
                         }
                       },
-                      "GreenOutEntry": {
+                      "greenOutEntry": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35538,7 +35538,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35547,23 +35547,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35582,7 +35582,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -35591,47 +35591,47 @@
                           }
                         }
                       },
-                      "HomeRights": {
+                      "homeRights": {
                         "type": "object",
-                        "oc1Required": ["HomeRightsEntry"],
+                        "oc1Required": ["homeRightsEntry"],
                         "properties": {
-                          "HomeRightsEntry": {
+                          "homeRightsEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "ChangeOfAddressIndicator",
-                                    "HomeRightsEntryDetails"
+                                    "changeOfAddressIndicator",
+                                    "homeRightsEntryDetails"
                                   ],
                                   "properties": {
-                                    "ChangeOfAddressIndicator": {
+                                    "changeOfAddressIndicator": {
                                       "type": "string",
                                       "enum": ["true", "false"]
                                     },
-                                    "HomeRightsEntryDetails": {
+                                    "homeRightsEntryDetails": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ],
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": ["A", "B", "C", "D"]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -35650,33 +35650,33 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
                                     },
-                                    "ChangeOfAddressEntryDetails": {
+                                    "changeOfAddressEntryDetails": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ],
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": ["A", "B", "C", "D"]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -35695,7 +35695,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -35707,33 +35707,33 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "ChangeOfAddressIndicator",
-                                  "HomeRightsEntryDetails"
+                                  "changeOfAddressIndicator",
+                                  "homeRightsEntryDetails"
                                 ],
                                 "properties": {
-                                  "ChangeOfAddressIndicator": {
+                                  "changeOfAddressIndicator": {
                                     "type": "string",
                                     "enum": ["true", "false"]
                                   },
-                                  "HomeRightsEntryDetails": {
+                                  "homeRightsEntryDetails": {
                                     "type": "object",
-                                    "oc1Required": ["EntryNumber", "EntryText"],
+                                    "oc1Required": ["entryNumber", "entryText"],
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": ["A", "B", "C", "D"]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -35752,30 +35752,30 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
                                   },
-                                  "ChangeOfAddressEntryDetails": {
+                                  "changeOfAddressEntryDetails": {
                                     "type": "object",
-                                    "oc1Required": ["EntryNumber", "EntryText"],
+                                    "oc1Required": ["entryNumber", "entryText"],
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": ["A", "B", "C", "D"]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -35794,7 +35794,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -35805,33 +35805,33 @@
                           }
                         }
                       },
-                      "RentCharge": {
+                      "rentCharge": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35850,7 +35850,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35859,23 +35859,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35894,7 +35894,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -35903,33 +35903,33 @@
                           }
                         }
                       },
-                      "VendorsLien": {
+                      "vendorsLien": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -35948,7 +35948,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -35957,23 +35957,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -35992,7 +35992,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36001,33 +36001,33 @@
                           }
                         }
                       },
-                      "RightOfPreEmption": {
+                      "rightOfPreEmption": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36046,7 +36046,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36055,23 +36055,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36090,7 +36090,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36099,24 +36099,24 @@
                           }
                         }
                       },
-                      "DocumentDetails": {
+                      "documentDetails": {
                         "type": "object",
-                        "oc1Required": ["Document"],
+                        "oc1Required": ["document"],
                         "properties": {
-                          "Document": {
+                          "document": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "DocumentType",
-                                    "EntryNumber",
-                                    "PlanOnlyIndicator",
-                                    "RegisterDescription"
+                                    "documentType",
+                                    "entryNumber",
+                                    "planOnlyIndicator",
+                                    "registerDescription"
                                   ],
                                   "properties": {
-                                    "DocumentType": {
+                                    "documentType": {
                                       "type": "string",
                                       "enum": [
                                         "10",
@@ -36139,10 +36139,10 @@
                                         "180"
                                       ]
                                     },
-                                    "DocumentDate": {
+                                    "documentDate": {
                                       "type": "string"
                                     },
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -36156,14 +36156,14 @@
                                         }
                                       ]
                                     },
-                                    "PlanOnlyIndicator": {
+                                    "planOnlyIndicator": {
                                       "type": "string",
                                       "enum": ["true", "false"]
                                     },
-                                    "FiledUnder": {
+                                    "filedUnder": {
                                       "type": "string"
                                     },
-                                    "RegisterDescription": {
+                                    "registerDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -36173,13 +36173,13 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "DocumentType",
-                                  "EntryNumber",
-                                  "PlanOnlyIndicator",
-                                  "RegisterDescription"
+                                  "documentType",
+                                  "entryNumber",
+                                  "planOnlyIndicator",
+                                  "registerDescription"
                                 ],
                                 "properties": {
-                                  "DocumentType": {
+                                  "documentType": {
                                     "type": "string",
                                     "enum": [
                                       "10",
@@ -36202,10 +36202,10 @@
                                       "180"
                                     ]
                                   },
-                                  "DocumentDate": {
+                                  "documentDate": {
                                     "type": "string"
                                   },
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -36219,14 +36219,14 @@
                                       }
                                     ]
                                   },
-                                  "PlanOnlyIndicator": {
+                                  "planOnlyIndicator": {
                                     "type": "string",
                                     "enum": ["true", "false"]
                                   },
-                                  "FiledUnder": {
+                                  "filedUnder": {
                                     "type": "string"
                                   },
-                                  "RegisterDescription": {
+                                  "registerDescription": {
                                     "type": "string"
                                   }
                                 }
@@ -36235,43 +36235,43 @@
                           }
                         }
                       },
-                      "UnilateralNoticeDetails": {
+                      "unilateralNoticeDetails": {
                         "type": "object",
-                        "oc1Required": ["UnilateralNoticeEntry"],
+                        "oc1Required": ["unilateralNoticeEntry"],
                         "properties": {
-                          "UnilateralNoticeEntry": {
+                          "unilateralNoticeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "UnilateralNotice",
-                                    "UnilateralNoticeBeneficiary"
+                                    "unilateralNotice",
+                                    "unilateralNoticeBeneficiary"
                                   ],
                                   "properties": {
-                                    "UnilateralNotice": {
+                                    "unilateralNotice": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ],
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": ["A", "B", "C", "D"]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -36290,33 +36290,33 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
                                     },
-                                    "UnilateralNoticeBeneficiary": {
+                                    "unilateralNoticeBeneficiary": {
                                       "type": "object",
                                       "oc1Required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ],
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": ["A", "B", "C", "D"]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -36335,7 +36335,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -36347,29 +36347,29 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "UnilateralNotice",
-                                  "UnilateralNoticeBeneficiary"
+                                  "unilateralNotice",
+                                  "unilateralNoticeBeneficiary"
                                 ],
                                 "properties": {
-                                  "UnilateralNotice": {
+                                  "unilateralNotice": {
                                     "type": "object",
-                                    "oc1Required": ["EntryNumber", "EntryText"],
+                                    "oc1Required": ["entryNumber", "entryText"],
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": ["A", "B", "C", "D"]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -36388,30 +36388,30 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
                                   },
-                                  "UnilateralNoticeBeneficiary": {
+                                  "unilateralNoticeBeneficiary": {
                                     "type": "object",
-                                    "oc1Required": ["EntryNumber", "EntryText"],
+                                    "oc1Required": ["entryNumber", "entryText"],
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": ["A", "B", "C", "D"]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -36430,7 +36430,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -36441,33 +36441,33 @@
                           }
                         }
                       },
-                      "DeathOfProprietor": {
+                      "deathOfProprietor": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36486,7 +36486,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36495,23 +36495,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36530,7 +36530,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36539,33 +36539,33 @@
                           }
                         }
                       },
-                      "DiscountCharge": {
+                      "discountCharge": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36584,7 +36584,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36593,23 +36593,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36628,7 +36628,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36637,33 +36637,33 @@
                           }
                         }
                       },
-                      "EquitableCharge": {
+                      "equitableCharge": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36682,7 +36682,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36691,23 +36691,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36726,7 +36726,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36735,33 +36735,33 @@
                           }
                         }
                       },
-                      "NotedCharge": {
+                      "notedCharge": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36780,7 +36780,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36789,23 +36789,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36824,7 +36824,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36833,33 +36833,33 @@
                           }
                         }
                       },
-                      "CreditorsNotice": {
+                      "creditorsNotice": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36878,7 +36878,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36887,23 +36887,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -36922,7 +36922,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -36931,33 +36931,33 @@
                           }
                         }
                       },
-                      "UnidentifiedEntry": {
+                      "unidentifiedEntry": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -36976,7 +36976,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -36985,23 +36985,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -37020,7 +37020,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -37029,33 +37029,33 @@
                           }
                         }
                       },
-                      "CCBIEntry": {
+                      "ccbiEntry": {
                         "type": "object",
-                        "oc1Required": ["EntryDetails"],
+                        "oc1Required": ["entryDetails"],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": ["A", "B", "C", "D"]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -37074,7 +37074,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -37083,23 +37083,23 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": ["A", "B", "C", "D"]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -37118,7 +37118,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -37129,22 +37129,22 @@
                       }
                     }
                   },
-                  "OCRegisterData": {
+                  "ocRegisterData": {
                     "title": "Official Copy Register Data",
                     "type": "object",
                     "oc1Required": [
-                      "PropertyRegister",
-                      "ProprietorshipRegister"
+                      "propertyRegister",
+                      "proprietorshipRegister"
                     ],
                     "properties": {
-                      "PropertyRegister": {
+                      "propertyRegister": {
                         "type": "object",
-                        "oc1Required": ["RegisterEntry"],
+                        "oc1Required": ["registerEntry"],
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -37160,24 +37160,24 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -37197,18 +37197,18 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -37226,41 +37226,41 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "oc1Required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ],
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -37281,20 +37281,20 @@
                                         {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37319,34 +37319,34 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37367,20 +37367,20 @@
                                       {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -37404,14 +37404,14 @@
                           }
                         }
                       },
-                      "ProprietorshipRegister": {
+                      "proprietorshipRegister": {
                         "type": "object",
-                        "oc1Required": ["RegisterEntry"],
+                        "oc1Required": ["registerEntry"],
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -37427,24 +37427,24 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -37464,18 +37464,18 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -37493,41 +37493,41 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "oc1Required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ],
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -37548,20 +37548,20 @@
                                         {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37586,34 +37586,34 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37634,20 +37634,20 @@
                                       {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -37671,14 +37671,14 @@
                           }
                         }
                       },
-                      "ChargesRegister": {
+                      "chargesRegister": {
                         "type": "object",
-                        "oc1Required": ["RegisterEntry"],
+                        "oc1Required": ["registerEntry"],
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -37694,24 +37694,24 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "oc1Required": ["EntryNumber", "EntryText"],
+                                  "oc1Required": ["entryNumber", "entryText"],
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -37731,18 +37731,18 @@
                               },
                               {
                                 "type": "object",
-                                "oc1Required": ["EntryNumber", "EntryText"],
+                                "oc1Required": ["entryNumber", "entryText"],
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -37760,41 +37760,41 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "oc1Required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "oc1Required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ],
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -37815,20 +37815,20 @@
                                         {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37853,34 +37853,34 @@
                               {
                                 "type": "object",
                                 "oc1Required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "oc1Required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ],
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -37901,20 +37901,20 @@
                                       {
                                         "type": "object",
                                         "oc1Required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ],
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -32,7 +32,7 @@
         "baspiRequired": ["name", "email", "role"],
         "properties": {
           "name": {
-            "title": "name",
+            "title": "Name",
             "type": "object",
             "baspiRequired": ["firstName", "lastName"],
             "properties": {
@@ -745,7 +745,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "name"
+                        "title": "Name"
                       },
                       "contact": {
                         "type": "object",
@@ -912,7 +912,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "title": "name",
+                        "title": "Name",
                         "type": "string"
                       },
                       "transportType": {
@@ -956,7 +956,7 @@
                     "title": "Healthcare service",
                     "properties": {
                       "name": {
-                        "title": "name",
+                        "title": "Name",
                         "type": "string"
                       },
                       "typeOfHealthCare": {
@@ -12097,7 +12097,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "1.16",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -13493,7 +13493,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "2.11",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -14688,7 +14688,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "4.8",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15188,7 +15188,7 @@
                             "properties": {
                               "itemName": {
                                 "ta10Ref": "5.8",
-                                "title": "name",
+                                "title": "Name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -15682,7 +15682,7 @@
                             "properties": {
                               "itemName": {
                                 "ta10Ref": "5.19",
-                                "title": "name",
+                                "title": "Name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -16180,7 +16180,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "6.8",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -16673,7 +16673,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "7.8",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -17470,7 +17470,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "8.13",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -17974,7 +17974,7 @@
                         "properties": {
                           "itemName": {
                             "ta10Ref": "11.1",
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {

--- a/src/schemas/v3/overlays/llc1.json
+++ b/src/schemas/v3/overlays/llc1.json
@@ -9,11 +9,11 @@
             "localLandCharges": {
               "items": {
                 "required": [
-                  "HMLRReference",
-                  "RegistrationDate",
-                  "Category",
-                  "Location",
-                  "LocationDominantBuilding"
+                  "hmlrReference",
+                  "registrationDate",
+                  "category",
+                  "location",
+                  "locationDominantBuilding"
                 ]
               }
             }

--- a/src/schemas/v3/overlays/oc1.json
+++ b/src/schemas/v3/overlays/oc1.json
@@ -116,7 +116,7 @@
                                   "properties": {
                                     "privateIndividual": {
                                       "required": [
-                                        "Name"
+                                        "name"
                                       ],
                                       "properties": {
                                         "name": {
@@ -144,7 +144,7 @@
                                     },
                                     "organization": {
                                       "required": [
-                                        "Name"
+                                        "name"
                                       ]
                                     },
                                     "address": {
@@ -204,7 +204,7 @@
                                 "properties": {
                                   "privateIndividual": {
                                     "required": [
-                                      "Name"
+                                      "name"
                                     ],
                                     "properties": {
                                       "name": {
@@ -232,7 +232,7 @@
                                   },
                                   "organization": {
                                     "required": [
-                                      "Name"
+                                      "name"
                                     ]
                                   },
                                   "address": {
@@ -296,7 +296,7 @@
                                   "properties": {
                                     "privateIndividual": {
                                       "required": [
-                                        "Name"
+                                        "name"
                                       ],
                                       "properties": {
                                         "name": {
@@ -324,7 +324,7 @@
                                     },
                                     "organization": {
                                       "required": [
-                                        "Name"
+                                        "name"
                                       ]
                                     },
                                     "address": {
@@ -384,7 +384,7 @@
                                 "properties": {
                                   "privateIndividual": {
                                     "required": [
-                                      "Name"
+                                      "name"
                                     ],
                                     "properties": {
                                       "name": {
@@ -412,7 +412,7 @@
                                   },
                                   "organization": {
                                     "required": [
-                                      "Name"
+                                      "name"
                                     ]
                                   },
                                   "address": {
@@ -490,7 +490,7 @@
                                     "properties": {
                                       "privateIndividual": {
                                         "required": [
-                                          "Name"
+                                          "name"
                                         ],
                                         "properties": {
                                           "name": {
@@ -518,7 +518,7 @@
                                       },
                                       "organization": {
                                         "required": [
-                                          "Name"
+                                          "name"
                                         ]
                                       },
                                       "address": {
@@ -730,7 +730,7 @@
                                                 "properties": {
                                                   "privateIndividual": {
                                                     "required": [
-                                                      "Name"
+                                                      "name"
                                                     ],
                                                     "properties": {
                                                       "name": {
@@ -758,7 +758,7 @@
                                                   },
                                                   "organization": {
                                                     "required": [
-                                                      "Name"
+                                                      "name"
                                                     ]
                                                   },
                                                   "address": {
@@ -818,7 +818,7 @@
                                               "properties": {
                                                 "privateIndividual": {
                                                   "required": [
-                                                    "Name"
+                                                    "name"
                                                   ],
                                                   "properties": {
                                                     "name": {
@@ -846,7 +846,7 @@
                                                 },
                                                 "organization": {
                                                   "required": [
-                                                    "Name"
+                                                    "name"
                                                   ]
                                                 },
                                                 "address": {
@@ -946,7 +946,7 @@
                                                           "properties": {
                                                             "privateIndividual": {
                                                               "required": [
-                                                                "Name"
+                                                                "name"
                                                               ],
                                                               "properties": {
                                                                 "name": {
@@ -974,7 +974,7 @@
                                                             },
                                                             "organization": {
                                                               "required": [
-                                                                "Name"
+                                                                "name"
                                                               ]
                                                             },
                                                             "address": {
@@ -1034,7 +1034,7 @@
                                                         "properties": {
                                                           "privateIndividual": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -1062,7 +1062,7 @@
                                                           },
                                                           "organization": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ]
                                                           },
                                                           "address": {
@@ -1162,7 +1162,7 @@
                                                         "properties": {
                                                           "privateIndividual": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -1190,7 +1190,7 @@
                                                           },
                                                           "organization": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ]
                                                           },
                                                           "address": {
@@ -1250,7 +1250,7 @@
                                                       "properties": {
                                                         "privateIndividual": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -1278,7 +1278,7 @@
                                                         },
                                                         "organization": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ]
                                                         },
                                                         "address": {
@@ -1382,7 +1382,7 @@
                                               "properties": {
                                                 "privateIndividual": {
                                                   "required": [
-                                                    "Name"
+                                                    "name"
                                                   ],
                                                   "properties": {
                                                     "name": {
@@ -1410,7 +1410,7 @@
                                                 },
                                                 "organization": {
                                                   "required": [
-                                                    "Name"
+                                                    "name"
                                                   ]
                                                 },
                                                 "address": {
@@ -1470,7 +1470,7 @@
                                             "properties": {
                                               "privateIndividual": {
                                                 "required": [
-                                                  "Name"
+                                                  "name"
                                                 ],
                                                 "properties": {
                                                   "name": {
@@ -1498,7 +1498,7 @@
                                               },
                                               "organization": {
                                                 "required": [
-                                                  "Name"
+                                                  "name"
                                                 ]
                                               },
                                               "address": {
@@ -1598,7 +1598,7 @@
                                                         "properties": {
                                                           "privateIndividual": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ],
                                                             "properties": {
                                                               "name": {
@@ -1626,7 +1626,7 @@
                                                           },
                                                           "organization": {
                                                             "required": [
-                                                              "Name"
+                                                              "name"
                                                             ]
                                                           },
                                                           "address": {
@@ -1686,7 +1686,7 @@
                                                       "properties": {
                                                         "privateIndividual": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -1714,7 +1714,7 @@
                                                         },
                                                         "organization": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ]
                                                         },
                                                         "address": {
@@ -1814,7 +1814,7 @@
                                                       "properties": {
                                                         "privateIndividual": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ],
                                                           "properties": {
                                                             "name": {
@@ -1842,7 +1842,7 @@
                                                         },
                                                         "organization": {
                                                           "required": [
-                                                            "Name"
+                                                            "name"
                                                           ]
                                                         },
                                                         "address": {
@@ -1902,7 +1902,7 @@
                                                     "properties": {
                                                       "privateIndividual": {
                                                         "required": [
-                                                          "Name"
+                                                          "name"
                                                         ],
                                                         "properties": {
                                                           "name": {
@@ -1930,7 +1930,7 @@
                                                       },
                                                       "organization": {
                                                         "required": [
-                                                          "Name"
+                                                          "name"
                                                         ]
                                                       },
                                                       "address": {

--- a/src/schemas/v3/overlays/oc1.json
+++ b/src/schemas/v3/overlays/oc1.json
@@ -9,173 +9,173 @@
             "properties": {
               "registerExtract": {
                 "required": [
-                  "OCSummaryData",
-                  "OCRegisterData"
+                  "ocSummaryData",
+                  "ocRegisterData"
                 ],
                 "properties": {
-                  "OCSummaryData": {
+                  "ocSummaryData": {
                     "required": [
-                      "OfficialCopyDateTime",
-                      "EditionDate",
-                      "PropertyAddress",
-                      "Title",
-                      "RegisterEntryIndicators",
-                      "Proprietorship"
+                      "officialCopyDateTime",
+                      "editionDate",
+                      "propertyAddress",
+                      "title",
+                      "registerEntryIndicators",
+                      "proprietorship"
                     ],
                     "properties": {
-                      "PricePaidEntry": {
+                      "pricePaidEntry": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "required": [
-                              "EntryNumber",
-                              "EntryText"
+                              "entryNumber",
+                              "entryText"
                             ]
                           }
                         }
                       },
-                      "PropertyAddress": {
+                      "propertyAddress": {
                         "required": [
-                          "AddressLine"
+                          "addressLine"
                         ],
                         "properties": {
-                          "PostcodeZone": {
+                          "postcodeZone": {
                             "required": [
-                              "Postcode"
+                              "postcode"
                             ]
                           }
                         }
                       },
-                      "Title": {
+                      "title": {
                         "required": [
-                          "TitleNumber",
-                          "ClassOfTitleCode",
-                          "CommonholdIndicator",
-                          "TitleRegistrationDetails"
+                          "titleNumber",
+                          "classOfTitleCode",
+                          "commonholdIndicator",
+                          "titleRegistrationDetails"
                         ],
                         "properties": {
-                          "TitleRegistrationDetails": {
+                          "titleRegistrationDetails": {
                             "required": [
-                              "DistrictName",
-                              "AdministrativeArea",
-                              "LandRegistryOfficeName",
-                              "LatestEditionDate"
+                              "districtName",
+                              "administrativeArea",
+                              "landRegistryOfficeName",
+                              "latestEditionDate"
                             ],
                             "properties": {
-                              "PostcodeZone": {
+                              "postcodeZone": {
                                 "required": [
-                                  "Postcode"
+                                  "postcode"
                                 ]
                               }
                             }
                           }
                         }
                       },
-                      "RegisterEntryIndicators": {
+                      "registerEntryIndicators": {
                         "required": [
-                          "AgreedNoticeIndicator",
-                          "BankruptcyIndicator",
-                          "CautionIndicator",
-                          "CCBIIndicator",
-                          "ChargeeIndicator",
-                          "ChargeIndicator",
-                          "ChargeRelatedRestrictionIndicator",
-                          "ChargeRestrictionIndicator",
-                          "CreditorsNoticeIndicator",
-                          "DeathOfProprietorIndicator",
-                          "DeedOfPostponementIndicator",
-                          "DiscountChargeIndicator",
-                          "EquitableChargeIndicator",
-                          "GreenOutEntryIndicator",
-                          "HomeRightsChangeOfAddressIndicator",
-                          "HomeRightsIndicator",
-                          "LeaseHoldTitleIndicator",
-                          "MultipleChargeIndicator",
-                          "NonChargeRestrictionIndicator",
-                          "NotedChargeIndicator",
-                          "PricePaidIndicator",
-                          "PropertyDescriptionNotesIndicator",
-                          "RentChargeIndicator",
-                          "RightOfPreEmptionIndicator",
-                          "ScheduleOfLeasesIndicator",
-                          "SubChargeIndicator",
-                          "UnidentifiedEntryIndicator",
-                          "UnilateralNoticeBeneficiaryIndicator",
-                          "UnilateralNoticeIndicator",
-                          "VendorsLienIndicator"
+                          "agreedNoticeIndicator",
+                          "bankruptcyIndicator",
+                          "cautionIndicator",
+                          "ccbiIndicator",
+                          "chargeeIndicator",
+                          "chargeIndicator",
+                          "chargeRelatedRestrictionIndicator",
+                          "chargeRestrictionIndicator",
+                          "creditorsNoticeIndicator",
+                          "deathOfProprietorIndicator",
+                          "deedOfPostponementIndicator",
+                          "discountChargeIndicator",
+                          "equitableChargeIndicator",
+                          "greenOutEntryIndicator",
+                          "homeRightsChangeOfAddressIndicator",
+                          "homeRightsIndicator",
+                          "leaseHoldTitleIndicator",
+                          "multipleChargeIndicator",
+                          "nonChargeRestrictionIndicator",
+                          "notedChargeIndicator",
+                          "pricePaidIndicator",
+                          "propertyDescriptionNotesIndicator",
+                          "rentChargeIndicator",
+                          "rightOfPreEmptionIndicator",
+                          "scheduleOfLeasesIndicator",
+                          "subChargeIndicator",
+                          "unidentifiedEntryIndicator",
+                          "unilateralNoticeBeneficiaryIndicator",
+                          "unilateralNoticeIndicator",
+                          "vendorsLienIndicator"
                         ]
                       },
-                      "Proprietorship": {
+                      "proprietorship": {
                         "properties": {
-                          "CautionerParty": {
+                          "cautionerParty": {
                             "oneOf": [
                               {
                                 "items": {
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "required": [
                                         "Name"
                                       ],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "required": [
-                                            "SurnameName"
+                                            "surnameName"
                                           ]
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "items": {
                                                 "required": [
-                                                  "SurnameName"
+                                                  "surnameName"
                                                 ]
                                               }
                                             },
                                             {
                                               "required": [
-                                                "SurnameName"
+                                                "surnameName"
                                               ]
                                             }
                                           ]
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "required": [
                                         "Name"
                                       ]
                                     },
-                                    "Address": {
+                                    "address": {
                                       "required": [
-                                        "AddressLine"
+                                        "addressLine"
                                       ],
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "required": [
-                                            "Postcode"
+                                            "postcode"
                                           ]
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "required": [
-                                        "CharityName",
-                                        "CharityType"
+                                        "charityName",
+                                        "charityType"
                                       ],
                                       "properties": {
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "items": {
                                                 "required": [
-                                                  "AddressLine"
+                                                  "addressLine"
                                                 ],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "required": [
-                                                      "Postcode"
+                                                      "postcode"
                                                     ]
                                                   }
                                                 }
@@ -183,12 +183,12 @@
                                             },
                                             {
                                               "required": [
-                                                "AddressLine"
+                                                "addressLine"
                                               ],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "required": [
-                                                    "Postcode"
+                                                    "postcode"
                                                   ]
                                                 }
                                               }
@@ -202,68 +202,68 @@
                               },
                               {
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "required": [
                                       "Name"
                                     ],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "required": [
-                                          "SurnameName"
+                                          "surnameName"
                                         ]
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "items": {
                                               "required": [
-                                                "SurnameName"
+                                                "surnameName"
                                               ]
                                             }
                                           },
                                           {
                                             "required": [
-                                              "SurnameName"
+                                              "surnameName"
                                             ]
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "required": [
                                       "Name"
                                     ]
                                   },
-                                  "Address": {
+                                  "address": {
                                     "required": [
-                                      "AddressLine"
+                                      "addressLine"
                                     ],
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "required": [
-                                          "Postcode"
+                                          "postcode"
                                         ]
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "required": [
-                                      "CharityName",
-                                      "CharityType"
+                                      "charityName",
+                                      "charityType"
                                     ],
                                     "properties": {
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "items": {
                                               "required": [
-                                                "AddressLine"
+                                                "addressLine"
                                               ],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "required": [
-                                                    "Postcode"
+                                                    "postcode"
                                                   ]
                                                 }
                                               }
@@ -271,12 +271,12 @@
                                           },
                                           {
                                             "required": [
-                                              "AddressLine"
+                                              "addressLine"
                                             ],
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "required": [
-                                                  "Postcode"
+                                                  "postcode"
                                                 ]
                                               }
                                             }
@@ -289,73 +289,73 @@
                               }
                             ]
                           },
-                          "RegisteredProprietorParty": {
+                          "registeredProprietorParty": {
                             "oneOf": [
                               {
                                 "items": {
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "required": [
                                         "Name"
                                       ],
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "required": [
-                                            "SurnameName"
+                                            "surnameName"
                                           ]
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "items": {
                                                 "required": [
-                                                  "SurnameName"
+                                                  "surnameName"
                                                 ]
                                               }
                                             },
                                             {
                                               "required": [
-                                                "SurnameName"
+                                                "surnameName"
                                               ]
                                             }
                                           ]
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "required": [
                                         "Name"
                                       ]
                                     },
-                                    "Address": {
+                                    "address": {
                                       "required": [
-                                        "AddressLine"
+                                        "addressLine"
                                       ],
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "required": [
-                                            "Postcode"
+                                            "postcode"
                                           ]
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "required": [
-                                        "CharityName",
-                                        "CharityType"
+                                        "charityName",
+                                        "charityType"
                                       ],
                                       "properties": {
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "items": {
                                                 "required": [
-                                                  "AddressLine"
+                                                  "addressLine"
                                                 ],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "required": [
-                                                      "Postcode"
+                                                      "postcode"
                                                     ]
                                                   }
                                                 }
@@ -363,12 +363,12 @@
                                             },
                                             {
                                               "required": [
-                                                "AddressLine"
+                                                "addressLine"
                                               ],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "required": [
-                                                    "Postcode"
+                                                    "postcode"
                                                   ]
                                                 }
                                               }
@@ -382,68 +382,68 @@
                               },
                               {
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "required": [
                                       "Name"
                                     ],
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "required": [
-                                          "SurnameName"
+                                          "surnameName"
                                         ]
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "items": {
                                               "required": [
-                                                "SurnameName"
+                                                "surnameName"
                                               ]
                                             }
                                           },
                                           {
                                             "required": [
-                                              "SurnameName"
+                                              "surnameName"
                                             ]
                                           }
                                         ]
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "required": [
                                       "Name"
                                     ]
                                   },
-                                  "Address": {
+                                  "address": {
                                     "required": [
-                                      "AddressLine"
+                                      "addressLine"
                                     ],
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "required": [
-                                          "Postcode"
+                                          "postcode"
                                         ]
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "required": [
-                                      "CharityName",
-                                      "CharityType"
+                                      "charityName",
+                                      "charityType"
                                     ],
                                     "properties": {
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "items": {
                                               "required": [
-                                                "AddressLine"
+                                                "addressLine"
                                               ],
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "required": [
-                                                    "Postcode"
+                                                    "postcode"
                                                   ]
                                                 }
                                               }
@@ -451,12 +451,12 @@
                                           },
                                           {
                                             "required": [
-                                              "AddressLine"
+                                              "addressLine"
                                             ],
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "required": [
-                                                  "Postcode"
+                                                  "postcode"
                                                 ]
                                               }
                                             }
@@ -471,85 +471,85 @@
                           }
                         }
                       },
-                      "Lease": {
+                      "lease": {
                         "required": [
-                          "LeaseEntry"
+                          "leaseEntry"
                         ],
                         "properties": {
-                          "LeaseEntry": {
+                          "leaseEntry": {
                             "items": {
                               "required": [
-                                "LeaseTerm",
-                                "LeaseDate",
-                                "LeaseParty",
-                                "EntryDetails"
+                                "leaseTerm",
+                                "leaseDate",
+                                "leaseParty",
+                                "entryDetails"
                               ],
                               "properties": {
-                                "LeaseParty": {
+                                "leaseParty": {
                                   "items": {
                                     "properties": {
-                                      "PrivateIndividual": {
+                                      "privateIndividual": {
                                         "required": [
                                           "Name"
                                         ],
                                         "properties": {
-                                          "Name": {
+                                          "name": {
                                             "required": [
-                                              "SurnameName"
+                                              "surnameName"
                                             ]
                                           },
-                                          "Alias": {
+                                          "alias": {
                                             "oneOf": [
                                               {
                                                 "items": {
                                                   "required": [
-                                                    "SurnameName"
+                                                    "surnameName"
                                                   ]
                                                 }
                                               },
                                               {
                                                 "required": [
-                                                  "SurnameName"
+                                                  "surnameName"
                                                 ]
                                               }
                                             ]
                                           }
                                         }
                                       },
-                                      "Organization": {
+                                      "organization": {
                                         "required": [
                                           "Name"
                                         ]
                                       },
-                                      "Address": {
+                                      "address": {
                                         "required": [
-                                          "AddressLine"
+                                          "addressLine"
                                         ],
                                         "properties": {
-                                          "PostcodeZone": {
+                                          "postcodeZone": {
                                             "required": [
-                                              "Postcode"
+                                              "postcode"
                                             ]
                                           }
                                         }
                                       },
-                                      "CharityDetails": {
+                                      "charityDetails": {
                                         "required": [
-                                          "CharityName",
-                                          "CharityType"
+                                          "charityName",
+                                          "charityType"
                                         ],
                                         "properties": {
-                                          "CharityAddress": {
+                                          "charityAddress": {
                                             "oneOf": [
                                               {
                                                 "items": {
                                                   "required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ]
                                                     }
                                                   }
@@ -557,12 +557,12 @@
                                               },
                                               {
                                                 "required": [
-                                                  "AddressLine"
+                                                  "addressLine"
                                                 ],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "required": [
-                                                      "Postcode"
+                                                      "postcode"
                                                     ]
                                                   }
                                                 }
@@ -574,10 +574,10 @@
                                     }
                                   }
                                 },
-                                "EntryDetails": {
+                                "entryDetails": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               }
@@ -585,54 +585,54 @@
                           }
                         }
                       },
-                      "RestrictionDetails": {
+                      "restrictionDetails": {
                         "required": [
-                          "RestrictionEntry"
+                          "restrictionEntry"
                         ],
                         "properties": {
-                          "RestrictionEntry": {
+                          "restrictionEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "properties": {
-                                    "ChargeRelatedRestriction": {
+                                    "chargeRelatedRestriction": {
                                       "required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       }
                                     },
-                                    "ChargeRestriction": {
+                                    "chargeRestriction": {
                                       "required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       }
                                     },
-                                    "NonChargeRestriction": {
+                                    "nonChargeRestriction": {
                                       "required": [
-                                        "RestrictionTypeCode",
-                                        "EntryDetails"
+                                        "restrictionTypeCode",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       }
@@ -642,44 +642,44 @@
                               },
                               {
                                 "properties": {
-                                  "ChargeRelatedRestriction": {
+                                  "chargeRelatedRestriction": {
                                     "required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     }
                                   },
-                                  "ChargeRestriction": {
+                                  "chargeRestriction": {
                                     "required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     }
                                   },
-                                  "NonChargeRestriction": {
+                                  "nonChargeRestriction": {
                                     "required": [
-                                      "RestrictionTypeCode",
-                                      "EntryDetails"
+                                      "restrictionTypeCode",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     }
@@ -690,106 +690,106 @@
                           }
                         }
                       },
-                      "Charge": {
+                      "charge": {
                         "required": [
-                          "ChargeEntry"
+                          "chargeEntry"
                         ],
                         "properties": {
-                          "ChargeEntry": {
+                          "chargeEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "RegisteredCharge",
-                                    "ChargeProprietor"
+                                    "registeredCharge",
+                                    "chargeProprietor"
                                   ],
                                   "properties": {
-                                    "RegisteredCharge": {
+                                    "registeredCharge": {
                                       "required": [
-                                        "EntryDetails"
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       }
                                     },
-                                    "ChargeProprietor": {
+                                    "chargeProprietor": {
                                       "required": [
-                                        "ChargeeParty",
-                                        "EntryDetails"
+                                        "chargeeParty",
+                                        "entryDetails"
                                       ],
                                       "properties": {
-                                        "ChargeeParty": {
+                                        "chargeeParty": {
                                           "oneOf": [
                                             {
                                               "items": {
                                                 "properties": {
-                                                  "PrivateIndividual": {
+                                                  "privateIndividual": {
                                                     "required": [
                                                       "Name"
                                                     ],
                                                     "properties": {
-                                                      "Name": {
+                                                      "name": {
                                                         "required": [
-                                                          "SurnameName"
+                                                          "surnameName"
                                                         ]
                                                       },
-                                                      "Alias": {
+                                                      "alias": {
                                                         "oneOf": [
                                                           {
                                                             "items": {
                                                               "required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ]
                                                             }
                                                           },
                                                           {
                                                             "required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ]
                                                           }
                                                         ]
                                                       }
                                                     }
                                                   },
-                                                  "Organization": {
+                                                  "organization": {
                                                     "required": [
                                                       "Name"
                                                     ]
                                                   },
-                                                  "Address": {
+                                                  "address": {
                                                     "required": [
-                                                      "AddressLine"
+                                                      "addressLine"
                                                     ],
                                                     "properties": {
-                                                      "PostcodeZone": {
+                                                      "postcodeZone": {
                                                         "required": [
-                                                          "Postcode"
+                                                          "postcode"
                                                         ]
                                                       }
                                                     }
                                                   },
-                                                  "CharityDetails": {
+                                                  "charityDetails": {
                                                     "required": [
-                                                      "CharityName",
-                                                      "CharityType"
+                                                      "charityName",
+                                                      "charityType"
                                                     ],
                                                     "properties": {
-                                                      "CharityAddress": {
+                                                      "charityAddress": {
                                                         "oneOf": [
                                                           {
                                                             "items": {
                                                               "required": [
-                                                                "AddressLine"
+                                                                "addressLine"
                                                               ],
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "required": [
-                                                                    "Postcode"
+                                                                    "postcode"
                                                                   ]
                                                                 }
                                                               }
@@ -797,12 +797,12 @@
                                                           },
                                                           {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
@@ -816,68 +816,68 @@
                                             },
                                             {
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "required": [
                                                     "Name"
                                                   ],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "required": [
-                                                        "SurnameName"
+                                                        "surnameName"
                                                       ]
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "items": {
                                                             "required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ]
                                                           }
                                                         },
                                                         {
                                                           "required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ]
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "required": [
                                                     "Name"
                                                   ]
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "required": [
-                                                    "CharityName",
-                                                    "CharityType"
+                                                    "charityName",
+                                                    "charityType"
                                                   ],
                                                   "properties": {
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "items": {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
@@ -885,12 +885,12 @@
                                                         },
                                                         {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
@@ -903,109 +903,109 @@
                                             }
                                           ]
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       }
                                     },
-                                    "SubCharge": {
+                                    "subCharge": {
                                       "oneOf": [
                                         {
                                           "items": {
                                             "required": [
-                                              "RegisteredCharge",
-                                              "ChargeProprietor"
+                                              "registeredCharge",
+                                              "chargeProprietor"
                                             ],
                                             "properties": {
-                                              "RegisteredCharge": {
+                                              "registeredCharge": {
                                                 "required": [
-                                                  "EntryDetails"
+                                                  "entryDetails"
                                                 ],
                                                 "properties": {
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "required": [
-                                                      "EntryNumber",
-                                                      "EntryText"
+                                                      "entryNumber",
+                                                      "entryText"
                                                     ]
                                                   }
                                                 }
                                               },
-                                              "ChargeProprietor": {
+                                              "chargeProprietor": {
                                                 "required": [
-                                                  "ChargeeParty",
-                                                  "EntryDetails"
+                                                  "chargeeParty",
+                                                  "entryDetails"
                                                 ],
                                                 "properties": {
-                                                  "ChargeeParty": {
+                                                  "chargeeParty": {
                                                     "oneOf": [
                                                       {
                                                         "items": {
                                                           "properties": {
-                                                            "PrivateIndividual": {
+                                                            "privateIndividual": {
                                                               "required": [
                                                                 "Name"
                                                               ],
                                                               "properties": {
-                                                                "Name": {
+                                                                "name": {
                                                                   "required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ]
                                                                 },
-                                                                "Alias": {
+                                                                "alias": {
                                                                   "oneOf": [
                                                                     {
                                                                       "items": {
                                                                         "required": [
-                                                                          "SurnameName"
+                                                                          "surnameName"
                                                                         ]
                                                                       }
                                                                     },
                                                                     {
                                                                       "required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ]
                                                                     }
                                                                   ]
                                                                 }
                                                               }
                                                             },
-                                                            "Organization": {
+                                                            "organization": {
                                                               "required": [
                                                                 "Name"
                                                               ]
                                                             },
-                                                            "Address": {
+                                                            "address": {
                                                               "required": [
-                                                                "AddressLine"
+                                                                "addressLine"
                                                               ],
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "required": [
-                                                                    "Postcode"
+                                                                    "postcode"
                                                                   ]
                                                                 }
                                                               }
                                                             },
-                                                            "CharityDetails": {
+                                                            "charityDetails": {
                                                               "required": [
-                                                                "CharityName",
-                                                                "CharityType"
+                                                                "charityName",
+                                                                "charityType"
                                                               ],
                                                               "properties": {
-                                                                "CharityAddress": {
+                                                                "charityAddress": {
                                                                   "oneOf": [
                                                                     {
                                                                       "items": {
                                                                         "required": [
-                                                                          "AddressLine"
+                                                                          "addressLine"
                                                                         ],
                                                                         "properties": {
-                                                                          "PostcodeZone": {
+                                                                          "postcodeZone": {
                                                                             "required": [
-                                                                              "Postcode"
+                                                                              "postcode"
                                                                             ]
                                                                           }
                                                                         }
@@ -1013,12 +1013,12 @@
                                                                     },
                                                                     {
                                                                       "required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ]
                                                                         }
                                                                       }
@@ -1032,68 +1032,68 @@
                                                       },
                                                       {
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ]
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ]
                                                                     }
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "required": [
                                                               "Name"
                                                             ]
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ]
                                                                         }
                                                                       }
@@ -1101,12 +1101,12 @@
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1119,10 +1119,10 @@
                                                       }
                                                     ]
                                                   },
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "required": [
-                                                      "EntryNumber",
-                                                      "EntryText"
+                                                      "entryNumber",
+                                                      "entryText"
                                                     ]
                                                   }
                                                 }
@@ -1132,96 +1132,96 @@
                                         },
                                         {
                                           "required": [
-                                            "RegisteredCharge",
-                                            "ChargeProprietor"
+                                            "registeredCharge",
+                                            "chargeProprietor"
                                           ],
                                           "properties": {
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "required": [
-                                                "EntryDetails"
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ]
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "required": [
-                                                "ChargeeParty",
-                                                "EntryDetails"
+                                                "chargeeParty",
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "items": {
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ]
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ]
                                                                     }
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "required": [
                                                               "Name"
                                                             ]
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ]
                                                                         }
                                                                       }
@@ -1229,12 +1229,12 @@
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1248,68 +1248,68 @@
                                                     },
                                                     {
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ]
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ]
                                                                 }
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "required": [
                                                             "Name"
                                                           ]
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1317,12 +1317,12 @@
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ]
                                                                     }
                                                                   }
@@ -1335,10 +1335,10 @@
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ]
                                                 }
                                               }
@@ -1352,96 +1352,96 @@
                               },
                               {
                                 "required": [
-                                  "RegisteredCharge",
-                                  "ChargeProprietor"
+                                  "registeredCharge",
+                                  "chargeProprietor"
                                 ],
                                 "properties": {
-                                  "RegisteredCharge": {
+                                  "registeredCharge": {
                                     "required": [
-                                      "EntryDetails"
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     }
                                   },
-                                  "ChargeProprietor": {
+                                  "chargeProprietor": {
                                     "required": [
-                                      "ChargeeParty",
-                                      "EntryDetails"
+                                      "chargeeParty",
+                                      "entryDetails"
                                     ],
                                     "properties": {
-                                      "ChargeeParty": {
+                                      "chargeeParty": {
                                         "oneOf": [
                                           {
                                             "items": {
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "required": [
                                                     "Name"
                                                   ],
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "required": [
-                                                        "SurnameName"
+                                                        "surnameName"
                                                       ]
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "items": {
                                                             "required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ]
                                                           }
                                                         },
                                                         {
                                                           "required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ]
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "required": [
                                                     "Name"
                                                   ]
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "required": [
-                                                    "AddressLine"
+                                                    "addressLine"
                                                   ],
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "required": [
-                                                        "Postcode"
+                                                        "postcode"
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "required": [
-                                                    "CharityName",
-                                                    "CharityType"
+                                                    "charityName",
+                                                    "charityType"
                                                   ],
                                                   "properties": {
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "items": {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
@@ -1449,12 +1449,12 @@
                                                         },
                                                         {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
@@ -1468,68 +1468,68 @@
                                           },
                                           {
                                             "properties": {
-                                              "PrivateIndividual": {
+                                              "privateIndividual": {
                                                 "required": [
                                                   "Name"
                                                 ],
                                                 "properties": {
-                                                  "Name": {
+                                                  "name": {
                                                     "required": [
-                                                      "SurnameName"
+                                                      "surnameName"
                                                     ]
                                                   },
-                                                  "Alias": {
+                                                  "alias": {
                                                     "oneOf": [
                                                       {
                                                         "items": {
                                                           "required": [
-                                                            "SurnameName"
+                                                            "surnameName"
                                                           ]
                                                         }
                                                       },
                                                       {
                                                         "required": [
-                                                          "SurnameName"
+                                                          "surnameName"
                                                         ]
                                                       }
                                                     ]
                                                   }
                                                 }
                                               },
-                                              "Organization": {
+                                              "organization": {
                                                 "required": [
                                                   "Name"
                                                 ]
                                               },
-                                              "Address": {
+                                              "address": {
                                                 "required": [
-                                                  "AddressLine"
+                                                  "addressLine"
                                                 ],
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "required": [
-                                                      "Postcode"
+                                                      "postcode"
                                                     ]
                                                   }
                                                 }
                                               },
-                                              "CharityDetails": {
+                                              "charityDetails": {
                                                 "required": [
-                                                  "CharityName",
-                                                  "CharityType"
+                                                  "charityName",
+                                                  "charityType"
                                                 ],
                                                 "properties": {
-                                                  "CharityAddress": {
+                                                  "charityAddress": {
                                                     "oneOf": [
                                                       {
                                                         "items": {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
@@ -1537,12 +1537,12 @@
                                                       },
                                                       {
                                                         "required": [
-                                                          "AddressLine"
+                                                          "addressLine"
                                                         ],
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "required": [
-                                                              "Postcode"
+                                                              "postcode"
                                                             ]
                                                           }
                                                         }
@@ -1555,109 +1555,109 @@
                                           }
                                         ]
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     }
                                   },
-                                  "SubCharge": {
+                                  "subCharge": {
                                     "oneOf": [
                                       {
                                         "items": {
                                           "required": [
-                                            "RegisteredCharge",
-                                            "ChargeProprietor"
+                                            "registeredCharge",
+                                            "chargeProprietor"
                                           ],
                                           "properties": {
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "required": [
-                                                "EntryDetails"
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ]
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "required": [
-                                                "ChargeeParty",
-                                                "EntryDetails"
+                                                "chargeeParty",
+                                                "entryDetails"
                                               ],
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "items": {
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "required": [
                                                               "Name"
                                                             ],
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ]
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "SurnameName"
+                                                                        "surnameName"
                                                                       ]
                                                                     }
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "required": [
                                                               "Name"
                                                             ]
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "required": [
-                                                              "AddressLine"
+                                                              "addressLine"
                                                             ],
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "required": [
-                                                                  "Postcode"
+                                                                  "postcode"
                                                                 ]
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "required": [
-                                                              "CharityName",
-                                                              "CharityType"
+                                                              "charityName",
+                                                              "charityType"
                                                             ],
                                                             "properties": {
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "items": {
                                                                       "required": [
-                                                                        "AddressLine"
+                                                                        "addressLine"
                                                                       ],
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "required": [
-                                                                            "Postcode"
+                                                                            "postcode"
                                                                           ]
                                                                         }
                                                                       }
@@ -1665,12 +1665,12 @@
                                                                   },
                                                                   {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1684,68 +1684,68 @@
                                                     },
                                                     {
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ]
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ]
                                                                 }
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "required": [
                                                             "Name"
                                                           ]
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1753,12 +1753,12 @@
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ]
                                                                     }
                                                                   }
@@ -1771,10 +1771,10 @@
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "required": [
-                                                    "EntryNumber",
-                                                    "EntryText"
+                                                    "entryNumber",
+                                                    "entryText"
                                                   ]
                                                 }
                                               }
@@ -1784,96 +1784,96 @@
                                       },
                                       {
                                         "required": [
-                                          "RegisteredCharge",
-                                          "ChargeProprietor"
+                                          "registeredCharge",
+                                          "chargeProprietor"
                                         ],
                                         "properties": {
-                                          "RegisteredCharge": {
+                                          "registeredCharge": {
                                             "required": [
-                                              "EntryDetails"
+                                              "entryDetails"
                                             ],
                                             "properties": {
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "required": [
-                                                  "EntryNumber",
-                                                  "EntryText"
+                                                  "entryNumber",
+                                                  "entryText"
                                                 ]
                                               }
                                             }
                                           },
-                                          "ChargeProprietor": {
+                                          "chargeProprietor": {
                                             "required": [
-                                              "ChargeeParty",
-                                              "EntryDetails"
+                                              "chargeeParty",
+                                              "entryDetails"
                                             ],
                                             "properties": {
-                                              "ChargeeParty": {
+                                              "chargeeParty": {
                                                 "oneOf": [
                                                   {
                                                     "items": {
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "required": [
                                                             "Name"
                                                           ],
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "required": [
-                                                                "SurnameName"
+                                                                "surnameName"
                                                               ]
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "SurnameName"
+                                                                      "surnameName"
                                                                     ]
                                                                   }
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ]
                                                                 }
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "required": [
                                                             "Name"
                                                           ]
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "required": [
-                                                            "AddressLine"
+                                                            "addressLine"
                                                           ],
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "required": [
-                                                                "Postcode"
+                                                                "postcode"
                                                               ]
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "required": [
-                                                            "CharityName",
-                                                            "CharityType"
+                                                            "charityName",
+                                                            "charityType"
                                                           ],
                                                           "properties": {
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "items": {
                                                                     "required": [
-                                                                      "AddressLine"
+                                                                      "addressLine"
                                                                     ],
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "required": [
-                                                                          "Postcode"
+                                                                          "postcode"
                                                                         ]
                                                                       }
                                                                     }
@@ -1881,12 +1881,12 @@
                                                                 },
                                                                 {
                                                                   "required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ]
                                                                     }
                                                                   }
@@ -1900,68 +1900,68 @@
                                                   },
                                                   {
                                                     "properties": {
-                                                      "PrivateIndividual": {
+                                                      "privateIndividual": {
                                                         "required": [
                                                           "Name"
                                                         ],
                                                         "properties": {
-                                                          "Name": {
+                                                          "name": {
                                                             "required": [
-                                                              "SurnameName"
+                                                              "surnameName"
                                                             ]
                                                           },
-                                                          "Alias": {
+                                                          "alias": {
                                                             "oneOf": [
                                                               {
                                                                 "items": {
                                                                   "required": [
-                                                                    "SurnameName"
+                                                                    "surnameName"
                                                                   ]
                                                                 }
                                                               },
                                                               {
                                                                 "required": [
-                                                                  "SurnameName"
+                                                                  "surnameName"
                                                                 ]
                                                               }
                                                             ]
                                                           }
                                                         }
                                                       },
-                                                      "Organization": {
+                                                      "organization": {
                                                         "required": [
                                                           "Name"
                                                         ]
                                                       },
-                                                      "Address": {
+                                                      "address": {
                                                         "required": [
-                                                          "AddressLine"
+                                                          "addressLine"
                                                         ],
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "required": [
-                                                              "Postcode"
+                                                              "postcode"
                                                             ]
                                                           }
                                                         }
                                                       },
-                                                      "CharityDetails": {
+                                                      "charityDetails": {
                                                         "required": [
-                                                          "CharityName",
-                                                          "CharityType"
+                                                          "charityName",
+                                                          "charityType"
                                                         ],
                                                         "properties": {
-                                                          "CharityAddress": {
+                                                          "charityAddress": {
                                                             "oneOf": [
                                                               {
                                                                 "items": {
                                                                   "required": [
-                                                                    "AddressLine"
+                                                                    "addressLine"
                                                                   ],
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "required": [
-                                                                        "Postcode"
+                                                                        "postcode"
                                                                       ]
                                                                     }
                                                                   }
@@ -1969,12 +1969,12 @@
                                                               },
                                                               {
                                                                 "required": [
-                                                                  "AddressLine"
+                                                                  "addressLine"
                                                                 ],
                                                                 "properties": {
-                                                                  "PostcodeZone": {
+                                                                  "postcodeZone": {
                                                                     "required": [
-                                                                      "Postcode"
+                                                                      "postcode"
                                                                     ]
                                                                   }
                                                                 }
@@ -1987,10 +1987,10 @@
                                                   }
                                                 ]
                                               },
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "required": [
-                                                  "EntryNumber",
-                                                  "EntryText"
+                                                  "entryNumber",
+                                                  "entryText"
                                                 ]
                                               }
                                             }
@@ -2005,23 +2005,23 @@
                           }
                         }
                       },
-                      "AgreedNotice": {
+                      "agreedNotice": {
                         "required": [
-                          "AgreedNoticeEntry"
+                          "agreedNoticeEntry"
                         ],
                         "properties": {
-                          "AgreedNoticeEntry": {
+                          "agreedNoticeEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryDetails"
+                                    "entryDetails"
                                   ],
                                   "properties": {
-                                    "EntryDetails": {
+                                    "entryDetails": {
                                       "required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ]
                                     }
                                   }
@@ -2029,13 +2029,13 @@
                               },
                               {
                                 "required": [
-                                  "EntryDetails"
+                                  "entryDetails"
                                 ],
                                 "properties": {
-                                  "EntryDetails": {
+                                  "entryDetails": {
                                     "required": [
-                                      "EntryNumber",
-                                      "EntryText"
+                                      "entryNumber",
+                                      "entryText"
                                     ]
                                   }
                                 }
@@ -2044,130 +2044,130 @@
                           }
                         }
                       },
-                      "Bankruptcy": {
+                      "bankruptcy": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "Caution": {
+                      "caution": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "DeedOfPostponement": {
+                      "deedOfPostponement": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "GreenOutEntry": {
+                      "greenOutEntry": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "HomeRights": {
+                      "homeRights": {
                         "required": [
-                          "HomeRightsEntry"
+                          "homeRightsEntry"
                         ],
                         "properties": {
-                          "HomeRightsEntry": {
+                          "homeRightsEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "ChangeOfAddressIndicator",
-                                    "HomeRightsEntryDetails"
+                                    "changeOfAddressIndicator",
+                                    "homeRightsEntryDetails"
                                   ],
                                   "properties": {
-                                    "HomeRightsEntryDetails": {
+                                    "homeRightsEntryDetails": {
                                       "required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ]
                                     },
-                                    "ChangeOfAddressEntryDetails": {
+                                    "changeOfAddressEntryDetails": {
                                       "required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ]
                                     }
                                   }
@@ -2175,20 +2175,20 @@
                               },
                               {
                                 "required": [
-                                  "ChangeOfAddressIndicator",
-                                  "HomeRightsEntryDetails"
+                                  "changeOfAddressIndicator",
+                                  "homeRightsEntryDetails"
                                 ],
                                 "properties": {
-                                  "HomeRightsEntryDetails": {
+                                  "homeRightsEntryDetails": {
                                     "required": [
-                                      "EntryNumber",
-                                      "EntryText"
+                                      "entryNumber",
+                                      "entryText"
                                     ]
                                   },
-                                  "ChangeOfAddressEntryDetails": {
+                                  "changeOfAddressEntryDetails": {
                                     "required": [
-                                      "EntryNumber",
-                                      "EntryText"
+                                      "entryNumber",
+                                      "entryText"
                                     ]
                                   }
                                 }
@@ -2197,134 +2197,134 @@
                           }
                         }
                       },
-                      "RentCharge": {
+                      "rentCharge": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "VendorsLien": {
+                      "vendorsLien": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "RightOfPreEmption": {
+                      "rightOfPreEmption": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "DocumentDetails": {
+                      "documentDetails": {
                         "required": [
-                          "Document"
+                          "document"
                         ],
                         "properties": {
-                          "Document": {
+                          "document": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "DocumentType",
-                                    "EntryNumber",
-                                    "PlanOnlyIndicator",
-                                    "RegisterDescription"
+                                    "documentType",
+                                    "entryNumber",
+                                    "planOnlyIndicator",
+                                    "registerDescription"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "DocumentType",
-                                  "EntryNumber",
-                                  "PlanOnlyIndicator",
-                                  "RegisterDescription"
+                                  "documentType",
+                                  "entryNumber",
+                                  "planOnlyIndicator",
+                                  "registerDescription"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "UnilateralNoticeDetails": {
+                      "unilateralNoticeDetails": {
                         "required": [
-                          "UnilateralNoticeEntry"
+                          "unilateralNoticeEntry"
                         ],
                         "properties": {
-                          "UnilateralNoticeEntry": {
+                          "unilateralNoticeEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "UnilateralNotice",
-                                    "UnilateralNoticeBeneficiary"
+                                    "unilateralNotice",
+                                    "unilateralNoticeBeneficiary"
                                   ],
                                   "properties": {
-                                    "UnilateralNotice": {
+                                    "unilateralNotice": {
                                       "required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ]
                                     },
-                                    "UnilateralNoticeBeneficiary": {
+                                    "unilateralNoticeBeneficiary": {
                                       "required": [
-                                        "EntryNumber",
-                                        "EntryText"
+                                        "entryNumber",
+                                        "entryText"
                                       ]
                                     }
                                   }
@@ -2332,20 +2332,20 @@
                               },
                               {
                                 "required": [
-                                  "UnilateralNotice",
-                                  "UnilateralNoticeBeneficiary"
+                                  "unilateralNotice",
+                                  "unilateralNoticeBeneficiary"
                                 ],
                                 "properties": {
-                                  "UnilateralNotice": {
+                                  "unilateralNotice": {
                                     "required": [
-                                      "EntryNumber",
-                                      "EntryText"
+                                      "entryNumber",
+                                      "entryText"
                                     ]
                                   },
-                                  "UnilateralNoticeBeneficiary": {
+                                  "unilateralNoticeBeneficiary": {
                                     "required": [
-                                      "EntryNumber",
-                                      "EntryText"
+                                      "entryNumber",
+                                      "entryText"
                                     ]
                                   }
                                 }
@@ -2354,175 +2354,175 @@
                           }
                         }
                       },
-                      "DeathOfProprietor": {
+                      "deathOfProprietor": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "DiscountCharge": {
+                      "discountCharge": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "EquitableCharge": {
+                      "equitableCharge": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "NotedCharge": {
+                      "notedCharge": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "CreditorsNotice": {
+                      "creditorsNotice": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "UnidentifiedEntry": {
+                      "unidentifiedEntry": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           }
                         }
                       },
-                      "CCBIEntry": {
+                      "ccbiEntry": {
                         "required": [
-                          "EntryDetails"
+                          "entryDetails"
                         ],
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
@@ -2531,58 +2531,58 @@
                       }
                     }
                   },
-                  "OCRegisterData": {
+                  "ocRegisterData": {
                     "required": [
-                      "PropertyRegister",
-                      "ProprietorshipRegister"
+                      "propertyRegister",
+                      "proprietorshipRegister"
                     ],
                     "properties": {
-                      "PropertyRegister": {
+                      "propertyRegister": {
                         "required": [
-                          "RegisterEntry"
+                          "registerEntry"
                         ],
                         "properties": {
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "items": {
                                             "required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ]
                                           }
                                         },
                                         {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       ]
@@ -2592,24 +2592,24 @@
                               },
                               {
                                 "required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "items": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       },
                                       {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     ]
@@ -2620,52 +2620,52 @@
                           }
                         }
                       },
-                      "ProprietorshipRegister": {
+                      "proprietorshipRegister": {
                         "required": [
-                          "RegisterEntry"
+                          "registerEntry"
                         ],
                         "properties": {
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "items": {
                                             "required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ]
                                           }
                                         },
                                         {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       ]
@@ -2675,24 +2675,24 @@
                               },
                               {
                                 "required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "items": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       },
                                       {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     ]
@@ -2703,52 +2703,52 @@
                           }
                         }
                       },
-                      "ChargesRegister": {
+                      "chargesRegister": {
                         "required": [
-                          "RegisterEntry"
+                          "registerEntry"
                         ],
                         "properties": {
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "EntryNumber",
-                                    "EntryText"
+                                    "entryNumber",
+                                    "entryText"
                                   ]
                                 }
                               },
                               {
                                 "required": [
-                                  "EntryNumber",
-                                  "EntryText"
+                                  "entryNumber",
+                                  "entryText"
                                 ]
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "items": {
                                   "required": [
-                                    "ScheduleType",
-                                    "ScheduleEntry"
+                                    "scheduleType",
+                                    "scheduleEntry"
                                   ],
                                   "properties": {
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "items": {
                                             "required": [
-                                              "EntryNumber",
-                                              "EntryText"
+                                              "entryNumber",
+                                              "entryText"
                                             ]
                                           }
                                         },
                                         {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       ]
@@ -2758,24 +2758,24 @@
                               },
                               {
                                 "required": [
-                                  "ScheduleType",
-                                  "ScheduleEntry"
+                                  "scheduleType",
+                                  "scheduleEntry"
                                 ],
                                 "properties": {
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "items": {
                                           "required": [
-                                            "EntryNumber",
-                                            "EntryText"
+                                            "entryNumber",
+                                            "entryText"
                                           ]
                                         }
                                       },
                                       {
                                         "required": [
-                                          "EntryNumber",
-                                          "EntryText"
+                                          "entryNumber",
+                                          "entryText"
                                         ]
                                       }
                                     ]

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -32,7 +32,7 @@
         "title": "Participant Details",
         "properties": {
           "name": {
-            "title": "name",
+            "title": "Name",
             "type": "object",
             "properties": {
               "firstName": {
@@ -624,7 +624,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "name"
+                        "title": "Name"
                       },
                       "contact": {
                         "type": "object",
@@ -810,7 +810,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "title": "name",
+                        "title": "Name",
                         "type": "string"
                       },
                       "transportType": {
@@ -854,7 +854,7 @@
                     "title": "Healthcare service",
                     "properties": {
                       "name": {
-                        "title": "name",
+                        "title": "Name",
                         "type": "string"
                       },
                       "typeOfHealthCare": {
@@ -10431,7 +10431,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -11687,7 +11687,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -12743,7 +12743,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -13180,7 +13180,7 @@
                             "type": "object",
                             "properties": {
                               "itemName": {
-                                "title": "name",
+                                "title": "Name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -13613,7 +13613,7 @@
                             "type": "object",
                             "properties": {
                               "itemName": {
-                                "title": "name",
+                                "title": "Name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -14049,7 +14049,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -14483,7 +14483,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15186,7 +15186,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15631,7 +15631,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "name",
+                            "title": "Name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -91,7 +91,7 @@
                 "type": "string"
               },
               "postcode": {
-                "title": "Postcode",
+                "title": "postcode",
                 "type": "string",
                 "minLength": 1
               }
@@ -154,7 +154,7 @@
                   "type": "string"
                 },
                 "postcode": {
-                  "title": "Postcode",
+                  "title": "postcode",
                   "type": "string",
                   "minLength": 1
                 }
@@ -652,7 +652,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "Postcode",
+                                "title": "postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -887,7 +887,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "Postcode",
+                                "title": "postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -1147,7 +1147,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1235,7 +1235,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1323,7 +1323,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1420,7 +1420,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "Postcode",
+                                                "title": "postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1682,7 +1682,7 @@
                                                       "type": "string"
                                                     },
                                                     "postcode": {
-                                                      "title": "Postcode",
+                                                      "title": "postcode",
                                                       "type": "string",
                                                       "minLength": 1
                                                     }
@@ -3144,7 +3144,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3232,7 +3232,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3320,7 +3320,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3409,7 +3409,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3506,7 +3506,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3594,7 +3594,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3821,7 +3821,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "Postcode",
+                                                          "title": "postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4080,7 +4080,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "Postcode",
+                                                          "title": "postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4264,7 +4264,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "Postcode",
+                                                    "title": "postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -17643,100 +17643,100 @@
                       "title": "Mobile predicted coverage per Ofcom Connected Nations",
                       "type": "object",
                       "properties": {
-                        "EEVoiceOutdoor": {
+                        "eeVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "EEVoiceOutdoorNo4g": {
+                        "eeVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "EEVoiceIndoor": {
+                        "eeVoiceIndoor": {
                           "type": "integer"
                         },
-                        "EEVoiceIndoorNo4g": {
+                        "eeVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "EEDataOutdoor": {
+                        "eeDataOutdoor": {
                           "type": "integer"
                         },
-                        "EEDataOutdoorNo4g": {
+                        "eeDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "EEDataIndoor": {
+                        "eeDataIndoor": {
                           "type": "integer"
                         },
-                        "EEDataIndoorNo4g": {
+                        "eeDataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "H3VoiceOutdoor": {
+                        "h3VoiceOutdoor": {
                           "type": "integer"
                         },
-                        "H3VoiceOutdoorNo4g": {
+                        "h3VoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "H3VoiceIndoor": {
+                        "h3VoiceIndoor": {
                           "type": "integer"
                         },
-                        "H3VoiceIndoorNo4g": {
+                        "h3VoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "H3DataOutdoor": {
+                        "h3DataOutdoor": {
                           "type": "integer"
                         },
-                        "H3DataOutdoorNo4g": {
+                        "h3DataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "H3DataIndoor": {
+                        "h3DataIndoor": {
                           "type": "integer"
                         },
-                        "H3DataIndoorNo4g": {
+                        "h3DataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "TFVoiceOutdoor": {
+                        "tfVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "TFVoiceOutdoorNo4g": {
+                        "tfVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "TFVoiceIndoor": {
+                        "tfVoiceIndoor": {
                           "type": "integer"
                         },
-                        "TFVoiceIndoorNo4g": {
+                        "tfVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "TFDataOutdoor": {
+                        "tfDataOutdoor": {
                           "type": "integer"
                         },
-                        "TFDataOutdoorNo4g": {
+                        "tfDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "TFDataIndoor": {
+                        "tfDataIndoor": {
                           "type": "integer"
                         },
-                        "TFDataIndoorNo4g": {
+                        "tfDataIndoorNo4g": {
                           "type": "integer"
                         },
-                        "VOVoiceOutdoor": {
+                        "voVoiceOutdoor": {
                           "type": "integer"
                         },
-                        "VOVoiceOutdoorNo4g": {
+                        "voVoiceOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "VOVoiceIndoor": {
+                        "voVoiceIndoor": {
                           "type": "integer"
                         },
-                        "VOVoiceIndoorNo4g": {
+                        "voVoiceIndoorNo4g": {
                           "type": "integer"
                         },
-                        "VODataOutdoor": {
+                        "voDataOutdoor": {
                           "type": "integer"
                         },
-                        "VODataOutdoorNo4g": {
+                        "voDataOutdoorNo4g": {
                           "type": "integer"
                         },
-                        "VODataIndoor": {
+                        "voDataIndoor": {
                           "type": "integer"
                         },
-                        "VODataIndoorNo4g": {
+                        "voDataIndoorNo4g": {
                           "type": "integer"
                         }
                       }
@@ -21950,7 +21950,7 @@
                               "type": "string"
                             },
                             "postcode": {
-                              "title": "Postcode",
+                              "title": "postcode",
                               "type": "string",
                               "minLength": 1
                             }
@@ -22086,41 +22086,41 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "HMLRReference": {
+                  "hmlrReference": {
                     "type": "string"
                   },
-                  "OriginatingAuthority": {
+                  "originatingAuthority": {
                     "type": "string"
                   },
-                  "AuthorityReference": {
+                  "authorityReference": {
                     "type": "string"
                   },
-                  "CreationDate": {
+                  "creationDate": {
                     "type": "string",
                     "format": "date"
                   },
-                  "RegistrationDate": {
+                  "registrationDate": {
                     "type": "string",
                     "format": "date"
                   },
-                  "Category": {
+                  "category": {
                     "type": "string"
                   },
-                  "ChargeSubCategory": {
+                  "chargeSubCategory": {
                     "type": "string"
                   },
-                  "Law": {
+                  "law": {
                     "type": "string"
                   },
-                  "LegalDocument": {
+                  "legalDocument": {
                     "type": "string"
                   },
-                  "Location": {
+                  "location": {
                     "type": "object",
                     "required": [
                       "line1",
                       "line2",
-                      "Postcode"
+                      "postcode"
                     ],
                     "properties": {
                       "line1": {
@@ -22129,17 +22129,17 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       }
                     }
                   },
-                  "LocationDominantBuilding": {
+                  "locationDominantBuilding": {
                     "type": "object",
                     "required": [
                       "line1",
                       "line2",
-                      "Postcode"
+                      "postcode"
                     ],
                     "properties": {
                       "line1": {
@@ -22148,33 +22148,33 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       }
                     }
                   },
-                  "Description": {
+                  "description": {
                     "type": "string"
                   },
-                  "SourceOfInformation": {
+                  "sourceOfInformation": {
                     "type": "string"
                   },
-                  "AvailableDocument": {
+                  "availableDocument": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "required": [
-                        "Document"
+                        "document"
                       ],
                       "properties": {
-                        "Document": {
+                        "document": {
                           "type": "string"
                         },
-                        "StartDate": {
+                        "startDate": {
                           "type": "string",
                           "format": "date"
                         },
-                        "EndDate": {
+                        "endDate": {
                           "type": "string",
                           "format": "date"
                         }
@@ -22182,18 +22182,18 @@
                     },
                     "minItems": 0
                   },
-                  "InterestInLand": {
+                  "interestInLand": {
                     "type": "string"
                   },
-                  "ApplicantName": {
+                  "applicantName": {
                     "type": "string"
                   },
-                  "ApplicantAddress": {
+                  "applicantAddress": {
                     "type": "object",
                     "required": [
                       "line1",
                       "line2",
-                      "Postcode"
+                      "postcode"
                     ],
                     "properties": {
                       "line1": {
@@ -22202,73 +22202,73 @@
                       "line2": {
                         "type": "string"
                       },
-                      "Postcode": {
+                      "postcode": {
                         "type": "string"
                       },
-                      "Country": {
+                      "country": {
                         "type": "string"
                       }
                     }
                   },
-                  "ServientLandDevelopment": {
+                  "servientLandDevelopment": {
                     "type": "object",
                     "required": [
-                      "Height",
-                      "CoversAllOrPartOfExtent"
+                      "height",
+                      "coversAllOrPartOfExtent"
                     ],
                     "properties": {
-                      "Height": {
+                      "height": {
                         "type": "string"
                       },
-                      "CoversAllOrPartOfExtent": {
+                      "coversAllOrPartOfExtent": {
                         "type": "string"
                       }
                     }
                   },
-                  "Amount": {
+                  "amount": {
                     "type": "string"
                   },
-                  "InterestRate": {
+                  "interestRate": {
                     "type": "string"
                   },
-                  "LandSold": {
+                  "landSold": {
                     "type": "string"
                   },
-                  "WorksDone": {
+                  "worksDone": {
                     "type": "string"
                   },
-                  "AdvancePayment": {
+                  "advancePayment": {
                     "type": "string"
                   },
-                  "TotalCompensation": {
+                  "totalCompensation": {
                     "type": "string"
                   },
-                  "AgreedOrEstimated": {
+                  "agreedOrEstimated": {
                     "type": "string"
                   },
-                  "Adjoining": {
+                  "adjoining": {
                     "type": "boolean"
                   },
-                  "OtherData": {
+                  "otherData": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "required": [
-                        "DataLabel",
+                        "dataLabel",
                         "Data"
                       ],
                       "properties": {
-                        "DataLabel": {
+                        "dataLabel": {
                           "type": "string"
                         },
-                        "Data": {
+                        "data": {
                           "type": "string"
                         }
                       }
                     },
                     "minItems": 0
                   },
-                  "ChargeExtent": {
+                  "chargeExtent": {
                     "description": "Stringified GeoJSON, to support object dbs that don't support directly nested arrays",
                     "type": "string"
                   }
@@ -26405,42 +26405,42 @@
                 "title": "HMLR Official Copy Register Extract",
                 "type": "object",
                 "properties": {
-                  "OCSummaryData": {
+                  "ocSummaryData": {
                     "title": "Official Copy Summary Data",
                     "type": "object",
                     "properties": {
-                      "OfficialCopyDateTime": {
+                      "officialCopyDateTime": {
                         "type": "string",
                         "format": "date-time"
                       },
-                      "EditionDate": {
+                      "editionDate": {
                         "type": "string",
                         "format": "date"
                       },
-                      "PricePaidEntry": {
+                      "pricePaidEntry": {
                         "type": "object",
                         "properties": {
-                          "MultipleTitleIndicator": {
+                          "multipleTitleIndicator": {
                             "type": "string",
                             "enum": [
                               "2",
-                              "MoreThan2"
+                              "moreThan2"
                             ]
                           },
-                          "EntryDetails": {
+                          "entryDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryNumber": {
+                              "entryNumber": {
                                 "type": "string"
                               },
-                              "EntryText": {
+                              "entryText": {
                                 "type": "string"
                               },
-                              "RegistrationDate": {
+                              "registrationDate": {
                                 "type": "string",
                                 "format": "date"
                               },
-                              "SubRegisterCode": {
+                              "subRegisterCode": {
                                 "type": "string",
                                 "enum": [
                                   "A",
@@ -26449,7 +26449,7 @@
                                   "D"
                                 ]
                               },
-                              "ScheduleCode": {
+                              "scheduleCode": {
                                 "type": "string",
                                 "enum": [
                                   "0",
@@ -26468,28 +26468,28 @@
                                   "130"
                                 ]
                               },
-                              "Infills": {
+                              "infills": {
                                 "type": "object"
                               }
                             }
                           }
                         }
                       },
-                      "PropertyAddress": {
+                      "propertyAddress": {
                         "type": "object",
                         "properties": {
-                          "PostcodeZone": {
+                          "postcodeZone": {
                             "type": "object",
                             "properties": {
-                              "Postcode": {
+                              "postcode": {
                                 "type": "string"
                               }
                             }
                           },
-                          "AddressLine": {
+                          "addressLine": {
                             "type": "object",
                             "properties": {
-                              "Line": {
+                              "line": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
@@ -26500,13 +26500,13 @@
                           }
                         }
                       },
-                      "Title": {
+                      "title": {
                         "type": "object",
                         "properties": {
-                          "TitleNumber": {
+                          "titleNumber": {
                             "type": "string"
                           },
-                          "ClassOfTitleCode": {
+                          "classOfTitleCode": {
                             "type": "string",
                             "enum": [
                               "10",
@@ -26524,38 +26524,38 @@
                               "130"
                             ]
                           },
-                          "CommonholdIndicator": {
+                          "commonholdIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "TitleRegistrationDetails": {
+                          "titleRegistrationDetails": {
                             "type": "object",
                             "properties": {
-                              "DistrictName": {
+                              "districtName": {
                                 "type": "string"
                               },
-                              "AdministrativeArea": {
+                              "administrativeArea": {
                                 "type": "string"
                               },
-                              "LandRegistryOfficeName": {
+                              "landRegistryOfficeName": {
                                 "type": "string"
                               },
-                              "LatestEditionDate": {
+                              "latestEditionDate": {
                                 "type": "string",
                                 "format": "date"
                               },
-                              "PostcodeZone": {
+                              "postcodeZone": {
                                 "type": "object",
                                 "properties": {
-                                  "Postcode": {
+                                  "postcode": {
                                     "type": "string"
                                   }
                                 }
                               },
-                              "RegistrationDate": {
+                              "registrationDate": {
                                 "type": "string",
                                 "format": "date"
                               }
@@ -26563,213 +26563,213 @@
                           }
                         }
                       },
-                      "RegisterEntryIndicators": {
+                      "registerEntryIndicators": {
                         "type": "object",
                         "properties": {
-                          "AgreedNoticeIndicator": {
+                          "agreedNoticeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "BankruptcyIndicator": {
+                          "bankruptcyIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "CautionIndicator": {
+                          "cautionIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "CCBIIndicator": {
+                          "ccbiIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "ChargeeIndicator": {
+                          "chargeeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "ChargeIndicator": {
+                          "chargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "ChargeRelatedRestrictionIndicator": {
+                          "chargeRelatedRestrictionIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "ChargeRestrictionIndicator": {
+                          "chargeRestrictionIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "CreditorsNoticeIndicator": {
+                          "creditorsNoticeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "DeathOfProprietorIndicator": {
+                          "deathOfProprietorIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "DeedOfPostponementIndicator": {
+                          "deedOfPostponementIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "DiscountChargeIndicator": {
+                          "discountChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "EquitableChargeIndicator": {
+                          "equitableChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "GreenOutEntryIndicator": {
+                          "greenOutEntryIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "HomeRightsChangeOfAddressIndicator": {
+                          "homeRightsChangeOfAddressIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "HomeRightsIndicator": {
+                          "homeRightsIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "LeaseHoldTitleIndicator": {
+                          "leaseHoldTitleIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "MultipleChargeIndicator": {
+                          "multipleChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "NonChargeRestrictionIndicator": {
+                          "nonChargeRestrictionIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "NotedChargeIndicator": {
+                          "notedChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "PricePaidIndicator": {
+                          "pricePaidIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "PropertyDescriptionNotesIndicator": {
+                          "propertyDescriptionNotesIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "RentChargeIndicator": {
+                          "rentChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "RightOfPreEmptionIndicator": {
+                          "rightOfPreEmptionIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "ScheduleOfLeasesIndicator": {
+                          "scheduleOfLeasesIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "SubChargeIndicator": {
+                          "subChargeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "UnidentifiedEntryIndicator": {
+                          "unidentifiedEntryIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "UnilateralNoticeBeneficiaryIndicator": {
+                          "unilateralNoticeBeneficiaryIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "UnilateralNoticeIndicator": {
+                          "unilateralNoticeIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
                               "false"
                             ]
                           },
-                          "VendorsLienIndicator": {
+                          "vendorsLienIndicator": {
                             "type": "string",
                             "enum": [
                               "true",
@@ -26778,45 +26778,45 @@
                           }
                         }
                       },
-                      "Proprietorship": {
+                      "proprietorship": {
                         "type": "object",
                         "properties": {
-                          "CurrentProprietorshipDate": {
+                          "currentProprietorshipDate": {
                             "type": "string",
                             "format": "date"
                           },
-                          "CautionerParty": {
+                          "cautionerParty": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "type": "object",
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "object",
                                           "properties": {
-                                            "ForenamesName": {
+                                            "forenamesName": {
                                               "type": "string"
                                             },
-                                            "SurnameName": {
+                                            "surnameName": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -26826,10 +26826,10 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -26838,32 +26838,32 @@
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "type": "object",
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "string"
                                         },
-                                        "CompanyRegistrationNumber": {
+                                        "companyRegistrationNumber": {
                                           "type": "string"
                                         }
                                       }
                                     },
-                                    "Address": {
+                                    "address": {
                                       "type": "object",
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "type": "object",
                                           "properties": {
-                                            "Postcode": {
+                                            "postcode": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "AddressLine": {
+                                        "addressLine": {
                                           "type": "object",
                                           "properties": {
-                                            "Line": {
+                                            "line": {
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -26874,10 +26874,10 @@
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "type": "object",
                                       "properties": {
-                                        "CharityName": {
+                                        "charityName": {
                                           "oneOf": [
                                             {
                                               "type": "array",
@@ -26891,25 +26891,25 @@
                                             }
                                           ]
                                         },
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -26925,18 +26925,18 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -26949,10 +26949,10 @@
                                             }
                                           ]
                                         },
-                                        "CharityType": {
+                                        "charityType": {
                                           "type": "object",
                                           "properties": {
-                                            "Value": {
+                                            "value": {
                                               "type": "string",
                                               "enum": [
                                                 "C",
@@ -26964,13 +26964,13 @@
                                         }
                                       }
                                     },
-                                    "TradingName": {
+                                    "tradingName": {
                                       "type": "string"
                                     },
-                                    "PartyNumber": {
+                                    "partyNumber": {
                                       "type": "string"
                                     },
-                                    "PartyDescription": {
+                                    "partyDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -26980,31 +26980,31 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "type": "object",
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "object",
                                         "properties": {
-                                          "ForenamesName": {
+                                          "forenamesName": {
                                             "type": "string"
                                           },
-                                          "SurnameName": {
+                                          "surnameName": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -27014,10 +27014,10 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
@@ -27026,32 +27026,32 @@
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "type": "object",
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "string"
                                       },
-                                      "CompanyRegistrationNumber": {
+                                      "companyRegistrationNumber": {
                                         "type": "string"
                                       }
                                     }
                                   },
-                                  "Address": {
+                                  "address": {
                                     "type": "object",
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "type": "object",
                                         "properties": {
-                                          "Postcode": {
+                                          "postcode": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "AddressLine": {
+                                      "addressLine": {
                                         "type": "object",
                                         "properties": {
-                                          "Line": {
+                                          "line": {
                                             "type": "array",
                                             "items": {
                                               "type": "string"
@@ -27062,10 +27062,10 @@
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "type": "object",
                                     "properties": {
-                                      "CharityName": {
+                                      "charityName": {
                                         "oneOf": [
                                           {
                                             "type": "array",
@@ -27079,25 +27079,25 @@
                                           }
                                         ]
                                       },
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -27113,18 +27113,18 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Postcode": {
+                                                  "postcode": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "AddressLine": {
+                                              "addressLine": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Line": {
+                                                  "line": {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -27137,10 +27137,10 @@
                                           }
                                         ]
                                       },
-                                      "CharityType": {
+                                      "charityType": {
                                         "type": "object",
                                         "properties": {
-                                          "Value": {
+                                          "value": {
                                             "type": "string",
                                             "enum": [
                                               "C",
@@ -27152,51 +27152,51 @@
                                       }
                                     }
                                   },
-                                  "TradingName": {
+                                  "tradingName": {
                                     "type": "string"
                                   },
-                                  "PartyNumber": {
+                                  "partyNumber": {
                                     "type": "string"
                                   },
-                                  "PartyDescription": {
+                                  "partyDescription": {
                                     "type": "string"
                                   }
                                 }
                               }
                             ]
                           },
-                          "RegisteredProprietorParty": {
+                          "registeredProprietorParty": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "PrivateIndividual": {
+                                    "privateIndividual": {
                                       "type": "object",
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "object",
                                           "properties": {
-                                            "ForenamesName": {
+                                            "forenamesName": {
                                               "type": "string"
                                             },
-                                            "SurnameName": {
+                                            "surnameName": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "Alias": {
+                                        "alias": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -27206,10 +27206,10 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -27218,32 +27218,32 @@
                                         }
                                       }
                                     },
-                                    "Organization": {
+                                    "organization": {
                                       "type": "object",
                                       "properties": {
-                                        "Name": {
+                                        "name": {
                                           "type": "string"
                                         },
-                                        "CompanyRegistrationNumber": {
+                                        "companyRegistrationNumber": {
                                           "type": "string"
                                         }
                                       }
                                     },
-                                    "Address": {
+                                    "address": {
                                       "type": "object",
                                       "properties": {
-                                        "PostcodeZone": {
+                                        "postcodeZone": {
                                           "type": "object",
                                           "properties": {
-                                            "Postcode": {
+                                            "postcode": {
                                               "type": "string"
                                             }
                                           }
                                         },
-                                        "AddressLine": {
+                                        "addressLine": {
                                           "type": "object",
                                           "properties": {
-                                            "Line": {
+                                            "line": {
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -27254,10 +27254,10 @@
                                         }
                                       }
                                     },
-                                    "CharityDetails": {
+                                    "charityDetails": {
                                       "type": "object",
                                       "properties": {
-                                        "CharityName": {
+                                        "charityName": {
                                           "oneOf": [
                                             {
                                               "type": "array",
@@ -27271,25 +27271,25 @@
                                             }
                                           ]
                                         },
-                                        "CharityAddress": {
+                                        "charityAddress": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -27305,18 +27305,18 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -27329,10 +27329,10 @@
                                             }
                                           ]
                                         },
-                                        "CharityType": {
+                                        "charityType": {
                                           "type": "object",
                                           "properties": {
-                                            "Value": {
+                                            "value": {
                                               "type": "string",
                                               "enum": [
                                                 "C",
@@ -27344,13 +27344,13 @@
                                         }
                                       }
                                     },
-                                    "TradingName": {
+                                    "tradingName": {
                                       "type": "string"
                                     },
-                                    "PartyNumber": {
+                                    "partyNumber": {
                                       "type": "string"
                                     },
-                                    "PartyDescription": {
+                                    "partyDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -27360,31 +27360,31 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "PrivateIndividual": {
+                                  "privateIndividual": {
                                     "type": "object",
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "object",
                                         "properties": {
-                                          "ForenamesName": {
+                                          "forenamesName": {
                                             "type": "string"
                                           },
-                                          "SurnameName": {
+                                          "surnameName": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Alias": {
+                                      "alias": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "ForenamesName": {
+                                                "forenamesName": {
                                                   "type": "string"
                                                 },
-                                                "SurnameName": {
+                                                "surnameName": {
                                                   "type": "string"
                                                 }
                                               }
@@ -27394,10 +27394,10 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
@@ -27406,32 +27406,32 @@
                                       }
                                     }
                                   },
-                                  "Organization": {
+                                  "organization": {
                                     "type": "object",
                                     "properties": {
-                                      "Name": {
+                                      "name": {
                                         "type": "string"
                                       },
-                                      "CompanyRegistrationNumber": {
+                                      "companyRegistrationNumber": {
                                         "type": "string"
                                       }
                                     }
                                   },
-                                  "Address": {
+                                  "address": {
                                     "type": "object",
                                     "properties": {
-                                      "PostcodeZone": {
+                                      "postcodeZone": {
                                         "type": "object",
                                         "properties": {
-                                          "Postcode": {
+                                          "postcode": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "AddressLine": {
+                                      "addressLine": {
                                         "type": "object",
                                         "properties": {
-                                          "Line": {
+                                          "line": {
                                             "type": "array",
                                             "items": {
                                               "type": "string"
@@ -27442,10 +27442,10 @@
                                       }
                                     }
                                   },
-                                  "CharityDetails": {
+                                  "charityDetails": {
                                     "type": "object",
                                     "properties": {
-                                      "CharityName": {
+                                      "charityName": {
                                         "oneOf": [
                                           {
                                             "type": "array",
@@ -27459,25 +27459,25 @@
                                           }
                                         ]
                                       },
-                                      "CharityAddress": {
+                                      "charityAddress": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "PostcodeZone": {
+                                                "postcodeZone": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Postcode": {
+                                                    "postcode": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "AddressLine": {
+                                                "addressLine": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Line": {
+                                                    "line": {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
@@ -27493,18 +27493,18 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "PostcodeZone": {
+                                              "postcodeZone": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Postcode": {
+                                                  "postcode": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "AddressLine": {
+                                              "addressLine": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Line": {
+                                                  "line": {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
@@ -27517,10 +27517,10 @@
                                           }
                                         ]
                                       },
-                                      "CharityType": {
+                                      "charityType": {
                                         "type": "object",
                                         "properties": {
-                                          "Value": {
+                                          "value": {
                                             "type": "string",
                                             "enum": [
                                               "C",
@@ -27532,13 +27532,13 @@
                                       }
                                     }
                                   },
-                                  "TradingName": {
+                                  "tradingName": {
                                     "type": "string"
                                   },
-                                  "PartyNumber": {
+                                  "partyNumber": {
                                     "type": "string"
                                   },
-                                  "PartyDescription": {
+                                  "partyDescription": {
                                     "type": "string"
                                   }
                                 }
@@ -27547,53 +27547,53 @@
                           }
                         }
                       },
-                      "Lease": {
+                      "lease": {
                         "type": "object",
                         "properties": {
-                          "LeaseEntry": {
+                          "leaseEntry": {
                             "type": "array",
                             "items": {
                               "type": "object",
                               "properties": {
-                                "LeaseTerm": {
+                                "leaseTerm": {
                                   "type": "string"
                                 },
-                                "LeaseDate": {
+                                "leaseDate": {
                                   "type": "string"
                                 },
                                 "Rent": {
                                   "type": "string"
                                 },
-                                "LeaseParty": {
+                                "leaseParty": {
                                   "type": "array",
                                   "items": {
                                     "type": "object",
                                     "properties": {
-                                      "PrivateIndividual": {
+                                      "privateIndividual": {
                                         "type": "object",
                                         "properties": {
-                                          "Name": {
+                                          "name": {
                                             "type": "object",
                                             "properties": {
-                                              "ForenamesName": {
+                                              "forenamesName": {
                                                 "type": "string"
                                               },
-                                              "SurnameName": {
+                                              "surnameName": {
                                                 "type": "string"
                                               }
                                             }
                                           },
-                                          "Alias": {
+                                          "alias": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "ForenamesName": {
+                                                    "forenamesName": {
                                                       "type": "string"
                                                     },
-                                                    "SurnameName": {
+                                                    "surnameName": {
                                                       "type": "string"
                                                     }
                                                   }
@@ -27603,10 +27603,10 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
-                                                  "ForenamesName": {
+                                                  "forenamesName": {
                                                     "type": "string"
                                                   },
-                                                  "SurnameName": {
+                                                  "surnameName": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -27615,32 +27615,32 @@
                                           }
                                         }
                                       },
-                                      "Organization": {
+                                      "organization": {
                                         "type": "object",
                                         "properties": {
-                                          "Name": {
+                                          "name": {
                                             "type": "string"
                                           },
-                                          "CompanyRegistrationNumber": {
+                                          "companyRegistrationNumber": {
                                             "type": "string"
                                           }
                                         }
                                       },
-                                      "Address": {
+                                      "address": {
                                         "type": "object",
                                         "properties": {
-                                          "PostcodeZone": {
+                                          "postcodeZone": {
                                             "type": "object",
                                             "properties": {
-                                              "Postcode": {
+                                              "postcode": {
                                                 "type": "string"
                                               }
                                             }
                                           },
-                                          "AddressLine": {
+                                          "addressLine": {
                                             "type": "object",
                                             "properties": {
-                                              "Line": {
+                                              "line": {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
@@ -27651,10 +27651,10 @@
                                           }
                                         }
                                       },
-                                      "CharityDetails": {
+                                      "charityDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "CharityName": {
+                                          "charityName": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -27668,25 +27668,25 @@
                                               }
                                             ]
                                           },
-                                          "CharityAddress": {
+                                          "charityAddress": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
                                                 "items": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -27702,18 +27702,18 @@
                                               {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -27726,10 +27726,10 @@
                                               }
                                             ]
                                           },
-                                          "CharityType": {
+                                          "charityType": {
                                             "type": "object",
                                             "properties": {
-                                              "Value": {
+                                              "value": {
                                                 "type": "string",
                                                 "enum": [
                                                   "C",
@@ -27741,33 +27741,33 @@
                                           }
                                         }
                                       },
-                                      "TradingName": {
+                                      "tradingName": {
                                         "type": "string"
                                       },
-                                      "PartyNumber": {
+                                      "partyNumber": {
                                         "type": "string"
                                       },
-                                      "PartyDescription": {
+                                      "partyDescription": {
                                         "type": "string"
                                       }
                                     }
                                   },
                                   "minItems": 2
                                 },
-                                "EntryDetails": {
+                                "entryDetails": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -27776,7 +27776,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -27795,7 +27795,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -27806,20 +27806,20 @@
                           }
                         }
                       },
-                      "RestrictionDetails": {
+                      "restrictionDetails": {
                         "type": "object",
                         "properties": {
-                          "RestrictionEntry": {
+                          "restrictionEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ChargeRelatedRestriction": {
+                                    "chargeRelatedRestriction": {
                                       "type": "object",
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -27828,23 +27828,23 @@
                                             "30"
                                           ]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": [
                                                 "A",
@@ -27853,7 +27853,7 @@
                                                 "D"
                                               ]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -27872,17 +27872,17 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "ChargeRestriction": {
+                                    "chargeRestriction": {
                                       "type": "object",
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -27891,23 +27891,23 @@
                                             "30"
                                           ]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": [
                                                 "A",
@@ -27916,7 +27916,7 @@
                                                 "D"
                                               ]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -27935,17 +27935,17 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "NonChargeRestriction": {
+                                    "nonChargeRestriction": {
                                       "type": "object",
                                       "properties": {
-                                        "RestrictionTypeCode": {
+                                        "restrictionTypeCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -27954,23 +27954,23 @@
                                             "30"
                                           ]
                                         },
-                                        "ChargeID": {
+                                        "chargeID": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": [
                                                 "A",
@@ -27979,7 +27979,7 @@
                                                 "D"
                                               ]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -27998,7 +27998,7 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
@@ -28012,10 +28012,10 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ChargeRelatedRestriction": {
+                                  "chargeRelatedRestriction": {
                                     "type": "object",
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -28024,23 +28024,23 @@
                                           "30"
                                         ]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": [
                                               "A",
@@ -28049,7 +28049,7 @@
                                               "D"
                                             ]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -28068,17 +28068,17 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "ChargeRestriction": {
+                                  "chargeRestriction": {
                                     "type": "object",
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -28087,23 +28087,23 @@
                                           "30"
                                         ]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": [
                                               "A",
@@ -28112,7 +28112,7 @@
                                               "D"
                                             ]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -28131,17 +28131,17 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "NonChargeRestriction": {
+                                  "nonChargeRestriction": {
                                     "type": "object",
                                     "properties": {
-                                      "RestrictionTypeCode": {
+                                      "restrictionTypeCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -28150,23 +28150,23 @@
                                           "30"
                                         ]
                                       },
-                                      "ChargeID": {
+                                      "chargeID": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": [
                                               "A",
@@ -28175,7 +28175,7 @@
                                               "D"
                                             ]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -28194,7 +28194,7 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
@@ -28207,43 +28207,43 @@
                           }
                         }
                       },
-                      "Charge": {
+                      "charge": {
                         "type": "object",
                         "properties": {
-                          "ChargeEntry": {
+                          "chargeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ChargeID": {
+                                    "chargeID": {
                                       "type": "string"
                                     },
-                                    "ChargeDate": {
+                                    "chargeDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "RegisteredCharge": {
+                                    "registeredCharge": {
                                       "type": "object",
                                       "properties": {
-                                        "MultipleTitleIndicator": {
+                                        "multipleTitleIndicator": {
                                           "type": "string"
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": [
                                                 "A",
@@ -28252,7 +28252,7 @@
                                                 "D"
                                               ]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -28271,48 +28271,48 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "ChargeProprietor": {
+                                    "chargeProprietor": {
                                       "type": "object",
                                       "properties": {
-                                        "ChargeeParty": {
+                                        "chargeeParty": {
                                           "oneOf": [
                                             {
                                               "type": "array",
                                               "items": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PrivateIndividual": {
+                                                  "privateIndividual": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Name": {
+                                                      "name": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "ForenamesName": {
+                                                          "forenamesName": {
                                                             "type": "string"
                                                           },
-                                                          "SurnameName": {
+                                                          "surnameName": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "Alias": {
+                                                      "alias": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
@@ -28322,10 +28322,10 @@
                                                           {
                                                             "type": "object",
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -28334,32 +28334,32 @@
                                                       }
                                                     }
                                                   },
-                                                  "Organization": {
+                                                  "organization": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Name": {
+                                                      "name": {
                                                         "type": "string"
                                                       },
-                                                      "CompanyRegistrationNumber": {
+                                                      "companyRegistrationNumber": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "Address": {
+                                                  "address": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "PostcodeZone": {
+                                                      "postcodeZone": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Postcode": {
+                                                          "postcode": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "AddressLine": {
+                                                      "addressLine": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Line": {
+                                                          "line": {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "string"
@@ -28370,10 +28370,10 @@
                                                       }
                                                     }
                                                   },
-                                                  "CharityDetails": {
+                                                  "charityDetails": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "CharityName": {
+                                                      "charityName": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
@@ -28387,25 +28387,25 @@
                                                           }
                                                         ]
                                                       },
-                                                      "CharityAddress": {
+                                                      "charityAddress": {
                                                         "oneOf": [
                                                           {
                                                             "type": "array",
                                                             "items": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Postcode": {
+                                                                    "postcode": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "AddressLine": {
+                                                                "addressLine": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Line": {
+                                                                    "line": {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "string"
@@ -28421,18 +28421,18 @@
                                                           {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -28445,10 +28445,10 @@
                                                           }
                                                         ]
                                                       },
-                                                      "CharityType": {
+                                                      "charityType": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Value": {
+                                                          "value": {
                                                             "type": "string",
                                                             "enum": [
                                                               "C",
@@ -28460,13 +28460,13 @@
                                                       }
                                                     }
                                                   },
-                                                  "TradingName": {
+                                                  "tradingName": {
                                                     "type": "string"
                                                   },
-                                                  "PartyNumber": {
+                                                  "partyNumber": {
                                                     "type": "string"
                                                   },
-                                                  "PartyDescription": {
+                                                  "partyDescription": {
                                                     "type": "string"
                                                   }
                                                 }
@@ -28476,31 +28476,31 @@
                                             {
                                               "type": "object",
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "ForenamesName": {
+                                                        "forenamesName": {
                                                           "type": "string"
                                                         },
-                                                        "SurnameName": {
+                                                        "surnameName": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -28510,10 +28510,10 @@
                                                         {
                                                           "type": "object",
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -28522,32 +28522,32 @@
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "string"
                                                     },
-                                                    "CompanyRegistrationNumber": {
+                                                    "companyRegistrationNumber": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -28558,10 +28558,10 @@
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "CharityName": {
+                                                    "charityName": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
@@ -28575,25 +28575,25 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -28609,18 +28609,18 @@
                                                         {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -28633,10 +28633,10 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityType": {
+                                                    "charityType": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Value": {
+                                                        "value": {
                                                           "type": "string",
                                                           "enum": [
                                                             "C",
@@ -28648,33 +28648,33 @@
                                                     }
                                                   }
                                                 },
-                                                "TradingName": {
+                                                "tradingName": {
                                                   "type": "string"
                                                 },
-                                                "PartyNumber": {
+                                                "partyNumber": {
                                                   "type": "string"
                                                 },
-                                                "PartyDescription": {
+                                                "partyDescription": {
                                                   "type": "string"
                                                 }
                                               }
                                             }
                                           ]
                                         },
-                                        "EntryDetails": {
+                                        "entryDetails": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "type": "string"
                                             },
-                                            "RegistrationDate": {
+                                            "registrationDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "SubRegisterCode": {
+                                            "subRegisterCode": {
                                               "type": "string",
                                               "enum": [
                                                 "A",
@@ -28683,7 +28683,7 @@
                                                 "D"
                                               ]
                                             },
-                                            "ScheduleCode": {
+                                            "scheduleCode": {
                                               "type": "string",
                                               "enum": [
                                                 "0",
@@ -28702,44 +28702,44 @@
                                                 "130"
                                               ]
                                             },
-                                            "Infills": {
+                                            "infills": {
                                               "type": "object"
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "SubCharge": {
+                                    "subCharge": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "properties": {
-                                              "ChargeDate": {
+                                              "chargeDate": {
                                                 "type": "string",
                                                 "format": "date"
                                               },
-                                              "RegisteredCharge": {
+                                              "registeredCharge": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "MultipleTitleIndicator": {
+                                                  "multipleTitleIndicator": {
                                                     "type": "string"
                                                   },
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "EntryNumber": {
+                                                      "entryNumber": {
                                                         "type": "string"
                                                       },
-                                                      "EntryText": {
+                                                      "entryText": {
                                                         "type": "string"
                                                       },
-                                                      "RegistrationDate": {
+                                                      "registrationDate": {
                                                         "type": "string",
                                                         "format": "date"
                                                       },
-                                                      "SubRegisterCode": {
+                                                      "subRegisterCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "A",
@@ -28748,7 +28748,7 @@
                                                           "D"
                                                         ]
                                                       },
-                                                      "ScheduleCode": {
+                                                      "scheduleCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "0",
@@ -28767,48 +28767,48 @@
                                                           "130"
                                                         ]
                                                       },
-                                                      "Infills": {
+                                                      "infills": {
                                                         "type": "object"
                                                       }
                                                     }
                                                   }
                                                 }
                                               },
-                                              "ChargeProprietor": {
+                                              "chargeProprietor": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "ChargeeParty": {
+                                                  "chargeeParty": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PrivateIndividual": {
+                                                            "privateIndividual": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Name": {
+                                                                "name": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "Alias": {
+                                                                "alias": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "ForenamesName": {
+                                                                          "forenamesName": {
                                                                             "type": "string"
                                                                           },
-                                                                          "SurnameName": {
+                                                                          "surnameName": {
                                                                             "type": "string"
                                                                           }
                                                                         }
@@ -28818,10 +28818,10 @@
                                                                     {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -28830,32 +28830,32 @@
                                                                 }
                                                               }
                                                             },
-                                                            "Organization": {
+                                                            "organization": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Name": {
+                                                                "name": {
                                                                   "type": "string"
                                                                 },
-                                                                "CompanyRegistrationNumber": {
+                                                                "companyRegistrationNumber": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Address": {
+                                                            "address": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "PostcodeZone": {
+                                                                "postcodeZone": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Postcode": {
+                                                                    "postcode": {
                                                                       "type": "string"
                                                                     }
                                                                   }
                                                                 },
-                                                                "AddressLine": {
+                                                                "addressLine": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Line": {
+                                                                    "line": {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "string"
@@ -28866,10 +28866,10 @@
                                                                 }
                                                               }
                                                             },
-                                                            "CharityDetails": {
+                                                            "charityDetails": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "CharityName": {
+                                                                "charityName": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
@@ -28883,25 +28883,25 @@
                                                                     }
                                                                   ]
                                                                 },
-                                                                "CharityAddress": {
+                                                                "charityAddress": {
                                                                   "oneOf": [
                                                                     {
                                                                       "type": "array",
                                                                       "items": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "PostcodeZone": {
+                                                                          "postcodeZone": {
                                                                             "type": "object",
                                                                             "properties": {
-                                                                              "Postcode": {
+                                                                              "postcode": {
                                                                                 "type": "string"
                                                                               }
                                                                             }
                                                                           },
-                                                                          "AddressLine": {
+                                                                          "addressLine": {
                                                                             "type": "object",
                                                                             "properties": {
-                                                                              "Line": {
+                                                                              "line": {
                                                                                 "type": "array",
                                                                                 "items": {
                                                                                   "type": "string"
@@ -28917,18 +28917,18 @@
                                                                     {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -28941,10 +28941,10 @@
                                                                     }
                                                                   ]
                                                                 },
-                                                                "CharityType": {
+                                                                "charityType": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "Value": {
+                                                                    "value": {
                                                                       "type": "string",
                                                                       "enum": [
                                                                         "C",
@@ -28956,13 +28956,13 @@
                                                                 }
                                                               }
                                                             },
-                                                            "TradingName": {
+                                                            "tradingName": {
                                                               "type": "string"
                                                             },
-                                                            "PartyNumber": {
+                                                            "partyNumber": {
                                                               "type": "string"
                                                             },
-                                                            "PartyDescription": {
+                                                            "partyDescription": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -28972,31 +28972,31 @@
                                                       {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -29006,10 +29006,10 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -29018,32 +29018,32 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -29054,10 +29054,10 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -29071,25 +29071,25 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -29105,18 +29105,18 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -29129,10 +29129,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -29144,33 +29144,33 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       }
                                                     ]
                                                   },
-                                                  "EntryDetails": {
+                                                  "entryDetails": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "EntryNumber": {
+                                                      "entryNumber": {
                                                         "type": "string"
                                                       },
-                                                      "EntryText": {
+                                                      "entryText": {
                                                         "type": "string"
                                                       },
-                                                      "RegistrationDate": {
+                                                      "registrationDate": {
                                                         "type": "string",
                                                         "format": "date"
                                                       },
-                                                      "SubRegisterCode": {
+                                                      "subRegisterCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "A",
@@ -29179,7 +29179,7 @@
                                                           "D"
                                                         ]
                                                       },
-                                                      "ScheduleCode": {
+                                                      "scheduleCode": {
                                                         "type": "string",
                                                         "enum": [
                                                           "0",
@@ -29198,7 +29198,7 @@
                                                           "130"
                                                         ]
                                                       },
-                                                      "Infills": {
+                                                      "infills": {
                                                         "type": "object"
                                                       }
                                                     }
@@ -29212,30 +29212,30 @@
                                         {
                                           "type": "object",
                                           "properties": {
-                                            "ChargeDate": {
+                                            "chargeDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "type": "object",
                                               "properties": {
-                                                "MultipleTitleIndicator": {
+                                                "multipleTitleIndicator": {
                                                   "type": "string"
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -29244,7 +29244,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -29263,48 +29263,48 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "type": "object",
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -29314,10 +29314,10 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -29326,32 +29326,32 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -29362,10 +29362,10 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -29379,25 +29379,25 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -29413,18 +29413,18 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -29437,10 +29437,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -29452,13 +29452,13 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -29468,31 +29468,31 @@
                                                     {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -29502,10 +29502,10 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -29514,32 +29514,32 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -29550,10 +29550,10 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -29567,25 +29567,25 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -29601,18 +29601,18 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -29625,10 +29625,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -29640,33 +29640,33 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -29675,7 +29675,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -29694,7 +29694,7 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
@@ -29712,33 +29712,33 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ChargeID": {
+                                  "chargeID": {
                                     "type": "string"
                                   },
-                                  "ChargeDate": {
+                                  "chargeDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "RegisteredCharge": {
+                                  "registeredCharge": {
                                     "type": "object",
                                     "properties": {
-                                      "MultipleTitleIndicator": {
+                                      "multipleTitleIndicator": {
                                         "type": "string"
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": [
                                               "A",
@@ -29747,7 +29747,7 @@
                                               "D"
                                             ]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -29766,48 +29766,48 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "ChargeProprietor": {
+                                  "chargeProprietor": {
                                     "type": "object",
                                     "properties": {
-                                      "ChargeeParty": {
+                                      "chargeeParty": {
                                         "oneOf": [
                                           {
                                             "type": "array",
                                             "items": {
                                               "type": "object",
                                               "properties": {
-                                                "PrivateIndividual": {
+                                                "privateIndividual": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "ForenamesName": {
+                                                        "forenamesName": {
                                                           "type": "string"
                                                         },
-                                                        "SurnameName": {
+                                                        "surnameName": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "Alias": {
+                                                    "alias": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
@@ -29817,10 +29817,10 @@
                                                         {
                                                           "type": "object",
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -29829,32 +29829,32 @@
                                                     }
                                                   }
                                                 },
-                                                "Organization": {
+                                                "organization": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "Name": {
+                                                    "name": {
                                                       "type": "string"
                                                     },
-                                                    "CompanyRegistrationNumber": {
+                                                    "companyRegistrationNumber": {
                                                       "type": "string"
                                                     }
                                                   }
                                                 },
-                                                "Address": {
+                                                "address": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "PostcodeZone": {
+                                                    "postcodeZone": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Postcode": {
+                                                        "postcode": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     },
-                                                    "AddressLine": {
+                                                    "addressLine": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Line": {
+                                                        "line": {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "string"
@@ -29865,10 +29865,10 @@
                                                     }
                                                   }
                                                 },
-                                                "CharityDetails": {
+                                                "charityDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "CharityName": {
+                                                    "charityName": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
@@ -29882,25 +29882,25 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityAddress": {
+                                                    "charityAddress": {
                                                       "oneOf": [
                                                         {
                                                           "type": "array",
                                                           "items": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -29916,18 +29916,18 @@
                                                         {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -29940,10 +29940,10 @@
                                                         }
                                                       ]
                                                     },
-                                                    "CharityType": {
+                                                    "charityType": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "Value": {
+                                                        "value": {
                                                           "type": "string",
                                                           "enum": [
                                                             "C",
@@ -29955,13 +29955,13 @@
                                                     }
                                                   }
                                                 },
-                                                "TradingName": {
+                                                "tradingName": {
                                                   "type": "string"
                                                 },
-                                                "PartyNumber": {
+                                                "partyNumber": {
                                                   "type": "string"
                                                 },
-                                                "PartyDescription": {
+                                                "partyDescription": {
                                                   "type": "string"
                                                 }
                                               }
@@ -29971,31 +29971,31 @@
                                           {
                                             "type": "object",
                                             "properties": {
-                                              "PrivateIndividual": {
+                                              "privateIndividual": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Name": {
+                                                  "name": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "ForenamesName": {
+                                                      "forenamesName": {
                                                         "type": "string"
                                                       },
-                                                      "SurnameName": {
+                                                      "surnameName": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "Alias": {
+                                                  "alias": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "ForenamesName": {
+                                                            "forenamesName": {
                                                               "type": "string"
                                                             },
-                                                            "SurnameName": {
+                                                            "surnameName": {
                                                               "type": "string"
                                                             }
                                                           }
@@ -30005,10 +30005,10 @@
                                                       {
                                                         "type": "object",
                                                         "properties": {
-                                                          "ForenamesName": {
+                                                          "forenamesName": {
                                                             "type": "string"
                                                           },
-                                                          "SurnameName": {
+                                                          "surnameName": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -30017,32 +30017,32 @@
                                                   }
                                                 }
                                               },
-                                              "Organization": {
+                                              "organization": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "Name": {
+                                                  "name": {
                                                     "type": "string"
                                                   },
-                                                  "CompanyRegistrationNumber": {
+                                                  "companyRegistrationNumber": {
                                                     "type": "string"
                                                   }
                                                 }
                                               },
-                                              "Address": {
+                                              "address": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "PostcodeZone": {
+                                                  "postcodeZone": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Postcode": {
+                                                      "postcode": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   },
-                                                  "AddressLine": {
+                                                  "addressLine": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Line": {
+                                                      "line": {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
@@ -30053,10 +30053,10 @@
                                                   }
                                                 }
                                               },
-                                              "CharityDetails": {
+                                              "charityDetails": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "CharityName": {
+                                                  "charityName": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
@@ -30070,25 +30070,25 @@
                                                       }
                                                     ]
                                                   },
-                                                  "CharityAddress": {
+                                                  "charityAddress": {
                                                     "oneOf": [
                                                       {
                                                         "type": "array",
                                                         "items": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -30104,18 +30104,18 @@
                                                       {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Postcode": {
+                                                              "postcode": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "AddressLine": {
+                                                          "addressLine": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Line": {
+                                                              "line": {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "string"
@@ -30128,10 +30128,10 @@
                                                       }
                                                     ]
                                                   },
-                                                  "CharityType": {
+                                                  "charityType": {
                                                     "type": "object",
                                                     "properties": {
-                                                      "Value": {
+                                                      "value": {
                                                         "type": "string",
                                                         "enum": [
                                                           "C",
@@ -30143,33 +30143,33 @@
                                                   }
                                                 }
                                               },
-                                              "TradingName": {
+                                              "tradingName": {
                                                 "type": "string"
                                               },
-                                              "PartyNumber": {
+                                              "partyNumber": {
                                                 "type": "string"
                                               },
-                                              "PartyDescription": {
+                                              "partyDescription": {
                                                 "type": "string"
                                               }
                                             }
                                           }
                                         ]
                                       },
-                                      "EntryDetails": {
+                                      "entryDetails": {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "type": "string"
                                           },
-                                          "RegistrationDate": {
+                                          "registrationDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "SubRegisterCode": {
+                                          "subRegisterCode": {
                                             "type": "string",
                                             "enum": [
                                               "A",
@@ -30178,7 +30178,7 @@
                                               "D"
                                             ]
                                           },
-                                          "ScheduleCode": {
+                                          "scheduleCode": {
                                             "type": "string",
                                             "enum": [
                                               "0",
@@ -30197,44 +30197,44 @@
                                               "130"
                                             ]
                                           },
-                                          "Infills": {
+                                          "infills": {
                                             "type": "object"
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "SubCharge": {
+                                  "subCharge": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "properties": {
-                                            "ChargeDate": {
+                                            "chargeDate": {
                                               "type": "string",
                                               "format": "date"
                                             },
-                                            "RegisteredCharge": {
+                                            "registeredCharge": {
                                               "type": "object",
                                               "properties": {
-                                                "MultipleTitleIndicator": {
+                                                "multipleTitleIndicator": {
                                                   "type": "string"
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -30243,7 +30243,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -30262,48 +30262,48 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
                                                 }
                                               }
                                             },
-                                            "ChargeProprietor": {
+                                            "chargeProprietor": {
                                               "type": "object",
                                               "properties": {
-                                                "ChargeeParty": {
+                                                "chargeeParty": {
                                                   "oneOf": [
                                                     {
                                                       "type": "array",
                                                       "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PrivateIndividual": {
+                                                          "privateIndividual": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "Alias": {
+                                                              "alias": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "ForenamesName": {
+                                                                        "forenamesName": {
                                                                           "type": "string"
                                                                         },
-                                                                        "SurnameName": {
+                                                                        "surnameName": {
                                                                           "type": "string"
                                                                         }
                                                                       }
@@ -30313,10 +30313,10 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -30325,32 +30325,32 @@
                                                               }
                                                             }
                                                           },
-                                                          "Organization": {
+                                                          "organization": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Name": {
+                                                              "name": {
                                                                 "type": "string"
                                                               },
-                                                              "CompanyRegistrationNumber": {
+                                                              "companyRegistrationNumber": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Address": {
+                                                          "address": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "PostcodeZone": {
+                                                              "postcodeZone": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Postcode": {
+                                                                  "postcode": {
                                                                     "type": "string"
                                                                   }
                                                                 }
                                                               },
-                                                              "AddressLine": {
+                                                              "addressLine": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Line": {
+                                                                  "line": {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "string"
@@ -30361,10 +30361,10 @@
                                                               }
                                                             }
                                                           },
-                                                          "CharityDetails": {
+                                                          "charityDetails": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "CharityName": {
+                                                              "charityName": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
@@ -30378,25 +30378,25 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityAddress": {
+                                                              "charityAddress": {
                                                                 "oneOf": [
                                                                   {
                                                                     "type": "array",
                                                                     "items": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "PostcodeZone": {
+                                                                        "postcodeZone": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Postcode": {
+                                                                            "postcode": {
                                                                               "type": "string"
                                                                             }
                                                                           }
                                                                         },
-                                                                        "AddressLine": {
+                                                                        "addressLine": {
                                                                           "type": "object",
                                                                           "properties": {
-                                                                            "Line": {
+                                                                            "line": {
                                                                               "type": "array",
                                                                               "items": {
                                                                                 "type": "string"
@@ -30412,18 +30412,18 @@
                                                                   {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -30436,10 +30436,10 @@
                                                                   }
                                                                 ]
                                                               },
-                                                              "CharityType": {
+                                                              "charityType": {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "Value": {
+                                                                  "value": {
                                                                     "type": "string",
                                                                     "enum": [
                                                                       "C",
@@ -30451,13 +30451,13 @@
                                                               }
                                                             }
                                                           },
-                                                          "TradingName": {
+                                                          "tradingName": {
                                                             "type": "string"
                                                           },
-                                                          "PartyNumber": {
+                                                          "partyNumber": {
                                                             "type": "string"
                                                           },
-                                                          "PartyDescription": {
+                                                          "partyDescription": {
                                                             "type": "string"
                                                           }
                                                         }
@@ -30467,31 +30467,31 @@
                                                     {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -30501,10 +30501,10 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -30513,32 +30513,32 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -30549,10 +30549,10 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -30566,25 +30566,25 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -30600,18 +30600,18 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -30624,10 +30624,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -30639,33 +30639,33 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "EntryDetails": {
+                                                "entryDetails": {
                                                   "type": "object",
                                                   "properties": {
-                                                    "EntryNumber": {
+                                                    "entryNumber": {
                                                       "type": "string"
                                                     },
-                                                    "EntryText": {
+                                                    "entryText": {
                                                       "type": "string"
                                                     },
-                                                    "RegistrationDate": {
+                                                    "registrationDate": {
                                                       "type": "string",
                                                       "format": "date"
                                                     },
-                                                    "SubRegisterCode": {
+                                                    "subRegisterCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "A",
@@ -30674,7 +30674,7 @@
                                                         "D"
                                                       ]
                                                     },
-                                                    "ScheduleCode": {
+                                                    "scheduleCode": {
                                                       "type": "string",
                                                       "enum": [
                                                         "0",
@@ -30693,7 +30693,7 @@
                                                         "130"
                                                       ]
                                                     },
-                                                    "Infills": {
+                                                    "infills": {
                                                       "type": "object"
                                                     }
                                                   }
@@ -30707,30 +30707,30 @@
                                       {
                                         "type": "object",
                                         "properties": {
-                                          "ChargeDate": {
+                                          "chargeDate": {
                                             "type": "string",
                                             "format": "date"
                                           },
-                                          "RegisteredCharge": {
+                                          "registeredCharge": {
                                             "type": "object",
                                             "properties": {
-                                              "MultipleTitleIndicator": {
+                                              "multipleTitleIndicator": {
                                                 "type": "string"
                                               },
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "EntryNumber": {
+                                                  "entryNumber": {
                                                     "type": "string"
                                                   },
-                                                  "EntryText": {
+                                                  "entryText": {
                                                     "type": "string"
                                                   },
-                                                  "RegistrationDate": {
+                                                  "registrationDate": {
                                                     "type": "string",
                                                     "format": "date"
                                                   },
-                                                  "SubRegisterCode": {
+                                                  "subRegisterCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "A",
@@ -30739,7 +30739,7 @@
                                                       "D"
                                                     ]
                                                   },
-                                                  "ScheduleCode": {
+                                                  "scheduleCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "0",
@@ -30758,48 +30758,48 @@
                                                       "130"
                                                     ]
                                                   },
-                                                  "Infills": {
+                                                  "infills": {
                                                     "type": "object"
                                                   }
                                                 }
                                               }
                                             }
                                           },
-                                          "ChargeProprietor": {
+                                          "chargeProprietor": {
                                             "type": "object",
                                             "properties": {
-                                              "ChargeeParty": {
+                                              "chargeeParty": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
                                                     "items": {
                                                       "type": "object",
                                                       "properties": {
-                                                        "PrivateIndividual": {
+                                                        "privateIndividual": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "ForenamesName": {
+                                                                "forenamesName": {
                                                                   "type": "string"
                                                                 },
-                                                                "SurnameName": {
+                                                                "surnameName": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "Alias": {
+                                                            "alias": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "ForenamesName": {
+                                                                      "forenamesName": {
                                                                         "type": "string"
                                                                       },
-                                                                      "SurnameName": {
+                                                                      "surnameName": {
                                                                         "type": "string"
                                                                       }
                                                                     }
@@ -30809,10 +30809,10 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -30821,32 +30821,32 @@
                                                             }
                                                           }
                                                         },
-                                                        "Organization": {
+                                                        "organization": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "Name": {
+                                                            "name": {
                                                               "type": "string"
                                                             },
-                                                            "CompanyRegistrationNumber": {
+                                                            "companyRegistrationNumber": {
                                                               "type": "string"
                                                             }
                                                           }
                                                         },
-                                                        "Address": {
+                                                        "address": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "PostcodeZone": {
+                                                            "postcodeZone": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Postcode": {
+                                                                "postcode": {
                                                                   "type": "string"
                                                                 }
                                                               }
                                                             },
-                                                            "AddressLine": {
+                                                            "addressLine": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Line": {
+                                                                "line": {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "string"
@@ -30857,10 +30857,10 @@
                                                             }
                                                           }
                                                         },
-                                                        "CharityDetails": {
+                                                        "charityDetails": {
                                                           "type": "object",
                                                           "properties": {
-                                                            "CharityName": {
+                                                            "charityName": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
@@ -30874,25 +30874,25 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityAddress": {
+                                                            "charityAddress": {
                                                               "oneOf": [
                                                                 {
                                                                   "type": "array",
                                                                   "items": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "PostcodeZone": {
+                                                                      "postcodeZone": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Postcode": {
+                                                                          "postcode": {
                                                                             "type": "string"
                                                                           }
                                                                         }
                                                                       },
-                                                                      "AddressLine": {
+                                                                      "addressLine": {
                                                                         "type": "object",
                                                                         "properties": {
-                                                                          "Line": {
+                                                                          "line": {
                                                                             "type": "array",
                                                                             "items": {
                                                                               "type": "string"
@@ -30908,18 +30908,18 @@
                                                                 {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -30932,10 +30932,10 @@
                                                                 }
                                                               ]
                                                             },
-                                                            "CharityType": {
+                                                            "charityType": {
                                                               "type": "object",
                                                               "properties": {
-                                                                "Value": {
+                                                                "value": {
                                                                   "type": "string",
                                                                   "enum": [
                                                                     "C",
@@ -30947,13 +30947,13 @@
                                                             }
                                                           }
                                                         },
-                                                        "TradingName": {
+                                                        "tradingName": {
                                                           "type": "string"
                                                         },
-                                                        "PartyNumber": {
+                                                        "partyNumber": {
                                                           "type": "string"
                                                         },
-                                                        "PartyDescription": {
+                                                        "partyDescription": {
                                                           "type": "string"
                                                         }
                                                       }
@@ -30963,31 +30963,31 @@
                                                   {
                                                     "type": "object",
                                                     "properties": {
-                                                      "PrivateIndividual": {
+                                                      "privateIndividual": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Name": {
+                                                          "name": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "ForenamesName": {
+                                                              "forenamesName": {
                                                                 "type": "string"
                                                               },
-                                                              "SurnameName": {
+                                                              "surnameName": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "Alias": {
+                                                          "alias": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "ForenamesName": {
+                                                                    "forenamesName": {
                                                                       "type": "string"
                                                                     },
-                                                                    "SurnameName": {
+                                                                    "surnameName": {
                                                                       "type": "string"
                                                                     }
                                                                   }
@@ -30997,10 +30997,10 @@
                                                               {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "ForenamesName": {
+                                                                  "forenamesName": {
                                                                     "type": "string"
                                                                   },
-                                                                  "SurnameName": {
+                                                                  "surnameName": {
                                                                     "type": "string"
                                                                   }
                                                                 }
@@ -31009,32 +31009,32 @@
                                                           }
                                                         }
                                                       },
-                                                      "Organization": {
+                                                      "organization": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "Name": {
+                                                          "name": {
                                                             "type": "string"
                                                           },
-                                                          "CompanyRegistrationNumber": {
+                                                          "companyRegistrationNumber": {
                                                             "type": "string"
                                                           }
                                                         }
                                                       },
-                                                      "Address": {
+                                                      "address": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "PostcodeZone": {
+                                                          "postcodeZone": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Postcode": {
+                                                              "postcode": {
                                                                 "type": "string"
                                                               }
                                                             }
                                                           },
-                                                          "AddressLine": {
+                                                          "addressLine": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Line": {
+                                                              "line": {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "string"
@@ -31045,10 +31045,10 @@
                                                           }
                                                         }
                                                       },
-                                                      "CharityDetails": {
+                                                      "charityDetails": {
                                                         "type": "object",
                                                         "properties": {
-                                                          "CharityName": {
+                                                          "charityName": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
@@ -31062,25 +31062,25 @@
                                                               }
                                                             ]
                                                           },
-                                                          "CharityAddress": {
+                                                          "charityAddress": {
                                                             "oneOf": [
                                                               {
                                                                 "type": "array",
                                                                 "items": {
                                                                   "type": "object",
                                                                   "properties": {
-                                                                    "PostcodeZone": {
+                                                                    "postcodeZone": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Postcode": {
+                                                                        "postcode": {
                                                                           "type": "string"
                                                                         }
                                                                       }
                                                                     },
-                                                                    "AddressLine": {
+                                                                    "addressLine": {
                                                                       "type": "object",
                                                                       "properties": {
-                                                                        "Line": {
+                                                                        "line": {
                                                                           "type": "array",
                                                                           "items": {
                                                                             "type": "string"
@@ -31096,18 +31096,18 @@
                                                               {
                                                                 "type": "object",
                                                                 "properties": {
-                                                                  "PostcodeZone": {
+                                                                  "postcodeZone": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "Postcode": {
+                                                                      "postcode": {
                                                                         "type": "string"
                                                                       }
                                                                     }
                                                                   },
-                                                                  "AddressLine": {
+                                                                  "addressLine": {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                      "Line": {
+                                                                      "line": {
                                                                         "type": "array",
                                                                         "items": {
                                                                           "type": "string"
@@ -31120,10 +31120,10 @@
                                                               }
                                                             ]
                                                           },
-                                                          "CharityType": {
+                                                          "charityType": {
                                                             "type": "object",
                                                             "properties": {
-                                                              "Value": {
+                                                              "value": {
                                                                 "type": "string",
                                                                 "enum": [
                                                                   "C",
@@ -31135,33 +31135,33 @@
                                                           }
                                                         }
                                                       },
-                                                      "TradingName": {
+                                                      "tradingName": {
                                                         "type": "string"
                                                       },
-                                                      "PartyNumber": {
+                                                      "partyNumber": {
                                                         "type": "string"
                                                       },
-                                                      "PartyDescription": {
+                                                      "partyDescription": {
                                                         "type": "string"
                                                       }
                                                     }
                                                   }
                                                 ]
                                               },
-                                              "EntryDetails": {
+                                              "entryDetails": {
                                                 "type": "object",
                                                 "properties": {
-                                                  "EntryNumber": {
+                                                  "entryNumber": {
                                                     "type": "string"
                                                   },
-                                                  "EntryText": {
+                                                  "entryText": {
                                                     "type": "string"
                                                   },
-                                                  "RegistrationDate": {
+                                                  "registrationDate": {
                                                     "type": "string",
                                                     "format": "date"
                                                   },
-                                                  "SubRegisterCode": {
+                                                  "subRegisterCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "A",
@@ -31170,7 +31170,7 @@
                                                       "D"
                                                     ]
                                                   },
-                                                  "ScheduleCode": {
+                                                  "scheduleCode": {
                                                     "type": "string",
                                                     "enum": [
                                                       "0",
@@ -31189,7 +31189,7 @@
                                                       "130"
                                                     ]
                                                   },
-                                                  "Infills": {
+                                                  "infills": {
                                                     "type": "object"
                                                   }
                                                 }
@@ -31206,37 +31206,37 @@
                           }
                         }
                       },
-                      "AgreedNotice": {
+                      "agreedNotice": {
                         "type": "object",
                         "properties": {
-                          "AgreedNoticeEntry": {
+                          "agreedNoticeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "AgreedNoticeType": {
+                                    "agreedNoticeType": {
                                       "type": "string",
                                       "enum": [
                                         "10",
                                         "20"
                                       ]
                                     },
-                                    "EntryDetails": {
+                                    "entryDetails": {
                                       "type": "object",
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": [
                                             "A",
@@ -31245,7 +31245,7 @@
                                             "D"
                                           ]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -31264,7 +31264,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -31276,27 +31276,27 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "AgreedNoticeType": {
+                                  "agreedNoticeType": {
                                     "type": "string",
                                     "enum": [
                                       "10",
                                       "20"
                                     ]
                                   },
-                                  "EntryDetails": {
+                                  "entryDetails": {
                                     "type": "object",
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": [
                                           "A",
@@ -31305,7 +31305,7 @@
                                           "D"
                                         ]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -31324,7 +31324,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -31335,27 +31335,27 @@
                           }
                         }
                       },
-                      "Bankruptcy": {
+                      "bankruptcy": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -31364,7 +31364,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -31383,7 +31383,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -31393,17 +31393,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -31412,7 +31412,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -31431,7 +31431,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -31440,27 +31440,27 @@
                           }
                         }
                       },
-                      "Caution": {
+                      "caution": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -31469,7 +31469,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -31488,7 +31488,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -31498,17 +31498,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -31517,7 +31517,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -31536,7 +31536,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -31545,27 +31545,27 @@
                           }
                         }
                       },
-                      "DeedOfPostponement": {
+                      "deedOfPostponement": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -31574,7 +31574,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -31593,7 +31593,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -31603,17 +31603,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -31622,7 +31622,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -31641,7 +31641,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -31650,27 +31650,27 @@
                           }
                         }
                       },
-                      "GreenOutEntry": {
+                      "greenOutEntry": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -31679,7 +31679,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -31698,7 +31698,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -31708,17 +31708,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -31727,7 +31727,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -31746,7 +31746,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -31755,37 +31755,37 @@
                           }
                         }
                       },
-                      "HomeRights": {
+                      "homeRights": {
                         "type": "object",
                         "properties": {
-                          "HomeRightsEntry": {
+                          "homeRightsEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ChangeOfAddressIndicator": {
+                                    "changeOfAddressIndicator": {
                                       "type": "string",
                                       "enum": [
                                         "true",
                                         "false"
                                       ]
                                     },
-                                    "HomeRightsEntryDetails": {
+                                    "homeRightsEntryDetails": {
                                       "type": "object",
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": [
                                             "A",
@@ -31794,7 +31794,7 @@
                                             "D"
                                           ]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -31813,25 +31813,25 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
                                     },
-                                    "ChangeOfAddressEntryDetails": {
+                                    "changeOfAddressEntryDetails": {
                                       "type": "object",
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": [
                                             "A",
@@ -31840,7 +31840,7 @@
                                             "D"
                                           ]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -31859,7 +31859,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -31871,27 +31871,27 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ChangeOfAddressIndicator": {
+                                  "changeOfAddressIndicator": {
                                     "type": "string",
                                     "enum": [
                                       "true",
                                       "false"
                                     ]
                                   },
-                                  "HomeRightsEntryDetails": {
+                                  "homeRightsEntryDetails": {
                                     "type": "object",
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": [
                                           "A",
@@ -31900,7 +31900,7 @@
                                           "D"
                                         ]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -31919,25 +31919,25 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
                                   },
-                                  "ChangeOfAddressEntryDetails": {
+                                  "changeOfAddressEntryDetails": {
                                     "type": "object",
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": [
                                           "A",
@@ -31946,7 +31946,7 @@
                                           "D"
                                         ]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -31965,7 +31965,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -31976,27 +31976,27 @@
                           }
                         }
                       },
-                      "RentCharge": {
+                      "rentCharge": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32005,7 +32005,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32024,7 +32024,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32034,17 +32034,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32053,7 +32053,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32072,7 +32072,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32081,27 +32081,27 @@
                           }
                         }
                       },
-                      "VendorsLien": {
+                      "vendorsLien": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32110,7 +32110,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32129,7 +32129,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32139,17 +32139,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32158,7 +32158,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32177,7 +32177,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32186,27 +32186,27 @@
                           }
                         }
                       },
-                      "RightOfPreEmption": {
+                      "rightOfPreEmption": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32215,7 +32215,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32234,7 +32234,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32244,17 +32244,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32263,7 +32263,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32282,7 +32282,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32291,17 +32291,17 @@
                           }
                         }
                       },
-                      "DocumentDetails": {
+                      "documentDetails": {
                         "type": "object",
                         "properties": {
-                          "Document": {
+                          "document": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "DocumentType": {
+                                    "documentType": {
                                       "type": "string",
                                       "enum": [
                                         "10",
@@ -32324,10 +32324,10 @@
                                         "180"
                                       ]
                                     },
-                                    "DocumentDate": {
+                                    "documentDate": {
                                       "type": "string"
                                     },
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -32341,17 +32341,17 @@
                                         }
                                       ]
                                     },
-                                    "PlanOnlyIndicator": {
+                                    "planOnlyIndicator": {
                                       "type": "string",
                                       "enum": [
                                         "true",
                                         "false"
                                       ]
                                     },
-                                    "FiledUnder": {
+                                    "filedUnder": {
                                       "type": "string"
                                     },
-                                    "RegisterDescription": {
+                                    "registerDescription": {
                                       "type": "string"
                                     }
                                   }
@@ -32361,7 +32361,7 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "DocumentType": {
+                                  "documentType": {
                                     "type": "string",
                                     "enum": [
                                       "10",
@@ -32384,10 +32384,10 @@
                                       "180"
                                     ]
                                   },
-                                  "DocumentDate": {
+                                  "documentDate": {
                                     "type": "string"
                                   },
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -32401,17 +32401,17 @@
                                       }
                                     ]
                                   },
-                                  "PlanOnlyIndicator": {
+                                  "planOnlyIndicator": {
                                     "type": "string",
                                     "enum": [
                                       "true",
                                       "false"
                                     ]
                                   },
-                                  "FiledUnder": {
+                                  "filedUnder": {
                                     "type": "string"
                                   },
-                                  "RegisterDescription": {
+                                  "registerDescription": {
                                     "type": "string"
                                   }
                                 }
@@ -32420,30 +32420,30 @@
                           }
                         }
                       },
-                      "UnilateralNoticeDetails": {
+                      "unilateralNoticeDetails": {
                         "type": "object",
                         "properties": {
-                          "UnilateralNoticeEntry": {
+                          "unilateralNoticeEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "UnilateralNotice": {
+                                    "unilateralNotice": {
                                       "type": "object",
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": [
                                             "A",
@@ -32452,7 +32452,7 @@
                                             "D"
                                           ]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -32471,25 +32471,25 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
                                     },
-                                    "UnilateralNoticeBeneficiary": {
+                                    "unilateralNoticeBeneficiary": {
                                       "type": "object",
                                       "properties": {
-                                        "EntryNumber": {
+                                        "entryNumber": {
                                           "type": "string"
                                         },
-                                        "EntryText": {
+                                        "entryText": {
                                           "type": "string"
                                         },
-                                        "RegistrationDate": {
+                                        "registrationDate": {
                                           "type": "string",
                                           "format": "date"
                                         },
-                                        "SubRegisterCode": {
+                                        "subRegisterCode": {
                                           "type": "string",
                                           "enum": [
                                             "A",
@@ -32498,7 +32498,7 @@
                                             "D"
                                           ]
                                         },
-                                        "ScheduleCode": {
+                                        "scheduleCode": {
                                           "type": "string",
                                           "enum": [
                                             "0",
@@ -32517,7 +32517,7 @@
                                             "130"
                                           ]
                                         },
-                                        "Infills": {
+                                        "infills": {
                                           "type": "object"
                                         }
                                       }
@@ -32529,20 +32529,20 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "UnilateralNotice": {
+                                  "unilateralNotice": {
                                     "type": "object",
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": [
                                           "A",
@@ -32551,7 +32551,7 @@
                                           "D"
                                         ]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -32570,25 +32570,25 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
                                   },
-                                  "UnilateralNoticeBeneficiary": {
+                                  "unilateralNoticeBeneficiary": {
                                     "type": "object",
                                     "properties": {
-                                      "EntryNumber": {
+                                      "entryNumber": {
                                         "type": "string"
                                       },
-                                      "EntryText": {
+                                      "entryText": {
                                         "type": "string"
                                       },
-                                      "RegistrationDate": {
+                                      "registrationDate": {
                                         "type": "string",
                                         "format": "date"
                                       },
-                                      "SubRegisterCode": {
+                                      "subRegisterCode": {
                                         "type": "string",
                                         "enum": [
                                           "A",
@@ -32597,7 +32597,7 @@
                                           "D"
                                         ]
                                       },
-                                      "ScheduleCode": {
+                                      "scheduleCode": {
                                         "type": "string",
                                         "enum": [
                                           "0",
@@ -32616,7 +32616,7 @@
                                           "130"
                                         ]
                                       },
-                                      "Infills": {
+                                      "infills": {
                                         "type": "object"
                                       }
                                     }
@@ -32627,27 +32627,27 @@
                           }
                         }
                       },
-                      "DeathOfProprietor": {
+                      "deathOfProprietor": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32656,7 +32656,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32675,7 +32675,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32685,17 +32685,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32704,7 +32704,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32723,7 +32723,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32732,27 +32732,27 @@
                           }
                         }
                       },
-                      "DiscountCharge": {
+                      "discountCharge": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32761,7 +32761,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32780,7 +32780,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32790,17 +32790,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32809,7 +32809,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32828,7 +32828,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32837,27 +32837,27 @@
                           }
                         }
                       },
-                      "EquitableCharge": {
+                      "equitableCharge": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32866,7 +32866,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32885,7 +32885,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -32895,17 +32895,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -32914,7 +32914,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -32933,7 +32933,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -32942,27 +32942,27 @@
                           }
                         }
                       },
-                      "NotedCharge": {
+                      "notedCharge": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -32971,7 +32971,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -32990,7 +32990,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -33000,17 +33000,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -33019,7 +33019,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -33038,7 +33038,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -33047,27 +33047,27 @@
                           }
                         }
                       },
-                      "CreditorsNotice": {
+                      "creditorsNotice": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -33076,7 +33076,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -33095,7 +33095,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -33105,17 +33105,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -33124,7 +33124,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -33143,7 +33143,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -33152,27 +33152,27 @@
                           }
                         }
                       },
-                      "UnidentifiedEntry": {
+                      "unidentifiedEntry": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -33181,7 +33181,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -33200,7 +33200,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -33210,17 +33210,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -33229,7 +33229,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -33248,7 +33248,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -33257,27 +33257,27 @@
                           }
                         }
                       },
-                      "CCBIEntry": {
+                      "ccbiEntry": {
                         "type": "object",
                         "properties": {
-                          "EntryDetails": {
+                          "entryDetails": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "type": "string"
                                     },
-                                    "RegistrationDate": {
+                                    "registrationDate": {
                                       "type": "string",
                                       "format": "date"
                                     },
-                                    "SubRegisterCode": {
+                                    "subRegisterCode": {
                                       "type": "string",
                                       "enum": [
                                         "A",
@@ -33286,7 +33286,7 @@
                                         "D"
                                       ]
                                     },
-                                    "ScheduleCode": {
+                                    "scheduleCode": {
                                       "type": "string",
                                       "enum": [
                                         "0",
@@ -33305,7 +33305,7 @@
                                         "130"
                                       ]
                                     },
-                                    "Infills": {
+                                    "infills": {
                                       "type": "object"
                                     }
                                   }
@@ -33315,17 +33315,17 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "type": "string"
                                   },
-                                  "RegistrationDate": {
+                                  "registrationDate": {
                                     "type": "string",
                                     "format": "date"
                                   },
-                                  "SubRegisterCode": {
+                                  "subRegisterCode": {
                                     "type": "string",
                                     "enum": [
                                       "A",
@@ -33334,7 +33334,7 @@
                                       "D"
                                     ]
                                   },
-                                  "ScheduleCode": {
+                                  "scheduleCode": {
                                     "type": "string",
                                     "enum": [
                                       "0",
@@ -33353,7 +33353,7 @@
                                       "130"
                                     ]
                                   },
-                                  "Infills": {
+                                  "infills": {
                                     "type": "object"
                                   }
                                 }
@@ -33364,17 +33364,17 @@
                       }
                     }
                   },
-                  "OCRegisterData": {
+                  "ocRegisterData": {
                     "title": "Official Copy Register Data",
                     "type": "object",
                     "properties": {
-                      "PropertyRegister": {
+                      "propertyRegister": {
                         "type": "object",
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -33390,23 +33390,23 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -33427,16 +33427,16 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -33454,33 +33454,33 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -33501,16 +33501,16 @@
                                         {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -33535,26 +33535,26 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -33575,16 +33575,16 @@
                                       {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -33608,13 +33608,13 @@
                           }
                         }
                       },
-                      "ProprietorshipRegister": {
+                      "proprietorshipRegister": {
                         "type": "object",
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -33630,23 +33630,23 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -33667,16 +33667,16 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -33694,33 +33694,33 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -33741,16 +33741,16 @@
                                         {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -33775,26 +33775,26 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -33815,16 +33815,16 @@
                                       {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",
@@ -33848,13 +33848,13 @@
                           }
                         }
                       },
-                      "ChargesRegister": {
+                      "chargesRegister": {
                         "type": "object",
                         "properties": {
-                          "DistrictDetails": {
+                          "districtDetails": {
                             "type": "object",
                             "properties": {
-                              "EntryText": {
+                              "entryText": {
                                 "oneOf": [
                                   {
                                     "type": "array",
@@ -33870,23 +33870,23 @@
                               }
                             }
                           },
-                          "RegisterEntry": {
+                          "registerEntry": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "EntryNumber": {
+                                    "entryNumber": {
                                       "type": "string"
                                     },
-                                    "EntryDate": {
+                                    "entryDate": {
                                       "type": "string"
                                     },
-                                    "EntryType": {
+                                    "entryType": {
                                       "type": "string"
                                     },
-                                    "EntryText": {
+                                    "entryText": {
                                       "oneOf": [
                                         {
                                           "type": "array",
@@ -33907,16 +33907,16 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "EntryNumber": {
+                                  "entryNumber": {
                                     "type": "string"
                                   },
-                                  "EntryDate": {
+                                  "entryDate": {
                                     "type": "string"
                                   },
-                                  "EntryType": {
+                                  "entryType": {
                                     "type": "string"
                                   },
-                                  "EntryText": {
+                                  "entryText": {
                                     "oneOf": [
                                       {
                                         "type": "array",
@@ -33934,33 +33934,33 @@
                               }
                             ]
                           },
-                          "Schedule": {
+                          "schedule": {
                             "oneOf": [
                               {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "ScheduleType": {
+                                    "scheduleType": {
                                       "type": "string"
                                     },
-                                    "ScheduleEntry": {
+                                    "scheduleEntry": {
                                       "oneOf": [
                                         {
                                           "type": "array",
                                           "items": {
                                             "type": "object",
                                             "properties": {
-                                              "EntryNumber": {
+                                              "entryNumber": {
                                                 "type": "string"
                                               },
-                                              "EntryDate": {
+                                              "entryDate": {
                                                 "type": "string"
                                               },
-                                              "EntryType": {
+                                              "entryType": {
                                                 "type": "string"
                                               },
-                                              "EntryText": {
+                                              "entryText": {
                                                 "oneOf": [
                                                   {
                                                     "type": "array",
@@ -33981,16 +33981,16 @@
                                         {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -34015,26 +34015,26 @@
                               {
                                 "type": "object",
                                 "properties": {
-                                  "ScheduleType": {
+                                  "scheduleType": {
                                     "type": "string"
                                   },
-                                  "ScheduleEntry": {
+                                  "scheduleEntry": {
                                     "oneOf": [
                                       {
                                         "type": "array",
                                         "items": {
                                           "type": "object",
                                           "properties": {
-                                            "EntryNumber": {
+                                            "entryNumber": {
                                               "type": "string"
                                             },
-                                            "EntryDate": {
+                                            "entryDate": {
                                               "type": "string"
                                             },
-                                            "EntryType": {
+                                            "entryType": {
                                               "type": "string"
                                             },
-                                            "EntryText": {
+                                            "entryText": {
                                               "oneOf": [
                                                 {
                                                   "type": "array",
@@ -34055,16 +34055,16 @@
                                       {
                                         "type": "object",
                                         "properties": {
-                                          "EntryNumber": {
+                                          "entryNumber": {
                                             "type": "string"
                                           },
-                                          "EntryDate": {
+                                          "entryDate": {
                                             "type": "string"
                                           },
-                                          "EntryType": {
+                                          "entryType": {
                                             "type": "string"
                                           },
-                                          "EntryText": {
+                                          "entryText": {
                                             "oneOf": [
                                               {
                                                 "type": "array",

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -91,7 +91,7 @@
                 "type": "string"
               },
               "postcode": {
-                "title": "postcode",
+                "title": "Postcode",
                 "type": "string",
                 "minLength": 1
               }
@@ -154,7 +154,7 @@
                   "type": "string"
                 },
                 "postcode": {
-                  "title": "postcode",
+                  "title": "Postcode",
                   "type": "string",
                   "minLength": 1
                 }
@@ -652,7 +652,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "postcode",
+                                "title": "Postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -887,7 +887,7 @@
                                 "type": "string"
                               },
                               "postcode": {
-                                "title": "postcode",
+                                "title": "Postcode",
                                 "type": "string",
                                 "minLength": 1
                               }
@@ -1147,7 +1147,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1235,7 +1235,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1323,7 +1323,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1420,7 +1420,7 @@
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "title": "postcode",
+                                                "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
                                               }
@@ -1682,7 +1682,7 @@
                                                       "type": "string"
                                                     },
                                                     "postcode": {
-                                                      "title": "postcode",
+                                                      "title": "Postcode",
                                                       "type": "string",
                                                       "minLength": 1
                                                     }
@@ -3144,7 +3144,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3232,7 +3232,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3320,7 +3320,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3409,7 +3409,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3506,7 +3506,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3594,7 +3594,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -3821,7 +3821,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "postcode",
+                                                          "title": "Postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4080,7 +4080,7 @@
                                                           "type": "string"
                                                         },
                                                         "postcode": {
-                                                          "title": "postcode",
+                                                          "title": "Postcode",
                                                           "type": "string",
                                                           "minLength": 1
                                                         }
@@ -4264,7 +4264,7 @@
                                                     "type": "string"
                                                   },
                                                   "postcode": {
-                                                    "title": "postcode",
+                                                    "title": "Postcode",
                                                     "type": "string",
                                                     "minLength": 1
                                                   }
@@ -21950,7 +21950,7 @@
                               "type": "string"
                             },
                             "postcode": {
-                              "title": "postcode",
+                              "title": "Postcode",
                               "type": "string",
                               "minLength": 1
                             }

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -32,7 +32,7 @@
         "title": "Participant Details",
         "properties": {
           "name": {
-            "title": "Name",
+            "title": "name",
             "type": "object",
             "properties": {
               "firstName": {
@@ -624,7 +624,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "title": "Name"
+                        "title": "name"
                       },
                       "contact": {
                         "type": "object",
@@ -810,7 +810,7 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "title": "Name",
+                        "title": "name",
                         "type": "string"
                       },
                       "transportType": {
@@ -854,7 +854,7 @@
                     "title": "Healthcare service",
                     "properties": {
                       "name": {
-                        "title": "Name",
+                        "title": "name",
                         "type": "string"
                       },
                       "typeOfHealthCare": {
@@ -10431,7 +10431,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -11687,7 +11687,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -12743,7 +12743,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -13180,7 +13180,7 @@
                             "type": "object",
                             "properties": {
                               "itemName": {
-                                "title": "Name",
+                                "title": "name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -13613,7 +13613,7 @@
                             "type": "object",
                             "properties": {
                               "itemName": {
-                                "title": "Name",
+                                "title": "name",
                                 "type": "string"
                               },
                               "isIncludedOrExcluded": {
@@ -14049,7 +14049,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -14483,7 +14483,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15186,7 +15186,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {
@@ -15631,7 +15631,7 @@
                         "type": "object",
                         "properties": {
                           "itemName": {
-                            "title": "Name",
+                            "title": "name",
                             "type": "string"
                           },
                           "isIncludedOrExcluded": {

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -26424,7 +26424,7 @@
                             "type": "string",
                             "enum": [
                               "2",
-                              "moreThan2"
+                              "MoreThan2"
                             ]
                           },
                           "entryDetails": {

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -2121,38 +2121,38 @@
             "details": {}
           },
           "predictedCoverage": {
-            "EEVoiceOutdoor": {},
-            "EEVoiceOutdoorNo4g": {},
-            "EEVoiceIndoor": {},
-            "EEVoiceIndoorNo4g": {},
-            "EEDataOutdoor": {},
-            "EEDataOutdoorNo4g": {},
-            "EEDataIndoor": {},
-            "EEDataIndoorNo4g": {},
-            "H3VoiceOutdoor": {},
-            "H3VoiceOutdoorNo4g": {},
-            "H3VoiceIndoor": {},
-            "H3VoiceIndoorNo4g": {},
-            "H3DataOutdoor": {},
-            "H3DataOutdoorNo4g": {},
-            "H3DataIndoor": {},
-            "H3DataIndoorNo4g": {},
-            "TFVoiceOutdoor": {},
-            "TFVoiceOutdoorNo4g": {},
-            "TFVoiceIndoor": {},
-            "TFVoiceIndoorNo4g": {},
-            "TFDataOutdoor": {},
-            "TFDataOutdoorNo4g": {},
-            "TFDataIndoor": {},
-            "TFDataIndoorNo4g": {},
-            "VOVoiceOutdoor": {},
-            "VOVoiceOutdoorNo4g": {},
-            "VOVoiceIndoor": {},
-            "VOVoiceIndoorNo4g": {},
-            "VODataOutdoor": {},
-            "VODataOutdoorNo4g": {},
-            "VODataIndoor": {},
-            "VODataIndoorNo4g": {}
+            "eeVoiceOutdoor": {},
+            "eeVoiceOutdoorNo4g": {},
+            "eeVoiceIndoor": {},
+            "eeVoiceIndoorNo4g": {},
+            "eeDataOutdoor": {},
+            "eeDataOutdoorNo4g": {},
+            "eeDataIndoor": {},
+            "eeDataIndoorNo4g": {},
+            "h3VoiceOutdoor": {},
+            "h3VoiceOutdoorNo4g": {},
+            "h3VoiceIndoor": {},
+            "h3VoiceIndoorNo4g": {},
+            "h3DataOutdoor": {},
+            "h3DataOutdoorNo4g": {},
+            "h3DataIndoor": {},
+            "h3DataIndoorNo4g": {},
+            "tfVoiceOutdoor": {},
+            "tfVoiceOutdoorNo4g": {},
+            "tfVoiceIndoor": {},
+            "tfVoiceIndoorNo4g": {},
+            "tfDataOutdoor": {},
+            "tfDataOutdoorNo4g": {},
+            "tfDataIndoor": {},
+            "tfDataIndoorNo4g": {},
+            "voVoiceOutdoor": {},
+            "voVoiceOutdoorNo4g": {},
+            "voVoiceIndoor": {},
+            "voVoiceIndoorNo4g": {},
+            "voDataOutdoor": {},
+            "voDataOutdoorNo4g": {},
+            "voDataIndoor": {},
+            "voDataIndoorNo4g": {}
           }
         }
       },
@@ -2741,57 +2741,57 @@
     },
     "localSearches": {
       "localLandCharges": {
-        "HMLRReference": {},
-        "OriginatingAuthority": {},
-        "AuthorityReference": {},
-        "CreationDate": {},
-        "RegistrationDate": {},
-        "Category": {},
-        "ChargeSubCategory": {},
-        "Law": {},
-        "LegalDocument": {},
-        "Location": {
+        "hmlrReference": {},
+        "originatingAuthority": {},
+        "authorityReference": {},
+        "creationDate": {},
+        "registrationDate": {},
+        "category": {},
+        "chargeSubCategory": {},
+        "law": {},
+        "legalDocument": {},
+        "location": {
           "line1": {},
           "line2": {},
-          "Postcode": {}
+          "postcode": {}
         },
-        "LocationDominantBuilding": {
+        "locationDominantBuilding": {
           "line1": {},
           "line2": {},
-          "Postcode": {}
+          "postcode": {}
         },
-        "Description": {},
-        "SourceOfInformation": {},
-        "AvailableDocument": {
-          "Document": {},
-          "StartDate": {},
-          "EndDate": {}
+        "description": {},
+        "sourceOfInformation": {},
+        "availableDocument": {
+          "document": {},
+          "startDate": {},
+          "endDate": {}
         },
-        "InterestInLand": {},
-        "ApplicantName": {},
-        "ApplicantAddress": {
+        "interestInLand": {},
+        "applicantName": {},
+        "applicantAddress": {
           "line1": {},
           "line2": {},
-          "Postcode": {},
-          "Country": {}
+          "postcode": {},
+          "country": {}
         },
-        "ServientLandDevelopment": {
-          "Height": {},
-          "CoversAllOrPartOfExtent": {}
+        "servientLandDevelopment": {
+          "height": {},
+          "coversAllOrPartOfExtent": {}
         },
-        "Amount": {},
-        "InterestRate": {},
-        "LandSold": {},
-        "WorksDone": {},
-        "AdvancePayment": {},
-        "TotalCompensation": {},
-        "AgreedOrEstimated": {},
-        "Adjoining": {},
-        "OtherData": {
-          "DataLabel": {},
-          "Data": {}
+        "amount": {},
+        "interestRate": {},
+        "landSold": {},
+        "worksDone": {},
+        "advancePayment": {},
+        "totalCompensation": {},
+        "agreedOrEstimated": {},
+        "adjoining": {},
+        "otherData": {
+          "dataLabel": {},
+          "data": {}
         },
-        "ChargeExtent": {}
+        "chargeExtent": {}
       },
       "localAuthoritySearches": {
         "planningAndBuildingRegulations": {
@@ -3303,652 +3303,652 @@
       "titleNumber": {},
       "titleExtents": {},
       "registerExtract": {
-        "OCSummaryData": {
-          "OfficialCopyDateTime": {},
-          "EditionDate": {},
-          "PricePaidEntry": {
-            "MultipleTitleIndicator": {},
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+        "ocSummaryData": {
+          "officialCopyDateTime": {},
+          "editionDate": {},
+          "pricePaidEntry": {
+            "multipleTitleIndicator": {},
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "PropertyAddress": {
-            "PostcodeZone": {
-              "Postcode": {}
+          "propertyAddress": {
+            "postcodeZone": {
+              "postcode": {}
             },
-            "AddressLine": {
-              "Line": {}
+            "addressLine": {
+              "line": {}
             }
           },
-          "Title": {
-            "TitleNumber": {},
-            "ClassOfTitleCode": {},
-            "CommonholdIndicator": {},
-            "TitleRegistrationDetails": {
-              "DistrictName": {},
-              "AdministrativeArea": {},
-              "LandRegistryOfficeName": {},
-              "LatestEditionDate": {},
-              "PostcodeZone": {
-                "Postcode": {}
+          "title": {
+            "titleNumber": {},
+            "classOfTitleCode": {},
+            "commonholdIndicator": {},
+            "titleRegistrationDetails": {
+              "districtName": {},
+              "administrativeArea": {},
+              "landRegistryOfficeName": {},
+              "latestEditionDate": {},
+              "postcodeZone": {
+                "postcode": {}
               },
-              "RegistrationDate": {}
+              "registrationDate": {}
             }
           },
-          "RegisterEntryIndicators": {
-            "AgreedNoticeIndicator": {},
-            "BankruptcyIndicator": {},
-            "CautionIndicator": {},
-            "CCBIIndicator": {},
-            "ChargeeIndicator": {},
-            "ChargeIndicator": {},
-            "ChargeRelatedRestrictionIndicator": {},
-            "ChargeRestrictionIndicator": {},
-            "CreditorsNoticeIndicator": {},
-            "DeathOfProprietorIndicator": {},
-            "DeedOfPostponementIndicator": {},
-            "DiscountChargeIndicator": {},
-            "EquitableChargeIndicator": {},
-            "GreenOutEntryIndicator": {},
-            "HomeRightsChangeOfAddressIndicator": {},
-            "HomeRightsIndicator": {},
-            "LeaseHoldTitleIndicator": {},
-            "MultipleChargeIndicator": {},
-            "NonChargeRestrictionIndicator": {},
-            "NotedChargeIndicator": {},
-            "PricePaidIndicator": {},
-            "PropertyDescriptionNotesIndicator": {},
-            "RentChargeIndicator": {},
-            "RightOfPreEmptionIndicator": {},
-            "ScheduleOfLeasesIndicator": {},
-            "SubChargeIndicator": {},
-            "UnidentifiedEntryIndicator": {},
-            "UnilateralNoticeBeneficiaryIndicator": {},
-            "UnilateralNoticeIndicator": {},
-            "VendorsLienIndicator": {}
+          "registerEntryIndicators": {
+            "agreedNoticeIndicator": {},
+            "bankruptcyIndicator": {},
+            "cautionIndicator": {},
+            "ccbiIndicator": {},
+            "chargeeIndicator": {},
+            "chargeIndicator": {},
+            "chargeRelatedRestrictionIndicator": {},
+            "chargeRestrictionIndicator": {},
+            "creditorsNoticeIndicator": {},
+            "deathOfProprietorIndicator": {},
+            "deedOfPostponementIndicator": {},
+            "discountChargeIndicator": {},
+            "equitableChargeIndicator": {},
+            "greenOutEntryIndicator": {},
+            "homeRightsChangeOfAddressIndicator": {},
+            "homeRightsIndicator": {},
+            "leaseHoldTitleIndicator": {},
+            "multipleChargeIndicator": {},
+            "nonChargeRestrictionIndicator": {},
+            "notedChargeIndicator": {},
+            "pricePaidIndicator": {},
+            "propertyDescriptionNotesIndicator": {},
+            "rentChargeIndicator": {},
+            "rightOfPreEmptionIndicator": {},
+            "scheduleOfLeasesIndicator": {},
+            "subChargeIndicator": {},
+            "unidentifiedEntryIndicator": {},
+            "unilateralNoticeBeneficiaryIndicator": {},
+            "unilateralNoticeIndicator": {},
+            "vendorsLienIndicator": {}
           },
-          "Proprietorship": {
-            "CurrentProprietorshipDate": {},
-            "CautionerParty": {
-              "PrivateIndividual": {
-                "Name": {
-                  "ForenamesName": {},
-                  "SurnameName": {}
+          "proprietorship": {
+            "currentProprietorshipDate": {},
+            "cautionerParty": {
+              "privateIndividual": {
+                "name": {
+                  "forenamesName": {},
+                  "surnameName": {}
                 },
-                "Alias": {
-                  "ForenamesName": {},
-                  "SurnameName": {}
+                "alias": {
+                  "forenamesName": {},
+                  "surnameName": {}
                 }
               },
-              "Organization": {
-                "Name": {},
-                "CompanyRegistrationNumber": {}
+              "organization": {
+                "name": {},
+                "companyRegistrationNumber": {}
               },
-              "Address": {
-                "PostcodeZone": {
-                  "Postcode": {}
+              "address": {
+                "postcodeZone": {
+                  "postcode": {}
                 },
-                "AddressLine": {
-                  "Line": {}
+                "addressLine": {
+                  "line": {}
                 }
               },
-              "CharityDetails": {
-                "CharityName": {},
-                "CharityAddress": {
-                  "PostcodeZone": {
-                    "Postcode": {}
+              "charityDetails": {
+                "charityName": {},
+                "charityAddress": {
+                  "postcodeZone": {
+                    "postcode": {}
                   },
-                  "AddressLine": {
-                    "Line": {}
+                  "addressLine": {
+                    "line": {}
                   }
                 },
-                "CharityType": {
-                  "Value": {}
+                "charityType": {
+                  "value": {}
                 }
               },
-              "TradingName": {},
-              "PartyNumber": {},
-              "PartyDescription": {}
+              "tradingName": {},
+              "partyNumber": {},
+              "partyDescription": {}
             },
-            "RegisteredProprietorParty": {
-              "PrivateIndividual": {
-                "Name": {
-                  "ForenamesName": {},
-                  "SurnameName": {}
+            "registeredProprietorParty": {
+              "privateIndividual": {
+                "name": {
+                  "forenamesName": {},
+                  "surnameName": {}
                 },
-                "Alias": {
-                  "ForenamesName": {},
-                  "SurnameName": {}
+                "alias": {
+                  "forenamesName": {},
+                  "surnameName": {}
                 }
               },
-              "Organization": {
-                "Name": {},
-                "CompanyRegistrationNumber": {}
+              "organization": {
+                "name": {},
+                "companyRegistrationNumber": {}
               },
-              "Address": {
-                "PostcodeZone": {
-                  "Postcode": {}
+              "address": {
+                "postcodeZone": {
+                  "postcode": {}
                 },
-                "AddressLine": {
-                  "Line": {}
+                "addressLine": {
+                  "line": {}
                 }
               },
-              "CharityDetails": {
-                "CharityName": {},
-                "CharityAddress": {
-                  "PostcodeZone": {
-                    "Postcode": {}
+              "charityDetails": {
+                "charityName": {},
+                "charityAddress": {
+                  "postcodeZone": {
+                    "postcode": {}
                   },
-                  "AddressLine": {
-                    "Line": {}
+                  "addressLine": {
+                    "line": {}
                   }
                 },
-                "CharityType": {
-                  "Value": {}
+                "charityType": {
+                  "value": {}
                 }
               },
-              "TradingName": {},
-              "PartyNumber": {},
-              "PartyDescription": {}
+              "tradingName": {},
+              "partyNumber": {},
+              "partyDescription": {}
             }
           },
-          "Lease": {
-            "LeaseEntry": {
-              "LeaseTerm": {},
-              "LeaseDate": {},
+          "lease": {
+            "leaseEntry": {
+              "leaseTerm": {},
+              "leaseDate": {},
               "Rent": {},
-              "LeaseParty": {
-                "PrivateIndividual": {
-                  "Name": {
-                    "ForenamesName": {},
-                    "SurnameName": {}
+              "leaseParty": {
+                "privateIndividual": {
+                  "name": {
+                    "forenamesName": {},
+                    "surnameName": {}
                   },
-                  "Alias": {
-                    "ForenamesName": {},
-                    "SurnameName": {}
+                  "alias": {
+                    "forenamesName": {},
+                    "surnameName": {}
                   }
                 },
-                "Organization": {
-                  "Name": {},
-                  "CompanyRegistrationNumber": {}
+                "organization": {
+                  "name": {},
+                  "companyRegistrationNumber": {}
                 },
-                "Address": {
-                  "PostcodeZone": {
-                    "Postcode": {}
+                "address": {
+                  "postcodeZone": {
+                    "postcode": {}
                   },
-                  "AddressLine": {
-                    "Line": {}
+                  "addressLine": {
+                    "line": {}
                   }
                 },
-                "CharityDetails": {
-                  "CharityName": {},
-                  "CharityAddress": {
-                    "PostcodeZone": {
-                      "Postcode": {}
+                "charityDetails": {
+                  "charityName": {},
+                  "charityAddress": {
+                    "postcodeZone": {
+                      "postcode": {}
                     },
-                    "AddressLine": {
-                      "Line": {}
+                    "addressLine": {
+                      "line": {}
                     }
                   },
-                  "CharityType": {
-                    "Value": {}
+                  "charityType": {
+                    "value": {}
                   }
                 },
-                "TradingName": {},
-                "PartyNumber": {},
-                "PartyDescription": {}
+                "tradingName": {},
+                "partyNumber": {},
+                "partyDescription": {}
               },
-              "EntryDetails": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+              "entryDetails": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               }
             }
           },
-          "RestrictionDetails": {
-            "RestrictionEntry": {
-              "ChargeRelatedRestriction": {
-                "RestrictionTypeCode": {},
-                "ChargeID": {},
-                "EntryDetails": {
-                  "EntryNumber": {},
-                  "EntryText": {},
-                  "RegistrationDate": {},
-                  "SubRegisterCode": {},
-                  "ScheduleCode": {},
-                  "Infills": {}
+          "restrictionDetails": {
+            "restrictionEntry": {
+              "chargeRelatedRestriction": {
+                "restrictionTypeCode": {},
+                "chargeID": {},
+                "entryDetails": {
+                  "entryNumber": {},
+                  "entryText": {},
+                  "registrationDate": {},
+                  "subRegisterCode": {},
+                  "scheduleCode": {},
+                  "infills": {}
                 }
               },
-              "ChargeRestriction": {
-                "RestrictionTypeCode": {},
-                "ChargeID": {},
-                "EntryDetails": {
-                  "EntryNumber": {},
-                  "EntryText": {},
-                  "RegistrationDate": {},
-                  "SubRegisterCode": {},
-                  "ScheduleCode": {},
-                  "Infills": {}
+              "chargeRestriction": {
+                "restrictionTypeCode": {},
+                "chargeID": {},
+                "entryDetails": {
+                  "entryNumber": {},
+                  "entryText": {},
+                  "registrationDate": {},
+                  "subRegisterCode": {},
+                  "scheduleCode": {},
+                  "infills": {}
                 }
               },
-              "NonChargeRestriction": {
-                "RestrictionTypeCode": {},
-                "ChargeID": {},
-                "EntryDetails": {
-                  "EntryNumber": {},
-                  "EntryText": {},
-                  "RegistrationDate": {},
-                  "SubRegisterCode": {},
-                  "ScheduleCode": {},
-                  "Infills": {}
+              "nonChargeRestriction": {
+                "restrictionTypeCode": {},
+                "chargeID": {},
+                "entryDetails": {
+                  "entryNumber": {},
+                  "entryText": {},
+                  "registrationDate": {},
+                  "subRegisterCode": {},
+                  "scheduleCode": {},
+                  "infills": {}
                 }
               }
             }
           },
-          "Charge": {
-            "ChargeEntry": {
-              "ChargeID": {},
-              "ChargeDate": {},
-              "RegisteredCharge": {
-                "MultipleTitleIndicator": {},
-                "EntryDetails": {
-                  "EntryNumber": {},
-                  "EntryText": {},
-                  "RegistrationDate": {},
-                  "SubRegisterCode": {},
-                  "ScheduleCode": {},
-                  "Infills": {}
+          "charge": {
+            "chargeEntry": {
+              "chargeID": {},
+              "chargeDate": {},
+              "registeredCharge": {
+                "multipleTitleIndicator": {},
+                "entryDetails": {
+                  "entryNumber": {},
+                  "entryText": {},
+                  "registrationDate": {},
+                  "subRegisterCode": {},
+                  "scheduleCode": {},
+                  "infills": {}
                 }
               },
-              "ChargeProprietor": {
-                "ChargeeParty": {
-                  "PrivateIndividual": {
-                    "Name": {
-                      "ForenamesName": {},
-                      "SurnameName": {}
+              "chargeProprietor": {
+                "chargeeParty": {
+                  "privateIndividual": {
+                    "name": {
+                      "forenamesName": {},
+                      "surnameName": {}
                     },
-                    "Alias": {
-                      "ForenamesName": {},
-                      "SurnameName": {}
+                    "alias": {
+                      "forenamesName": {},
+                      "surnameName": {}
                     }
                   },
-                  "Organization": {
-                    "Name": {},
-                    "CompanyRegistrationNumber": {}
+                  "organization": {
+                    "name": {},
+                    "companyRegistrationNumber": {}
                   },
-                  "Address": {
-                    "PostcodeZone": {
-                      "Postcode": {}
+                  "address": {
+                    "postcodeZone": {
+                      "postcode": {}
                     },
-                    "AddressLine": {
-                      "Line": {}
+                    "addressLine": {
+                      "line": {}
                     }
                   },
-                  "CharityDetails": {
-                    "CharityName": {},
-                    "CharityAddress": {
-                      "PostcodeZone": {
-                        "Postcode": {}
+                  "charityDetails": {
+                    "charityName": {},
+                    "charityAddress": {
+                      "postcodeZone": {
+                        "postcode": {}
                       },
-                      "AddressLine": {
-                        "Line": {}
+                      "addressLine": {
+                        "line": {}
                       }
                     },
-                    "CharityType": {
-                      "Value": {}
+                    "charityType": {
+                      "value": {}
                     }
                   },
-                  "TradingName": {},
-                  "PartyNumber": {},
-                  "PartyDescription": {}
+                  "tradingName": {},
+                  "partyNumber": {},
+                  "partyDescription": {}
                 },
-                "EntryDetails": {
-                  "EntryNumber": {},
-                  "EntryText": {},
-                  "RegistrationDate": {},
-                  "SubRegisterCode": {},
-                  "ScheduleCode": {},
-                  "Infills": {}
+                "entryDetails": {
+                  "entryNumber": {},
+                  "entryText": {},
+                  "registrationDate": {},
+                  "subRegisterCode": {},
+                  "scheduleCode": {},
+                  "infills": {}
                 }
               },
-              "SubCharge": {
-                "ChargeDate": {},
-                "RegisteredCharge": {
-                  "MultipleTitleIndicator": {},
-                  "EntryDetails": {
-                    "EntryNumber": {},
-                    "EntryText": {},
-                    "RegistrationDate": {},
-                    "SubRegisterCode": {},
-                    "ScheduleCode": {},
-                    "Infills": {}
+              "subCharge": {
+                "chargeDate": {},
+                "registeredCharge": {
+                  "multipleTitleIndicator": {},
+                  "entryDetails": {
+                    "entryNumber": {},
+                    "entryText": {},
+                    "registrationDate": {},
+                    "subRegisterCode": {},
+                    "scheduleCode": {},
+                    "infills": {}
                   }
                 },
-                "ChargeProprietor": {
-                  "ChargeeParty": {
-                    "PrivateIndividual": {
-                      "Name": {
-                        "ForenamesName": {},
-                        "SurnameName": {}
+                "chargeProprietor": {
+                  "chargeeParty": {
+                    "privateIndividual": {
+                      "name": {
+                        "forenamesName": {},
+                        "surnameName": {}
                       },
-                      "Alias": {
-                        "ForenamesName": {},
-                        "SurnameName": {}
+                      "alias": {
+                        "forenamesName": {},
+                        "surnameName": {}
                       }
                     },
-                    "Organization": {
-                      "Name": {},
-                      "CompanyRegistrationNumber": {}
+                    "organization": {
+                      "name": {},
+                      "companyRegistrationNumber": {}
                     },
-                    "Address": {
-                      "PostcodeZone": {
-                        "Postcode": {}
+                    "address": {
+                      "postcodeZone": {
+                        "postcode": {}
                       },
-                      "AddressLine": {
-                        "Line": {}
+                      "addressLine": {
+                        "line": {}
                       }
                     },
-                    "CharityDetails": {
-                      "CharityName": {},
-                      "CharityAddress": {
-                        "PostcodeZone": {
-                          "Postcode": {}
+                    "charityDetails": {
+                      "charityName": {},
+                      "charityAddress": {
+                        "postcodeZone": {
+                          "postcode": {}
                         },
-                        "AddressLine": {
-                          "Line": {}
+                        "addressLine": {
+                          "line": {}
                         }
                       },
-                      "CharityType": {
-                        "Value": {}
+                      "charityType": {
+                        "value": {}
                       }
                     },
-                    "TradingName": {},
-                    "PartyNumber": {},
-                    "PartyDescription": {}
+                    "tradingName": {},
+                    "partyNumber": {},
+                    "partyDescription": {}
                   },
-                  "EntryDetails": {
-                    "EntryNumber": {},
-                    "EntryText": {},
-                    "RegistrationDate": {},
-                    "SubRegisterCode": {},
-                    "ScheduleCode": {},
-                    "Infills": {}
+                  "entryDetails": {
+                    "entryNumber": {},
+                    "entryText": {},
+                    "registrationDate": {},
+                    "subRegisterCode": {},
+                    "scheduleCode": {},
+                    "infills": {}
                   }
                 }
               }
             }
           },
-          "AgreedNotice": {
-            "AgreedNoticeEntry": {
-              "AgreedNoticeType": {},
-              "EntryDetails": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+          "agreedNotice": {
+            "agreedNoticeEntry": {
+              "agreedNoticeType": {},
+              "entryDetails": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               }
             }
           },
-          "Bankruptcy": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "bankruptcy": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "Caution": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "caution": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "DeedOfPostponement": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "deedOfPostponement": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "GreenOutEntry": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "greenOutEntry": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "HomeRights": {
-            "HomeRightsEntry": {
-              "ChangeOfAddressIndicator": {},
-              "HomeRightsEntryDetails": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+          "homeRights": {
+            "homeRightsEntry": {
+              "changeOfAddressIndicator": {},
+              "homeRightsEntryDetails": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               },
-              "ChangeOfAddressEntryDetails": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+              "changeOfAddressEntryDetails": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               }
             }
           },
-          "RentCharge": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "rentCharge": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "VendorsLien": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "vendorsLien": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "RightOfPreEmption": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "rightOfPreEmption": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "DocumentDetails": {
-            "Document": {
-              "DocumentType": {},
-              "DocumentDate": {},
-              "EntryNumber": {},
-              "PlanOnlyIndicator": {},
-              "FiledUnder": {},
-              "RegisterDescription": {}
+          "documentDetails": {
+            "document": {
+              "documentType": {},
+              "documentDate": {},
+              "entryNumber": {},
+              "planOnlyIndicator": {},
+              "filedUnder": {},
+              "registerDescription": {}
             }
           },
-          "UnilateralNoticeDetails": {
-            "UnilateralNoticeEntry": {
-              "UnilateralNotice": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+          "unilateralNoticeDetails": {
+            "unilateralNoticeEntry": {
+              "unilateralNotice": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               },
-              "UnilateralNoticeBeneficiary": {
-                "EntryNumber": {},
-                "EntryText": {},
-                "RegistrationDate": {},
-                "SubRegisterCode": {},
-                "ScheduleCode": {},
-                "Infills": {}
+              "unilateralNoticeBeneficiary": {
+                "entryNumber": {},
+                "entryText": {},
+                "registrationDate": {},
+                "subRegisterCode": {},
+                "scheduleCode": {},
+                "infills": {}
               }
             }
           },
-          "DeathOfProprietor": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "deathOfProprietor": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "DiscountCharge": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "discountCharge": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "EquitableCharge": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "equitableCharge": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "NotedCharge": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "notedCharge": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "CreditorsNotice": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "creditorsNotice": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "UnidentifiedEntry": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "unidentifiedEntry": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           },
-          "CCBIEntry": {
-            "EntryDetails": {
-              "EntryNumber": {},
-              "EntryText": {},
-              "RegistrationDate": {},
-              "SubRegisterCode": {},
-              "ScheduleCode": {},
-              "Infills": {}
+          "ccbiEntry": {
+            "entryDetails": {
+              "entryNumber": {},
+              "entryText": {},
+              "registrationDate": {},
+              "subRegisterCode": {},
+              "scheduleCode": {},
+              "infills": {}
             }
           }
         },
-        "OCRegisterData": {
-          "PropertyRegister": {
-            "DistrictDetails": {
-              "EntryText": {}
+        "ocRegisterData": {
+          "propertyRegister": {
+            "districtDetails": {
+              "entryText": {}
             },
-            "RegisterEntry": {
-              "EntryNumber": {},
-              "EntryDate": {},
-              "EntryType": {},
-              "EntryText": {}
+            "registerEntry": {
+              "entryNumber": {},
+              "entryDate": {},
+              "entryType": {},
+              "entryText": {}
             },
-            "Schedule": {
-              "ScheduleType": {},
-              "ScheduleEntry": {
-                "EntryNumber": {},
-                "EntryDate": {},
-                "EntryType": {},
-                "EntryText": {}
+            "schedule": {
+              "scheduleType": {},
+              "scheduleEntry": {
+                "entryNumber": {},
+                "entryDate": {},
+                "entryType": {},
+                "entryText": {}
               }
             }
           },
-          "ProprietorshipRegister": {
-            "DistrictDetails": {
-              "EntryText": {}
+          "proprietorshipRegister": {
+            "districtDetails": {
+              "entryText": {}
             },
-            "RegisterEntry": {
-              "EntryNumber": {},
-              "EntryDate": {},
-              "EntryType": {},
-              "EntryText": {}
+            "registerEntry": {
+              "entryNumber": {},
+              "entryDate": {},
+              "entryType": {},
+              "entryText": {}
             },
-            "Schedule": {
-              "ScheduleType": {},
-              "ScheduleEntry": {
-                "EntryNumber": {},
-                "EntryDate": {},
-                "EntryType": {},
-                "EntryText": {}
+            "schedule": {
+              "scheduleType": {},
+              "scheduleEntry": {
+                "entryNumber": {},
+                "entryDate": {},
+                "entryType": {},
+                "entryText": {}
               }
             }
           },
-          "ChargesRegister": {
-            "DistrictDetails": {
-              "EntryText": {}
+          "chargesRegister": {
+            "districtDetails": {
+              "entryText": {}
             },
-            "RegisterEntry": {
-              "EntryNumber": {},
-              "EntryDate": {},
-              "EntryType": {},
-              "EntryText": {}
+            "registerEntry": {
+              "entryNumber": {},
+              "entryDate": {},
+              "entryType": {},
+              "entryText": {}
             },
-            "Schedule": {
-              "ScheduleType": {},
-              "ScheduleEntry": {
-                "EntryNumber": {},
-                "EntryDate": {},
-                "EntryType": {},
-                "EntryText": {}
+            "schedule": {
+              "scheduleType": {},
+              "scheduleEntry": {
+                "entryNumber": {},
+                "entryDate": {},
+                "entryType": {},
+                "entryText": {}
               }
             }
           }

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -2760,7 +2760,6 @@
           "line2": {},
           "postcode": {}
         },
-        "description": {},
         "sourceOfInformation": {},
         "availableDocument": {
           "document": {},
@@ -3323,21 +3322,6 @@
             },
             "addressLine": {
               "line": {}
-            }
-          },
-          "title": {
-            "titleNumber": {},
-            "classOfTitleCode": {},
-            "commonholdIndicator": {},
-            "titleRegistrationDetails": {
-              "districtName": {},
-              "administrativeArea": {},
-              "landRegistryOfficeName": {},
-              "latestEditionDate": {},
-              "postcodeZone": {
-                "postcode": {}
-              },
-              "registrationDate": {}
             }
           },
           "registerEntryIndicators": {

--- a/src/tests/v3/transactionSchema.test.js
+++ b/src/tests/v3/transactionSchema.test.js
@@ -108,8 +108,8 @@ test("correctly gets a subschema through an arrays element", () => {
     schemaId
   );
   expect(Object.keys(subschema.properties)).toEqual([
-    "OCSummaryData",
-    "OCRegisterData",
+    "ocSummaryData",
+    "ocRegisterData",
   ]);
 });
 
@@ -155,14 +155,14 @@ test("correctly gets yet, yet, yet another subschema through a second item depen
 
 test("correctly gets yes another subschema but through a non-baspi oneOf structure", () => {
   const subschema = getSubschema(
-    "/propertyPack/titlesToBeSold/0/registerExtract/OCSummaryData/RestrictionDetails/RestrictionEntry/ChargeRestriction/EntryDetails/EntryText"
+    "/propertyPack/titlesToBeSold/0/registerExtract/ocSummaryData/restrictionDetails/restrictionEntry/chargeRestriction/entryDetails/entryText"
   );
   expect(subschema).toEqual({ type: "string" });
 });
 
 test("correctly gets yes another subschema but through a non-baspi oneOf structure with array option", () => {
   const subschema = getSubschema(
-    "/propertyPack/titlesToBeSold/0/registerExtract/OCSummaryData/RestrictionDetails/RestrictionEntry/0/ChargeRestriction/EntryDetails/EntryText"
+    "/propertyPack/titlesToBeSold/0/registerExtract/ocSummaryData/restrictionDetails/restrictionEntry/0/chargeRestriction/entryDetails/entryText"
   );
   expect(subschema).toEqual({ type: "string" });
 });
@@ -333,14 +333,14 @@ test("correctly gets titles across schemas, arrays and non-existient title prope
   expect(
     getTitleAtPath(
       v3TransactionSchema,
-      "/propertyPack/titlesToBeSold/0/registerExtract/OCSummaryData/PropertyAddress"
+      "/propertyPack/titlesToBeSold/0/registerExtract/ocSummaryData/propertyAddress"
     )
   ).toBe("Property address");
 
   expect(
     getTitleAtPath(
       v3TransactionSchema,
-      "/propertyPack/titlesToBeSold/0/registerExtract/OCSummaryData/InvalidProp"
+      "/propertyPack/titlesToBeSold/0/registerExtract/ocSummaryData/invalidProp"
     )
   ).toBe(undefined);
 


### PR DESCRIPTION
Rebased version of #135 

---

## What:
Transform all keys to camelCase. This change streamlines the PDTF URI structure, offering enhanced consistency, interoperability, and independence from provider-specific case implementations.

## Why:
- **Interoperability**: Enhance compatibility for consuming organizations, enabling seamless serialization of schema data in a uniform manner.
- **Standardization**: Ensure consistent casing across all PDTF URIs, promoting clarity and ease of use:
Before: 
`/propertyPack/titlesToBeSold/0/registerExtract/OCSummaryData/RestrictionDetails/RestrictionEntry/ChargeRestriction/EntryDetails/EntryText`
After: 
`/propertyPack/titlesToBeSold/0/registerExtract/ocSummaryData/restrictionDetails/restrictionEntry/chargeRestriction/entryDetails/entryText`
- **Decoupled Design**: Remove the dependency of the schema on providers' case implementation. All PDTF claims must now adhere to the convention of serializing keys in camelCase.


resolves #133

To Do:
Update documentation and provide guidance to reflect the new camelCase key convention. Ensure users are informed about the standardized approach for improved integration.