### PR TITLE
Move sellersCapacity to participant

### DIFF
--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -13,6 +13,7 @@
       "email": "peter@theseller.com",
       "address": { "line1": "47 Park Road", "postcode": "AL3 5AF" },
       "role": "Seller",
+      "sellersCapacity": { "capacity": "Legal Owner" },
       "externalIds": { "MoveReady": "123434" }
     },
     {
@@ -566,7 +567,6 @@
         }
       ]
     },
-    "sellersCapacity": { "capacity": "Legal Owner" },
     "legalBoundaries": {
       "partOutsideLegalOwnership": {
         "yesNo": "No"

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -53,77 +53,6 @@
               "preferredName": {
                 "title": "Preferred name / known as",
                 "type": "string"
-              },
-              "sellersCapacity": {
-                "baspiRef": "B1.3",
-                "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
-                "piqRef": "B1.3.1",
-                "title": "Capacity in which the Seller sells",
-                "type": "object",
-                "baspiRequired": ["capacity"],
-                "properties": {
-                  "capacity": {
-                    "baspiRef": "B1.3.1",
-                    "type": "string",
-                    "title": "",
-                    "enum": [
-                      "Legal Owner",
-                      "Personal Representative for a Deceased Owner",
-                      "Under Power of Attorney",
-                      "Mortgagee in Possession",
-                      "Other"
-                    ]
-                  }
-                },
-                "discriminator": {
-                  "propertyName": "capacity"
-                },
-                "oneOf": [
-                  {
-                    "properties": {
-                      "capacity": {
-                        "enum": ["Legal Owner", "Mortgagee in Possession"]
-                      },
-                      "sellersCapacityDetails": {
-                        "baspiRef": "B1.3.2",
-                        "rdsRef": "Participants/OtherDocumentation",
-                        "title": "Please provide details if applicable",
-                        "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
-                        "type": "string"
-                      },
-                      "attachments": {
-                        "baspiRef": "B1.3.3",
-                        "title": "Attachments",
-                        "type": "string",
-                        "enum": ["Attached", "To follow"]
-                      }
-                    }
-                  },
-                  {
-                    "properties": {
-                      "capacity": {
-                        "enum": [
-                          "Personal Representative for a Deceased Owner",
-                          "Under Power of Attorney",
-                          "Other"
-                        ]
-                      },
-                      "sellersCapacityDetails": {
-                        "baspiRef": "B1.3.2",
-                        "rdsRef": "Participants/OtherDocumentation",
-                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
-                        "type": "string"
-                      },
-                      "attachments": {
-                        "baspiRef": "B1.3.3",
-                        "title": "Attachments",
-                        "type": "string",
-                        "enum": ["Attached", "To follow"]
-                      }
-                    },
-                    "baspiRequired": ["sellersCapacityDetails", "attachments"]
-                  }
-                ]
               }
             }
           },
@@ -187,11 +116,86 @@
               "Prospective Buyer",
               "Buyer",
               "Buyer's Conveyancer",
-              "Estate Agent"
+              "Estate Agent",
+              "Buyer's Agent",
+              "Surveyor",
+              "Mortgage Broker",
+              "Lender"
             ]
           },
           "externalIds": {
             "type": "object"
+          },
+          "sellersCapacity": {
+            "baspiRef": "B1.3",
+            "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+            "piqRef": "B1.3.1",
+            "title": "Capacity in which the Seller sells",
+            "type": "object",
+            "baspiRequired": ["capacity"],
+            "properties": {
+              "capacity": {
+                "baspiRef": "B1.3.1",
+                "type": "string",
+                "title": "",
+                "enum": [
+                  "Legal Owner",
+                  "Personal Representative for a Deceased Owner",
+                  "Under Power of Attorney",
+                  "Mortgagee in Possession",
+                  "Other"
+                ]
+              }
+            },
+            "discriminator": {
+              "propertyName": "capacity"
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": ["Legal Owner", "Mortgagee in Possession"]
+                  },
+                  "sellersCapacityDetails": {
+                    "baspiRef": "B1.3.2",
+                    "rdsRef": "Participants/OtherDocumentation",
+                    "title": "Please provide details if applicable",
+                    "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
+                    "type": "string"
+                  },
+                  "attachments": {
+                    "baspiRef": "B1.3.3",
+                    "title": "Attachments",
+                    "type": "string",
+                    "enum": ["Attached", "To follow"]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Other"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "baspiRef": "B1.3.2",
+                    "rdsRef": "Participants/OtherDocumentation",
+                    "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                    "type": "string"
+                  },
+                  "attachments": {
+                    "baspiRef": "B1.3.3",
+                    "title": "Attachments",
+                    "type": "string",
+                    "enum": ["Attached", "To follow"]
+                  }
+                },
+                "baspiRequired": ["sellersCapacityDetails", "attachments"]
+              }
+            ]
           }
         }
       }

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -53,6 +53,77 @@
               "preferredName": {
                 "title": "Preferred name / known as",
                 "type": "string"
+              },
+              "sellersCapacity": {
+                "baspiRef": "B1.3",
+                "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+                "piqRef": "B1.3.1",
+                "title": "Capacity in which the Seller sells",
+                "type": "object",
+                "baspiRequired": ["capacity"],
+                "properties": {
+                  "capacity": {
+                    "baspiRef": "B1.3.1",
+                    "type": "string",
+                    "title": "",
+                    "enum": [
+                      "Legal Owner",
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Mortgagee in Possession",
+                      "Other"
+                    ]
+                  }
+                },
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": ["Legal Owner", "Mortgagee in Possession"]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspiRef": "B1.3.2",
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details if applicable",
+                        "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "baspiRef": "B1.3.3",
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspiRef": "B1.3.2",
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "baspiRef": "B1.3.3",
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      }
+                    },
+                    "baspiRequired": ["sellersCapacityDetails", "attachments"]
+                  }
+                ]
               }
             }
           },
@@ -157,7 +228,6 @@
         "additionalInformation",
         "consumerProtectionRegulationsDeclaration",
         "legalOwners",
-        "sellersCapacity",
         "legalBoundaries",
         "servicesCrossing",
         "electricalWorks",
@@ -23517,77 +23587,6 @@
               }
             }
           }
-        },
-        "sellersCapacity": {
-          "baspiRef": "B1.3",
-          "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
-          "piqRef": "B1.3.1",
-          "title": "Capacity in which the Seller sells",
-          "type": "object",
-          "baspiRequired": ["capacity"],
-          "properties": {
-            "capacity": {
-              "baspiRef": "B1.3.1",
-              "type": "string",
-              "title": "",
-              "enum": [
-                "Legal Owner",
-                "Personal Representative for a Deceased Owner",
-                "Under Power of Attorney",
-                "Mortgagee in Possession",
-                "Other"
-              ]
-            }
-          },
-          "discriminator": {
-            "propertyName": "capacity"
-          },
-          "oneOf": [
-            {
-              "properties": {
-                "capacity": {
-                  "enum": ["Legal Owner", "Mortgagee in Possession"]
-                },
-                "sellersCapacityDetails": {
-                  "baspiRef": "B1.3.2",
-                  "rdsRef": "Participants/OtherDocumentation",
-                  "title": "Please provide details if applicable",
-                  "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
-                  "type": "string"
-                },
-                "attachments": {
-                  "baspiRef": "B1.3.3",
-                  "title": "Attachments",
-                  "type": "string",
-                  "enum": ["Attached", "To follow"]
-                }
-              }
-            },
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Personal Representative for a Deceased Owner",
-                    "Under Power of Attorney",
-                    "Other"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "baspiRef": "B1.3.2",
-                  "rdsRef": "Participants/OtherDocumentation",
-                  "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
-                  "type": "string"
-                },
-                "attachments": {
-                  "baspiRef": "B1.3.3",
-                  "title": "Attachments",
-                  "type": "string",
-                  "enum": ["Attached", "To follow"]
-                }
-              },
-              "baspiRequired": ["sellersCapacityDetails", "attachments"]
-            }
-          ]
         },
         "legalBoundaries": {
           "baspiRef": "B2.1",

--- a/src/schemas/v3/overlays/baspi.json
+++ b/src/schemas/v3/overlays/baspi.json
@@ -25,6 +25,59 @@
               "line1",
               "postcode"
             ]
+          },
+          "sellersCapacity": {
+            "baspiRef": "B1.3",
+            "discriminator": {
+              "propertyName": "capacity"
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Legal Owner",
+                      "Mortgagee in Possession"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "baspiRef": "B1.3.2"
+                  },
+                  "attachments": {
+                    "baspiRef": "B1.3.3"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Other"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "baspiRef": "B1.3.2"
+                  },
+                  "attachments": {
+                    "baspiRef": "B1.3.3"
+                  }
+                },
+                "required": [
+                  "sellersCapacityDetails",
+                  "attachments"
+                ]
+              }
+            ],
+            "required": [
+              "capacity"
+            ],
+            "properties": {
+              "capacity": {
+                "baspiRef": "B1.3.1"
+              }
+            }
           }
         }
       }
@@ -57,7 +110,6 @@
         "additionalInformation",
         "consumerProtectionRegulationsDeclaration",
         "legalOwners",
-        "sellersCapacity",
         "legalBoundaries",
         "servicesCrossing",
         "electricalWorks",
@@ -5909,59 +5961,6 @@
                   }
                 }
               }
-            }
-          }
-        },
-        "sellersCapacity": {
-          "baspiRef": "B1.3",
-          "discriminator": {
-            "propertyName": "capacity"
-          },
-          "oneOf": [
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Legal Owner",
-                    "Mortgagee in Possession"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "baspiRef": "B1.3.2"
-                },
-                "attachments": {
-                  "baspiRef": "B1.3.3"
-                }
-              }
-            },
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Personal Representative for a Deceased Owner",
-                    "Under Power of Attorney",
-                    "Other"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "baspiRef": "B1.3.2"
-                },
-                "attachments": {
-                  "baspiRef": "B1.3.3"
-                }
-              },
-              "required": [
-                "sellersCapacityDetails",
-                "attachments"
-              ]
-            }
-          ],
-          "required": [
-            "capacity"
-          ],
-          "properties": {
-            "capacity": {
-              "baspiRef": "B1.3.1"
             }
           }
         },

--- a/src/schemas/v3/overlays/piq.json
+++ b/src/schemas/v3/overlays/piq.json
@@ -2,6 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/piq.json",
   "properties": {
+    "participants": {
+      "items": {
+        "properties": {
+          "sellersCapacity": {
+            "piqRef": "B1.3.1",
+            "discriminator": {
+              "propertyName": "capacity"
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Legal Owner",
+                      "Mortgagee in Possession"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Other"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
     "propertyPack": {
       "properties": {
         "address": {
@@ -2395,35 +2430,6 @@
               "piqRef": "B1.1"
             }
           }
-        },
-        "sellersCapacity": {
-          "piqRef": "B1.3.1",
-          "discriminator": {
-            "propertyName": "capacity"
-          },
-          "oneOf": [
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Legal Owner",
-                    "Mortgagee in Possession"
-                  ]
-                }
-              }
-            },
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Personal Representative for a Deceased Owner",
-                    "Under Power of Attorney",
-                    "Other"
-                  ]
-                }
-              }
-            }
-          ]
         },
         "legalBoundaries": {
           "piqRef": "B3.1",

--- a/src/schemas/v3/overlays/rds.json
+++ b/src/schemas/v3/overlays/rds.json
@@ -2,6 +2,47 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/rds.json",
   "properties": {
+    "participants": {
+      "items": {
+        "properties": {
+          "sellersCapacity": {
+            "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+            "discriminator": {
+              "propertyName": "capacity"
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Legal Owner",
+                      "Mortgagee in Possession"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "rdsRef": "Participants/OtherDocumentation"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Other"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "rdsRef": "Participants/OtherDocumentation"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
     "propertyPack": {
       "properties": {
         "address": {
@@ -2627,41 +2668,6 @@
               "rdsRef": "RightsHolders"
             }
           }
-        },
-        "sellersCapacity": {
-          "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
-          "discriminator": {
-            "propertyName": "capacity"
-          },
-          "oneOf": [
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Legal Owner",
-                    "Mortgagee in Possession"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "rdsRef": "Participants/OtherDocumentation"
-                }
-              }
-            },
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Personal Representative for a Deceased Owner",
-                    "Under Power of Attorney",
-                    "Other"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "rdsRef": "Participants/OtherDocumentation"
-                }
-              }
-            }
-          ]
         },
         "legalBoundaries": {
           "properties": {

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -109,12 +109,82 @@
             "title": "Role",
             "type": "string",
             "enum": [
-              "Seller",
-              "Seller's Conveyancer",
-              "Prospective Buyer",
               "Buyer",
               "Buyer's Conveyancer",
-              "Estate Agent"
+              "Buyer's Agent",
+              "Buyer's Mortgage Broker",
+              "Estate Agent",
+              "Prospective Buyer",
+              "Seller",
+              "Seller's Conveyancer",
+              "Seller's Mortgage Broker",
+              "Surveyor"
+            ]
+          },
+          "sellersCapacity": {
+            "title": "Capacity in which the Seller sells",
+            "type": "object",
+            "properties": {
+              "capacity": {
+                "type": "string",
+                "title": "",
+                "enum": [
+                  "Legal Owner",
+                  "Personal Representative for a Deceased Owner",
+                  "Under Power of Attorney",
+                  "Mortgagee in Possession",
+                  "Beneficial Owner",
+                  "Other"
+                ]
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Legal Owner",
+                      "Mortgagee in Possession"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "title": "Please provide details if applicable",
+                    "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
+                    "type": "string"
+                  },
+                  "attachments": {
+                    "title": "Attachments",
+                    "type": "string",
+                    "enum": [
+                      "Attached",
+                      "To follow"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "capacity": {
+                    "enum": [
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Other"
+                    ]
+                  },
+                  "sellersCapacityDetails": {
+                    "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                    "type": "string"
+                  },
+                  "attachments": {
+                    "title": "Attachments",
+                    "type": "string",
+                    "enum": [
+                      "Attached",
+                      "To follow"
+                    ]
+                  }
+                }
+              }
             ]
           },
           "externalIds": {
@@ -21226,71 +21296,6 @@
               }
             }
           }
-        },
-        "sellersCapacity": {
-          "title": "Capacity in which the Seller sells",
-          "type": "object",
-          "properties": {
-            "capacity": {
-              "type": "string",
-              "title": "",
-              "enum": [
-                "Legal Owner",
-                "Personal Representative for a Deceased Owner",
-                "Under Power of Attorney",
-                "Mortgagee in Possession",
-                "Other"
-              ]
-            }
-          },
-          "oneOf": [
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Legal Owner",
-                    "Mortgagee in Possession"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "title": "Please provide details if applicable",
-                  "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
-                  "type": "string"
-                },
-                "attachments": {
-                  "title": "Attachments",
-                  "type": "string",
-                  "enum": [
-                    "Attached",
-                    "To follow"
-                  ]
-                }
-              }
-            },
-            {
-              "properties": {
-                "capacity": {
-                  "enum": [
-                    "Personal Representative for a Deceased Owner",
-                    "Under Power of Attorney",
-                    "Other"
-                  ]
-                },
-                "sellersCapacityDetails": {
-                  "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
-                  "type": "string"
-                },
-                "attachments": {
-                  "title": "Attachments",
-                  "type": "string",
-                  "enum": [
-                    "Attached",
-                    "To follow"
-                  ]
-                }
-              }
-            }
-          ]
         },
         "legalBoundaries": {
           "title": "Legal Boundaries",

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -109,17 +109,20 @@
             "title": "Role",
             "type": "string",
             "enum": [
-              "Buyer",
-              "Buyer's Conveyancer",
-              "Buyer's Agent",
-              "Buyer's Mortgage Broker",
-              "Estate Agent",
-              "Prospective Buyer",
               "Seller",
               "Seller's Conveyancer",
-              "Seller's Mortgage Broker",
-              "Surveyor"
+              "Prospective Buyer",
+              "Buyer",
+              "Buyer's Conveyancer",
+              "Estate Agent",
+              "Buyer's Agent",
+              "Surveyor",
+              "Mortgage Broker",
+              "Lender"
             ]
+          },
+          "externalIds": {
+            "type": "object"
           },
           "sellersCapacity": {
             "title": "Capacity in which the Seller sells",
@@ -133,7 +136,6 @@
                   "Personal Representative for a Deceased Owner",
                   "Under Power of Attorney",
                   "Mortgagee in Possession",
-                  "Beneficial Owner",
                   "Other"
                 ]
               }
@@ -186,9 +188,6 @@
                 }
               }
             ]
-          },
-          "externalIds": {
-            "type": "object"
           }
         }
       }

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -22,12 +22,12 @@
     "organisation": {},
     "organisationReference": {},
     "role": {},
+    "externalIds": {},
     "sellersCapacity": {
       "capacity": {},
       "sellersCapacityDetails": {},
       "attachments": {}
-    },
-    "externalIds": {}
+    }
   },
   "propertyPack": {
     "address": {

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -22,6 +22,11 @@
     "organisation": {},
     "organisationReference": {},
     "role": {},
+    "sellersCapacity": {
+      "capacity": {},
+      "sellersCapacityDetails": {},
+      "attachments": {}
+    },
     "externalIds": {}
   },
   "propertyPack": {
@@ -2561,11 +2566,6 @@
         "lastName": {},
         "organisationName": {}
       }
-    },
-    "sellersCapacity": {
-      "capacity": {},
-      "sellersCapacityDetails": {},
-      "attachments": {}
     },
     "legalBoundaries": {
       "partOutsideLegalOwnership": {


### PR DESCRIPTION
Capacity should be per participant and not applicable to the transaction.

Move block from `propertyPack.additionalLegalInfo.sellersCapacity` to `participant.sellersCapacity`.

Also added `Beneficial Owner` to `participant.sellersCapacity.capacity`. I did not add this to the enums on BASPI overlay as its not a valid option. This is the same approach as `Under Power of Attorney`. 