### PR TITLE
166 missing discriminator properties in items inside arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.0.0",
+  "version": "3.0.1-5",
   "description": "Property Data Trust Framework Schemas and Utilities",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.0.1-5",
+  "version": "3.0.1-6",
   "description": "Property Data Trust Framework Schemas and Utilities",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.0.1-6",
+  "version": "3.0.1",
   "description": "Property Data Trust Framework Schemas and Utilities",
   "main": "index.js",
   "directories": {

--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -728,7 +728,7 @@
             "documentDetails": {
               "document": {
                 "entryNumber": ["B3", "C2", "C3", "C4"],
-                "planOnlyIndicator": "false",
+                "planOnlyIndicator": false,
                 "registerDescription": "Charge",
                 "documentType": "50",
                 "documentDate": "2020-11-03"

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -14009,7 +14009,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14052,7 +14052,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14095,7 +14095,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14138,7 +14138,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14181,7 +14181,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14224,7 +14224,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14267,7 +14267,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14372,7 +14372,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14415,7 +14415,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14458,7 +14458,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14501,7 +14501,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14544,7 +14544,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14587,7 +14587,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },
@@ -14630,7 +14630,7 @@
                         {
                           "properties": {
                             "isIncludedExcludedOrNone": {
-                              "enum": ["Included"]
+                              "enum": ["Included", "None"]
                             }
                           }
                         },

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -11448,7 +11448,8 @@
             "fittedUnits",
             "outdoorArea",
             "televisionAndTelephone",
-            "stockOfFuel"
+            "stockOfFuel",
+            "otherItems"
           ],
           "properties": {
             "itemsToRemove": {
@@ -11571,6 +11572,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11581,12 +11587,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11599,23 +11600,6 @@
                           "ta10Ref": "1.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11631,6 +11615,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11641,12 +11630,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11659,23 +11643,6 @@
                           "ta10Ref": "1.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11691,6 +11658,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11701,12 +11673,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11719,23 +11686,6 @@
                           "ta10Ref": "1.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11751,6 +11701,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11761,12 +11716,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11779,23 +11729,6 @@
                           "ta10Ref": "1.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11811,6 +11744,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11821,12 +11759,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11839,23 +11772,6 @@
                           "ta10Ref": "1.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11871,6 +11787,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11881,12 +11802,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11899,23 +11815,6 @@
                           "ta10Ref": "1.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11931,6 +11830,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -11941,12 +11845,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -11959,23 +11858,6 @@
                           "ta10Ref": "1.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -11991,6 +11873,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12001,12 +11888,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12019,23 +11901,6 @@
                           "ta10Ref": "1.8b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12051,6 +11916,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12061,12 +11931,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12079,23 +11944,6 @@
                           "ta10Ref": "1.9b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12111,6 +11959,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12121,12 +11974,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12139,23 +11987,6 @@
                           "ta10Ref": "1.10b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12171,6 +12002,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12181,12 +12017,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12199,23 +12030,6 @@
                           "ta10Ref": "1.11b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12231,6 +12045,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12241,12 +12060,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12259,23 +12073,6 @@
                           "ta10Ref": "1.12b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12291,6 +12088,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12301,12 +12103,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12319,23 +12116,6 @@
                           "ta10Ref": "1.13b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12351,6 +12131,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12361,12 +12146,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12379,23 +12159,6 @@
                           "ta10Ref": "1.14b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12411,6 +12174,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12421,12 +12189,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -12439,23 +12202,6 @@
                           "ta10Ref": "1.15b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12489,11 +12235,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "1.16c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -12506,11 +12247,6 @@
                             "ta10Ref": "1.16b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "1.16c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -12547,6 +12283,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12557,49 +12298,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.1d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.1d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -12617,55 +12336,14 @@
                           "ta10Ref": "2.1d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.1d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -12681,6 +12359,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12691,49 +12374,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.2d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.2d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -12751,55 +12412,14 @@
                           "ta10Ref": "2.2d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.2d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -12815,6 +12435,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12825,49 +12450,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.3d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.3d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -12885,55 +12488,14 @@
                           "ta10Ref": "2.3d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.3d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -12949,6 +12511,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -12959,49 +12526,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.4d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.4d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13019,55 +12564,14 @@
                           "ta10Ref": "2.4d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.4d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13083,6 +12587,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13093,49 +12602,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.5d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.5d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13153,55 +12640,14 @@
                           "ta10Ref": "2.5d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.5d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13217,6 +12663,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13227,49 +12678,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.6d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.6d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13287,55 +12716,14 @@
                           "ta10Ref": "2.6d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.6d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13351,6 +12739,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13361,49 +12754,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.7d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.7d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13421,55 +12792,14 @@
                           "ta10Ref": "2.7d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.7d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13485,6 +12815,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13495,49 +12830,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.8d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.8d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13555,55 +12868,14 @@
                           "ta10Ref": "2.8d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.8d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.8c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13619,6 +12891,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13629,49 +12906,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.9d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.9d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13689,55 +12944,14 @@
                           "ta10Ref": "2.9d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.9d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.9c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13753,6 +12967,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -13763,49 +12982,27 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
+                          "enum": ["None"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
                           "enum": ["Included"]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.10d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.10d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     },
@@ -13823,55 +13020,14 @@
                           "ta10Ref": "2.10d",
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.10d",
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": ["Fitted", "Freestanding"]
                             }
                           },
-                          "ta10Required": ["isFittedOrFreestanding"],
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Fitted"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": ["Freestanding"]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c",
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.10c",
-                          "title": "Comments",
-                          "type": "string"
+                          "ta10Required": ["fittedOrFreestanding"]
                         }
                       }
                     }
@@ -13910,39 +13066,29 @@
                             "ta10Ref": "2.11d",
                             "type": "object",
                             "properties": {
-                              "isFittedOrFreestanding": {
+                              "fittedOrFreestanding": {
                                 "ta10Ref": "2.11d",
                                 "title": "Fitted, Freestanding",
                                 "type": "string",
                                 "enum": ["Fitted", "Freestanding"]
                               }
                             },
-                            "ta10Required": ["isFittedOrFreestanding"],
+                            "ta10Required": ["fittedOrFreestanding"],
                             "discriminator": {
-                              "propertyName": "isFittedOrFreestanding"
+                              "propertyName": "fittedOrFreestanding"
                             },
                             "oneOf": [
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": ["Fitted"]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c",
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               },
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": ["Freestanding"]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c",
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               }
@@ -13964,39 +13110,29 @@
                             "ta10Ref": "2.11d",
                             "type": "object",
                             "properties": {
-                              "isFittedOrFreestanding": {
+                              "fittedOrFreestanding": {
                                 "ta10Ref": "2.11d",
                                 "title": "Fitted, Freestanding",
                                 "type": "string",
                                 "enum": ["Fitted", "Freestanding"]
                               }
                             },
-                            "ta10Required": ["isFittedOrFreestanding"],
+                            "ta10Required": ["fittedOrFreestanding"],
                             "discriminator": {
-                              "propertyName": "isFittedOrFreestanding"
+                              "propertyName": "fittedOrFreestanding"
                             },
                             "oneOf": [
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": ["Fitted"]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c",
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               },
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": ["Freestanding"]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c",
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               }
@@ -14008,11 +13144,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["None"]
-                          },
-                          "comments": {
-                            "ta10Ref": "2.11c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -14048,6 +13179,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14058,12 +13194,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14076,23 +13207,6 @@
                           "ta10Ref": "3.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14108,6 +13222,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14118,12 +13237,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14136,23 +13250,6 @@
                           "ta10Ref": "3.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14168,6 +13265,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14178,12 +13280,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14196,23 +13293,6 @@
                           "ta10Ref": "3.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14228,6 +13308,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14238,12 +13323,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14256,23 +13336,6 @@
                           "ta10Ref": "3.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14288,6 +13351,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14298,12 +13366,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14316,23 +13379,6 @@
                           "ta10Ref": "3.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14348,6 +13394,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14358,12 +13409,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14376,23 +13422,6 @@
                           "ta10Ref": "3.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14408,6 +13437,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14418,12 +13452,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14436,23 +13465,6 @@
                           "ta10Ref": "3.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14468,6 +13480,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14478,12 +13495,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14496,23 +13508,6 @@
                           "ta10Ref": "3.8b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14528,6 +13523,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14538,12 +13538,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14556,23 +13551,6 @@
                           "ta10Ref": "3.9b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14588,6 +13566,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14598,12 +13581,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14616,23 +13594,6 @@
                           "ta10Ref": "3.10b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14664,6 +13625,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14674,12 +13640,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14692,23 +13653,6 @@
                           "ta10Ref": "4.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14724,6 +13668,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14734,12 +13683,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14752,23 +13696,6 @@
                           "ta10Ref": "4.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14784,6 +13711,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14794,12 +13726,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14812,23 +13739,6 @@
                           "ta10Ref": "4.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14844,6 +13754,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14854,12 +13769,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14872,23 +13782,6 @@
                           "ta10Ref": "4.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14904,6 +13797,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14914,12 +13812,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14932,23 +13825,6 @@
                           "ta10Ref": "4.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14964,6 +13840,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -14974,12 +13855,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -14992,23 +13868,6 @@
                           "ta10Ref": "4.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15024,6 +13883,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15034,12 +13898,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -15052,23 +13911,6 @@
                           "ta10Ref": "4.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15102,11 +13944,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "4.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -15119,11 +13956,6 @@
                             "ta10Ref": "4.8b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "4.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -15162,6 +13994,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15173,11 +14010,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15190,23 +14022,6 @@
                               "ta10Ref": "5.1b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15222,6 +14037,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15233,11 +14053,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15250,23 +14065,6 @@
                               "ta10Ref": "5.2b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15282,6 +14080,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15293,11 +14096,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15310,23 +14108,6 @@
                               "ta10Ref": "5.3b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15342,6 +14123,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15353,11 +14139,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15370,23 +14151,6 @@
                               "ta10Ref": "5.4b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15402,6 +14166,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15413,11 +14182,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15430,23 +14194,6 @@
                               "ta10Ref": "5.5b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15462,6 +14209,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15473,11 +14225,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15490,23 +14237,6 @@
                               "ta10Ref": "5.6b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15522,6 +14252,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15533,11 +14268,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15550,23 +14280,6 @@
                               "ta10Ref": "5.7b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15600,11 +14313,6 @@
                             "properties": {
                               "isIncludedOrExcluded": {
                                 "enum": ["Included"]
-                              },
-                              "comments": {
-                                "ta10Ref": "5.8c",
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           },
@@ -15617,11 +14325,6 @@
                                 "ta10Ref": "5.8b",
                                 "title": "Price",
                                 "type": "number"
-                              },
-                              "comments": {
-                                "ta10Ref": "5.8c",
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           }
@@ -15654,6 +14357,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15665,11 +14373,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15682,23 +14385,6 @@
                               "ta10Ref": "5.12b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15714,6 +14400,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15725,11 +14416,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15742,23 +14428,6 @@
                               "ta10Ref": "5.13b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15774,6 +14443,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15785,11 +14459,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15802,23 +14471,6 @@
                               "ta10Ref": "5.14b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15834,6 +14486,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15845,11 +14502,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15862,23 +14514,6 @@
                               "ta10Ref": "5.15b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15894,6 +14529,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15905,11 +14545,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15922,23 +14557,6 @@
                               "ta10Ref": "5.16b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -15954,6 +14572,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -15965,11 +14588,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -15982,23 +14600,6 @@
                               "ta10Ref": "5.17b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -16014,6 +14615,11 @@
                           "title": "Included, Excluded or None",
                           "type": "string",
                           "enum": ["Included", "Excluded", "None"]
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c",
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16025,11 +14631,6 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": ["Included"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -16042,23 +14643,6 @@
                               "ta10Ref": "5.18b",
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c",
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": ["None"]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c",
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -16092,11 +14676,6 @@
                             "properties": {
                               "isIncludedOrExcluded": {
                                 "enum": ["Included"]
-                              },
-                              "comments": {
-                                "ta10Ref": "5.19c",
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           },
@@ -16109,11 +14688,6 @@
                                 "ta10Ref": "5.19b",
                                 "title": "Price",
                                 "type": "number"
-                              },
-                              "comments": {
-                                "ta10Ref": "5.19c",
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           }
@@ -16149,6 +14723,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16159,12 +14738,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16177,23 +14751,6 @@
                           "ta10Ref": "6.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16209,6 +14766,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16219,12 +14781,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16237,23 +14794,6 @@
                           "ta10Ref": "6.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16269,6 +14809,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16279,12 +14824,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16297,23 +14837,6 @@
                           "ta10Ref": "6.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16329,6 +14852,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16339,12 +14867,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16357,23 +14880,6 @@
                           "ta10Ref": "6.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16389,6 +14895,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16399,12 +14910,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16417,23 +14923,6 @@
                           "ta10Ref": "6.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16449,6 +14938,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16459,12 +14953,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16477,23 +14966,6 @@
                           "ta10Ref": "6.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16509,6 +14981,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16519,12 +14996,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16537,23 +15009,6 @@
                           "ta10Ref": "6.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16587,11 +15042,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "6.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -16604,11 +15054,6 @@
                             "ta10Ref": "6.8b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "6.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -16642,6 +15087,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16652,12 +15102,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16670,23 +15115,6 @@
                           "ta10Ref": "7.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16702,6 +15130,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16712,12 +15145,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16730,23 +15158,6 @@
                           "ta10Ref": "7.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16762,6 +15173,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16772,12 +15188,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16790,23 +15201,6 @@
                           "ta10Ref": "7.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16822,6 +15216,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16832,12 +15231,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16850,23 +15244,6 @@
                           "ta10Ref": "7.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16882,6 +15259,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16892,12 +15274,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16910,23 +15287,6 @@
                           "ta10Ref": "7.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16942,6 +15302,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -16952,12 +15317,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -16970,23 +15330,6 @@
                           "ta10Ref": "7.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17002,6 +15345,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17012,12 +15360,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17030,23 +15373,6 @@
                           "ta10Ref": "7.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17080,11 +15406,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "7.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -17097,11 +15418,6 @@
                             "ta10Ref": "7.8b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "7.8c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -17139,6 +15455,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17149,12 +15470,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17167,23 +15483,6 @@
                           "ta10Ref": "8.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17199,6 +15498,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17209,12 +15513,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17227,23 +15526,6 @@
                           "ta10Ref": "8.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17259,6 +15541,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17269,12 +15556,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17287,23 +15569,6 @@
                           "ta10Ref": "8.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17319,6 +15584,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17329,12 +15599,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17347,23 +15612,6 @@
                           "ta10Ref": "8.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17379,6 +15627,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17389,12 +15642,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17407,23 +15655,6 @@
                           "ta10Ref": "8.5b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17439,6 +15670,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17449,12 +15685,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17467,23 +15698,6 @@
                           "ta10Ref": "8.6b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17499,6 +15713,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17509,12 +15728,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17527,23 +15741,6 @@
                           "ta10Ref": "8.7b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17559,6 +15756,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17569,12 +15771,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17587,23 +15784,6 @@
                           "ta10Ref": "8.8b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17619,6 +15799,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17629,12 +15814,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17647,23 +15827,6 @@
                           "ta10Ref": "8.9b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17679,6 +15842,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17689,12 +15857,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17707,23 +15870,6 @@
                           "ta10Ref": "8.10b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17739,6 +15885,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17749,12 +15900,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17767,23 +15913,6 @@
                           "ta10Ref": "8.11b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17799,6 +15928,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17809,12 +15943,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17827,23 +15956,6 @@
                           "ta10Ref": "8.12b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17877,11 +15989,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "8.13c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -17894,11 +16001,6 @@
                             "ta10Ref": "8.13b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "8.13c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -17928,6 +16030,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17938,12 +16045,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -17956,23 +16058,6 @@
                           "ta10Ref": "9.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -17988,6 +16073,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -17998,12 +16088,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18016,23 +16101,6 @@
                           "ta10Ref": "9.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18048,6 +16116,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -18058,12 +16131,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18076,23 +16144,6 @@
                           "ta10Ref": "9.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18108,6 +16159,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -18118,12 +16174,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18136,23 +16187,6 @@
                           "ta10Ref": "9.4b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18176,6 +16210,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -18186,12 +16225,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18204,23 +16238,6 @@
                           "ta10Ref": "10.1b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18236,6 +16253,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -18246,12 +16268,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18264,23 +16281,6 @@
                           "ta10Ref": "10.2b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18296,6 +16296,11 @@
                       "title": "Included, Excluded or None",
                       "type": "string",
                       "enum": ["Included", "Excluded", "None"]
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c",
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "ta10Required": ["isIncludedExcludedOrNone"],
@@ -18306,12 +16311,7 @@
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
-                          "enum": ["Included"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c",
-                          "title": "Comments",
-                          "type": "string"
+                          "enum": ["Included", "None"]
                         }
                       }
                     },
@@ -18324,23 +16324,6 @@
                           "ta10Ref": "10.3b",
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c",
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": ["None"]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c",
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -18381,11 +16364,6 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
-                          },
-                          "comments": {
-                            "ta10Ref": "11.1c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -18398,11 +16376,6 @@
                             "ta10Ref": "11.1b",
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "ta10Ref": "11.1c",
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -23548,10 +21521,7 @@
                 "yesNo": {
                   "type": "string",
                   "title": "",
-                  "enum": [
-                    "Yes",
-                    "No"
-                  ]
+                  "enum": ["Yes", "No"]
                 }
               }
             }
@@ -29960,7 +27930,7 @@
                                 }
                               ]
                             },
-                            "lheLocalAuthorityReceivedANoticeOfDisposal": {
+                            "theLocalAuthorityReceivedANoticeOfDisposal": {
                               "con29RRef": "3.15(b)(ii)",
                               "title": "Has the Local Authority received a notice of disposal?",
                               "type": "object",
@@ -30200,7 +28170,7 @@
                             ]
                           },
                           "commonholdIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "titleRegistrationDetails": {
                             "type": "object",
@@ -30277,94 +28247,94 @@
                         ],
                         "properties": {
                           "agreedNoticeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "bankruptcyIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "cautionIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "ccbiIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "chargeeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "chargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "chargeRelatedRestrictionIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "chargeRestrictionIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "creditorsNoticeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "deathOfProprietorIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "deedOfPostponementIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "discountChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "equitableChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "greenOutEntryIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "homeRightsChangeOfAddressIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "homeRightsIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "leaseHoldTitleIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "multipleChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "nonChargeRestrictionIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "notedChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "pricePaidIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "propertyDescriptionNotesIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "rentChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "rightOfPreEmptionIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "scheduleOfLeasesIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "subChargeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "unidentifiedEntryIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "unilateralNoticeBeneficiaryIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "unilateralNoticeIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           },
                           "vendorsLienIndicator": {
-                            "type":"boolean"
+                            "type": "boolean"
                           }
                         }
                       },
@@ -36480,8 +34450,7 @@
                                     ]
                                   },
                                   "planOnlyIndicator": {
-                                    "type": "string",
-                                    "enum": ["true", "false"]
+                                    "type": "boolean"
                                   },
                                   "filedUnder": {
                                     "type": "string"

--- a/src/schemas/v3/overlays/baspi.json
+++ b/src/schemas/v3/overlays/baspi.json
@@ -215,7 +215,6 @@
             "ownershipsToBeTransferred": {
               "baspiRef": "A1.3",
               "items": {
-                "baspiRef": "A1.3.0",
                 "discriminator": {
                   "propertyName": "ownershipType"
                 },
@@ -1036,6 +1035,7 @@
                     ]
                   }
                 ],
+                "baspiRef": "A1.3.0",
                 "required": [
                   "ownershipType"
                 ],
@@ -5909,7 +5909,6 @@
             "namesOfLegalOwners": {
               "baspiRef": "B1.1",
               "items": {
-                "baspiRef": "B1.1",
                 "discriminator": {
                   "propertyName": "ownerType"
                 },
@@ -5952,6 +5951,7 @@
                     ]
                   }
                 ],
+                "baspiRef": "B1.1",
                 "required": [
                   "ownerType"
                 ],

--- a/src/schemas/v3/overlays/con29R.json
+++ b/src/schemas/v3/overlays/con29R.json
@@ -2876,7 +2876,7 @@
                                 "yesNo"
                               ]
                             },
-                            "lheLocalAuthorityReceivedANoticeOfDisposal": {
+                            "theLocalAuthorityReceivedANoticeOfDisposal": {
                               "con29RRef": "3.15(b)(ii)",
                               "discriminator": {
                                 "propertyName": "yesNo"

--- a/src/schemas/v3/overlays/nts.json
+++ b/src/schemas/v3/overlays/nts.json
@@ -235,7 +235,6 @@
             "ownershipsToBeTransferred": {
               "ntsRef": "A3",
               "items": {
-                "ntsRef": "A3.1",
                 "discriminator": {
                   "propertyName": "ownershipType"
                 },
@@ -546,6 +545,7 @@
                     ]
                   }
                 ],
+                "ntsRef": "A3.1",
                 "required": [
                   "ownershipType"
                 ],

--- a/src/schemas/v3/overlays/piq.json
+++ b/src/schemas/v3/overlays/piq.json
@@ -2427,7 +2427,32 @@
         "legalOwners": {
           "properties": {
             "namesOfLegalOwners": {
-              "piqRef": "B1.1"
+              "piqRef": "B1.1",
+              "items": {
+                "discriminator": {
+                  "propertyName": "ownerType"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Private individual"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Organisation"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
             }
           }
         },

--- a/src/schemas/v3/overlays/rds.json
+++ b/src/schemas/v3/overlays/rds.json
@@ -2665,7 +2665,32 @@
         "legalOwners": {
           "properties": {
             "namesOfLegalOwners": {
-              "rdsRef": "RightsHolders"
+              "rdsRef": "RightsHolders",
+              "items": {
+                "discriminator": {
+                  "propertyName": "ownerType"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Private individual"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Organisation"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
             }
           }
         },

--- a/src/schemas/v3/overlays/ta10.json
+++ b/src/schemas/v3/overlays/ta10.json
@@ -36,7 +36,8 @@
             "fittedUnits",
             "outdoorArea",
             "televisionAndTelephone",
-            "stockOfFuel"
+            "stockOfFuel",
+            "otherItems"
           ],
           "properties": {
             "basicFittings": {
@@ -69,11 +70,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -86,21 +85,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.1c"
                         }
                       }
                     }
@@ -111,6 +95,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -124,11 +111,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c"
                         }
                       }
                     },
@@ -141,21 +126,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.2c"
                         }
                       }
                     }
@@ -166,6 +136,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -179,11 +152,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c"
                         }
                       }
                     },
@@ -196,21 +167,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.3c"
                         }
                       }
                     }
@@ -221,6 +177,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -234,11 +193,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c"
                         }
                       }
                     },
@@ -251,21 +208,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.4c"
                         }
                       }
                     }
@@ -276,6 +218,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -289,11 +234,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c"
                         }
                       }
                     },
@@ -306,21 +249,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.5c"
                         }
                       }
                     }
@@ -331,6 +259,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -344,11 +275,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c"
                         }
                       }
                     },
@@ -361,21 +290,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.6c"
                         }
                       }
                     }
@@ -386,6 +300,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -399,11 +316,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c"
                         }
                       }
                     },
@@ -416,21 +331,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.7c"
                         }
                       }
                     }
@@ -441,6 +341,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -454,11 +357,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c"
                         }
                       }
                     },
@@ -471,21 +372,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.8b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.8c"
                         }
                       }
                     }
@@ -496,6 +382,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.8a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -509,11 +398,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c"
                         }
                       }
                     },
@@ -526,21 +413,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.9b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.9c"
                         }
                       }
                     }
@@ -551,6 +423,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.9a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -564,11 +439,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c"
                         }
                       }
                     },
@@ -581,21 +454,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.10b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.10c"
                         }
                       }
                     }
@@ -606,6 +464,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.10a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -619,11 +480,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c"
                         }
                       }
                     },
@@ -636,21 +495,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.11b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.11c"
                         }
                       }
                     }
@@ -661,6 +505,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.11a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -674,11 +521,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c"
                         }
                       }
                     },
@@ -691,21 +536,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.12b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.12c"
                         }
                       }
                     }
@@ -716,6 +546,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.12a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -729,11 +562,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c"
                         }
                       }
                     },
@@ -746,21 +577,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.13b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.13c"
                         }
                       }
                     }
@@ -771,6 +587,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.13a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -784,11 +603,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c"
                         }
                       }
                     },
@@ -801,21 +618,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.14b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.14c"
                         }
                       }
                     }
@@ -826,6 +628,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.14a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -839,11 +644,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c"
                         }
                       }
                     },
@@ -856,21 +659,6 @@
                         },
                         "price": {
                           "ta10Ref": "1.15b"
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "1.15c"
                         }
                       }
                     }
@@ -881,12 +669,41 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "1.15a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherItems": {
                   "ta10Ref": "1.16",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "1.16b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -898,26 +715,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "1.16a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "1.16c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "1.16b"
-                          },
-                          "comments": {
-                            "ta10Ref": "1.16c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -947,45 +745,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.1d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.1d"
                             }
                           }
@@ -1004,55 +782,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.1d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.1c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.1d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.1c"
                         }
                       }
                     }
@@ -1063,6 +800,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1076,45 +816,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.2d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.2d"
                             }
                           }
@@ -1133,55 +853,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.2d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.2c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.2d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.2c"
                         }
                       }
                     }
@@ -1192,6 +871,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1205,45 +887,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.3d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.3d"
                             }
                           }
@@ -1262,55 +924,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.3d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.3c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.3d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.3c"
                         }
                       }
                     }
@@ -1321,6 +942,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1334,45 +958,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.4d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.4d"
                             }
                           }
@@ -1391,55 +995,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.4d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.4c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.4d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.4c"
                         }
                       }
                     }
@@ -1450,6 +1013,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1463,45 +1029,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.5d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.5d"
                             }
                           }
@@ -1520,55 +1066,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.5d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.5c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.5d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.5c"
                         }
                       }
                     }
@@ -1579,6 +1084,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1592,45 +1100,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.6d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.6d"
                             }
                           }
@@ -1649,55 +1137,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.6d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.6c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.6d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.6c"
                         }
                       }
                     }
@@ -1708,6 +1155,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1721,45 +1171,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.7d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.7d"
                             }
                           }
@@ -1778,55 +1208,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.7d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.7c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.7d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.7c"
                         }
                       }
                     }
@@ -1837,6 +1226,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1850,45 +1242,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.8d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.8d"
                             }
                           }
@@ -1907,55 +1279,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.8d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.8c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.8d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.8c"
                         }
                       }
                     }
@@ -1966,6 +1297,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.8a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -1979,45 +1313,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.9d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.9d"
                             }
                           }
@@ -2036,55 +1350,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.9d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.9c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.9d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.9c"
                         }
                       }
                     }
@@ -2095,6 +1368,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.9a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2108,45 +1384,25 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
                             "Included"
                           ]
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.10d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.10d"
                             }
                           }
@@ -2165,55 +1421,14 @@
                         },
                         "fittedOrFreestanding": {
                           "ta10Ref": "2.10d",
-                          "discriminator": {
-                            "propertyName": "isFittedOrFreestanding"
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "ta10Ref": "2.10c"
-                                }
-                              }
-                            }
-                          ],
                           "required": [
-                            "isFittedOrFreestanding"
+                            "fittedOrFreestanding"
                           ],
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "ta10Ref": "2.10d"
                             }
                           }
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "2.10c"
                         }
                       }
                     }
@@ -2224,12 +1439,118 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "2.10a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherItems": {
                   "ta10Ref": "2.11",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          },
+                          "fittedOrFreestanding": {
+                            "ta10Ref": "2.11d",
+                            "discriminator": {
+                              "propertyName": "fittedOrFreestanding"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "fittedOrFreestanding": {
+                                    "enum": [
+                                      "Fitted"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "fittedOrFreestanding": {
+                                    "enum": [
+                                      "Freestanding"
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "required": [
+                              "fittedOrFreestanding"
+                            ],
+                            "properties": {
+                              "fittedOrFreestanding": {
+                                "ta10Ref": "2.11d"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "2.11b"
+                          },
+                          "fittedOrFreestanding": {
+                            "ta10Ref": "2.11d",
+                            "discriminator": {
+                              "propertyName": "fittedOrFreestanding"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "fittedOrFreestanding": {
+                                    "enum": [
+                                      "Fitted"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "fittedOrFreestanding": {
+                                    "enum": [
+                                      "Freestanding"
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "required": [
+                              "fittedOrFreestanding"
+                            ],
+                            "properties": {
+                              "fittedOrFreestanding": {
+                                "ta10Ref": "2.11d"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "None"
+                            ]
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "isIncludedOrExcluded"
                     ],
@@ -2240,107 +1561,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "2.11a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "fittedOrFreestanding": {
-                            "ta10Ref": "2.11d",
-                            "discriminator": {
-                              "propertyName": "isFittedOrFreestanding"
-                            },
-                            "oneOf": [
-                              {
-                                "properties": {
-                                  "isFittedOrFreestanding": {
-                                    "enum": [
-                                      "Fitted"
-                                    ]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c"
-                                  }
-                                }
-                              },
-                              {
-                                "properties": {
-                                  "isFittedOrFreestanding": {
-                                    "enum": [
-                                      "Freestanding"
-                                    ]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c"
-                                  }
-                                }
-                              }
-                            ],
-                            "required": [
-                              "isFittedOrFreestanding"
-                            ],
-                            "properties": {
-                              "isFittedOrFreestanding": {
-                                "ta10Ref": "2.11d"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "2.11b"
-                          },
-                          "fittedOrFreestanding": {
-                            "ta10Ref": "2.11d",
-                            "discriminator": {
-                              "propertyName": "isFittedOrFreestanding"
-                            },
-                            "oneOf": [
-                              {
-                                "properties": {
-                                  "isFittedOrFreestanding": {
-                                    "enum": [
-                                      "Fitted"
-                                    ]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c"
-                                  }
-                                }
-                              },
-                              {
-                                "properties": {
-                                  "isFittedOrFreestanding": {
-                                    "enum": [
-                                      "Freestanding"
-                                    ]
-                                  },
-                                  "comments": {
-                                    "ta10Ref": "2.11c"
-                                  }
-                                }
-                              }
-                            ],
-                            "required": [
-                              "isFittedOrFreestanding"
-                            ],
-                            "properties": {
-                              "isFittedOrFreestanding": {
-                                "ta10Ref": "2.11d"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "2.11c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -2370,11 +1591,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c"
                         }
                       }
                     },
@@ -2387,21 +1606,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.1c"
                         }
                       }
                     }
@@ -2412,6 +1616,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2425,11 +1632,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c"
                         }
                       }
                     },
@@ -2442,21 +1647,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.2c"
                         }
                       }
                     }
@@ -2467,6 +1657,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2480,11 +1673,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c"
                         }
                       }
                     },
@@ -2497,21 +1688,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.3c"
                         }
                       }
                     }
@@ -2522,6 +1698,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2535,11 +1714,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c"
                         }
                       }
                     },
@@ -2552,21 +1729,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.4c"
                         }
                       }
                     }
@@ -2577,6 +1739,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2590,11 +1755,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c"
                         }
                       }
                     },
@@ -2607,21 +1770,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.5c"
                         }
                       }
                     }
@@ -2632,6 +1780,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2645,11 +1796,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c"
                         }
                       }
                     },
@@ -2662,21 +1811,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.6c"
                         }
                       }
                     }
@@ -2687,6 +1821,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2700,11 +1837,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c"
                         }
                       }
                     },
@@ -2717,21 +1852,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.7c"
                         }
                       }
                     }
@@ -2742,6 +1862,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2755,11 +1878,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c"
                         }
                       }
                     },
@@ -2772,21 +1893,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.8b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.8c"
                         }
                       }
                     }
@@ -2797,6 +1903,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.8a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2810,11 +1919,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c"
                         }
                       }
                     },
@@ -2827,21 +1934,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.9b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.9c"
                         }
                       }
                     }
@@ -2852,6 +1944,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.9a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2865,11 +1960,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c"
                         }
                       }
                     },
@@ -2882,21 +1975,6 @@
                         },
                         "price": {
                           "ta10Ref": "3.10b"
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "3.10c"
                         }
                       }
                     }
@@ -2907,6 +1985,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "3.10a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 }
@@ -2934,11 +2015,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c"
                         }
                       }
                     },
@@ -2951,21 +2030,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.1c"
                         }
                       }
                     }
@@ -2976,6 +2040,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -2989,11 +2056,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c"
                         }
                       }
                     },
@@ -3006,21 +2071,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.2c"
                         }
                       }
                     }
@@ -3031,6 +2081,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -3044,11 +2097,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c"
                         }
                       }
                     },
@@ -3061,21 +2112,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.3c"
                         }
                       }
                     }
@@ -3086,6 +2122,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -3099,11 +2138,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c"
                         }
                       }
                     },
@@ -3116,21 +2153,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.4c"
                         }
                       }
                     }
@@ -3141,6 +2163,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -3154,11 +2179,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c"
                         }
                       }
                     },
@@ -3171,21 +2194,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.5c"
                         }
                       }
                     }
@@ -3196,6 +2204,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -3209,11 +2220,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c"
                         }
                       }
                     },
@@ -3226,21 +2235,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.6c"
                         }
                       }
                     }
@@ -3251,6 +2245,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -3264,11 +2261,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c"
                         }
                       }
                     },
@@ -3281,21 +2276,6 @@
                         },
                         "price": {
                           "ta10Ref": "4.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "4.7c"
                         }
                       }
                     }
@@ -3306,12 +2286,41 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "4.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherRooms": {
                   "ta10Ref": "4.8",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "4.8b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -3323,26 +2332,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "4.8a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "4.8c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "4.8b"
-                          },
-                          "comments": {
-                            "ta10Ref": "4.8c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -3378,9 +2368,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c"
                             }
                           }
                         },
@@ -3393,21 +2380,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.1b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.1c"
                             }
                           }
                         }
@@ -3418,6 +2390,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.1a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3433,9 +2408,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c"
                             }
                           }
                         },
@@ -3448,21 +2420,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.2b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.2c"
                             }
                           }
                         }
@@ -3473,6 +2430,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.2a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3488,9 +2448,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c"
                             }
                           }
                         },
@@ -3503,21 +2460,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.3b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.3c"
                             }
                           }
                         }
@@ -3528,6 +2470,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.3a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3543,9 +2488,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c"
                             }
                           }
                         },
@@ -3558,21 +2500,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.4b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.4c"
                             }
                           }
                         }
@@ -3583,6 +2510,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.4a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3598,9 +2528,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c"
                             }
                           }
                         },
@@ -3613,21 +2540,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.5b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.5c"
                             }
                           }
                         }
@@ -3638,6 +2550,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.5a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3653,9 +2568,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c"
                             }
                           }
                         },
@@ -3668,21 +2580,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.6b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.6c"
                             }
                           }
                         }
@@ -3693,6 +2590,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.6a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3708,9 +2608,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c"
                             }
                           }
                         },
@@ -3723,21 +2620,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.7b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.7c"
                             }
                           }
                         }
@@ -3748,12 +2630,41 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.7a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
                     "otherRooms": {
                       "ta10Ref": "5.8",
                       "items": {
+                        "discriminator": {
+                          "propertyName": "isIncludedOrExcluded"
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "isIncludedOrExcluded": {
+                                "enum": [
+                                  "Included"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "isIncludedOrExcluded": {
+                                "enum": [
+                                  "Excluded"
+                                ]
+                              },
+                              "price": {
+                                "ta10Ref": "5.8b"
+                              }
+                            }
+                          }
+                        ],
                         "required": [
                           "itemName",
                           "isIncludedOrExcluded"
@@ -3765,26 +2676,7 @@
                           "isIncludedOrExcluded": {
                             "ta10Ref": "5.8a"
                           }
-                        },
-                        "oneOf": [
-                          {
-                            "properties": {
-                              "comments": {
-                                "ta10Ref": "5.8c"
-                              }
-                            }
-                          },
-                          {
-                            "properties": {
-                              "price": {
-                                "ta10Ref": "5.8b"
-                              },
-                              "comments": {
-                                "ta10Ref": "5.8c"
-                              }
-                            }
-                          }
-                        ]
+                        }
                       }
                     }
                   }
@@ -3813,9 +2705,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c"
                             }
                           }
                         },
@@ -3828,21 +2717,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.12b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.12c"
                             }
                           }
                         }
@@ -3853,6 +2727,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.12a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3868,9 +2745,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c"
                             }
                           }
                         },
@@ -3883,21 +2757,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.13b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.13c"
                             }
                           }
                         }
@@ -3908,6 +2767,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.13a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3923,9 +2785,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c"
                             }
                           }
                         },
@@ -3938,21 +2797,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.14b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.14c"
                             }
                           }
                         }
@@ -3963,6 +2807,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.14a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -3978,9 +2825,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c"
                             }
                           }
                         },
@@ -3993,21 +2837,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.15b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.15c"
                             }
                           }
                         }
@@ -4018,6 +2847,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.15a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -4033,9 +2865,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c"
                             }
                           }
                         },
@@ -4048,21 +2877,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.16b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.16c"
                             }
                           }
                         }
@@ -4073,6 +2887,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.16a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -4088,9 +2905,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c"
                             }
                           }
                         },
@@ -4103,21 +2917,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.17b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.17c"
                             }
                           }
                         }
@@ -4128,6 +2927,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.17a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
@@ -4143,9 +2945,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c"
                             }
                           }
                         },
@@ -4158,21 +2957,6 @@
                             },
                             "price": {
                               "ta10Ref": "5.18b"
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "ta10Ref": "5.18c"
                             }
                           }
                         }
@@ -4183,12 +2967,41 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "ta10Ref": "5.18a"
+                        },
+                        "comments": {
+                          "ta10Ref": "1.1c"
                         }
                       }
                     },
                     "otherRooms": {
                       "ta10Ref": "5.19",
                       "items": {
+                        "discriminator": {
+                          "propertyName": "isIncludedOrExcluded"
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "isIncludedOrExcluded": {
+                                "enum": [
+                                  "Included"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "isIncludedOrExcluded": {
+                                "enum": [
+                                  "Excluded"
+                                ]
+                              },
+                              "price": {
+                                "ta10Ref": "5.19b"
+                              }
+                            }
+                          }
+                        ],
                         "required": [
                           "itemName",
                           "isIncludedOrExcluded"
@@ -4200,26 +3013,7 @@
                           "isIncludedOrExcluded": {
                             "ta10Ref": "5.19a"
                           }
-                        },
-                        "oneOf": [
-                          {
-                            "properties": {
-                              "comments": {
-                                "ta10Ref": "5.19c"
-                              }
-                            }
-                          },
-                          {
-                            "properties": {
-                              "price": {
-                                "ta10Ref": "5.19b"
-                              },
-                              "comments": {
-                                "ta10Ref": "5.19c"
-                              }
-                            }
-                          }
-                        ]
+                        }
                       }
                     }
                   }
@@ -4248,11 +3042,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c"
                         }
                       }
                     },
@@ -4265,21 +3057,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.1c"
                         }
                       }
                     }
@@ -4290,6 +3067,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4303,11 +3083,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c"
                         }
                       }
                     },
@@ -4320,21 +3098,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.2c"
                         }
                       }
                     }
@@ -4345,6 +3108,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4358,11 +3124,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c"
                         }
                       }
                     },
@@ -4375,21 +3139,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.3c"
                         }
                       }
                     }
@@ -4400,6 +3149,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4413,11 +3165,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c"
                         }
                       }
                     },
@@ -4430,21 +3180,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.4c"
                         }
                       }
                     }
@@ -4455,6 +3190,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4468,11 +3206,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c"
                         }
                       }
                     },
@@ -4485,21 +3221,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.5c"
                         }
                       }
                     }
@@ -4510,6 +3231,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4523,11 +3247,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c"
                         }
                       }
                     },
@@ -4540,21 +3262,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.6c"
                         }
                       }
                     }
@@ -4565,6 +3272,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4578,11 +3288,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c"
                         }
                       }
                     },
@@ -4595,21 +3303,6 @@
                         },
                         "price": {
                           "ta10Ref": "6.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "6.7c"
                         }
                       }
                     }
@@ -4620,12 +3313,41 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "6.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherRooms": {
                   "ta10Ref": "6.8",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "6.8b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -4637,26 +3359,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "6.8a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "6.8c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "6.8b"
-                          },
-                          "comments": {
-                            "ta10Ref": "6.8c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -4683,11 +3386,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c"
                         }
                       }
                     },
@@ -4700,21 +3401,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.1c"
                         }
                       }
                     }
@@ -4725,6 +3411,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4738,11 +3427,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c"
                         }
                       }
                     },
@@ -4755,21 +3442,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.2c"
                         }
                       }
                     }
@@ -4780,6 +3452,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4793,11 +3468,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c"
                         }
                       }
                     },
@@ -4810,21 +3483,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.3c"
                         }
                       }
                     }
@@ -4835,6 +3493,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4848,11 +3509,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c"
                         }
                       }
                     },
@@ -4865,21 +3524,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.4c"
                         }
                       }
                     }
@@ -4890,6 +3534,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4903,11 +3550,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c"
                         }
                       }
                     },
@@ -4920,21 +3565,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.5c"
                         }
                       }
                     }
@@ -4945,6 +3575,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -4958,11 +3591,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c"
                         }
                       }
                     },
@@ -4975,21 +3606,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.6c"
                         }
                       }
                     }
@@ -5000,6 +3616,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5013,11 +3632,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c"
                         }
                       }
                     },
@@ -5030,21 +3647,6 @@
                         },
                         "price": {
                           "ta10Ref": "7.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "7.7c"
                         }
                       }
                     }
@@ -5055,12 +3657,41 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "7.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherRooms": {
                   "ta10Ref": "7.8",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "7.8b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -5072,26 +3703,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "7.8a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "7.8c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "7.8b"
-                          },
-                          "comments": {
-                            "ta10Ref": "7.8c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -5123,11 +3735,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c"
                         }
                       }
                     },
@@ -5140,21 +3750,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.1c"
                         }
                       }
                     }
@@ -5165,6 +3760,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5178,11 +3776,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c"
                         }
                       }
                     },
@@ -5195,21 +3791,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.2c"
                         }
                       }
                     }
@@ -5220,6 +3801,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5233,11 +3817,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c"
                         }
                       }
                     },
@@ -5250,21 +3832,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.3c"
                         }
                       }
                     }
@@ -5275,6 +3842,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5288,11 +3858,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c"
                         }
                       }
                     },
@@ -5305,21 +3873,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.4c"
                         }
                       }
                     }
@@ -5330,6 +3883,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5343,11 +3899,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c"
                         }
                       }
                     },
@@ -5360,21 +3914,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.5b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.5c"
                         }
                       }
                     }
@@ -5385,6 +3924,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.5a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5398,11 +3940,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c"
                         }
                       }
                     },
@@ -5415,21 +3955,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.6b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.6c"
                         }
                       }
                     }
@@ -5440,6 +3965,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.6a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5453,11 +3981,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c"
                         }
                       }
                     },
@@ -5470,21 +3996,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.7b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.7c"
                         }
                       }
                     }
@@ -5495,6 +4006,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.7a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5508,11 +4022,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c"
                         }
                       }
                     },
@@ -5525,21 +4037,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.8b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.8c"
                         }
                       }
                     }
@@ -5550,6 +4047,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.8a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5563,11 +4063,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c"
                         }
                       }
                     },
@@ -5580,21 +4078,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.9b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.9c"
                         }
                       }
                     }
@@ -5605,6 +4088,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.9a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5618,11 +4104,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c"
                         }
                       }
                     },
@@ -5635,21 +4119,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.10b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.10c"
                         }
                       }
                     }
@@ -5660,6 +4129,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.10a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5673,11 +4145,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c"
                         }
                       }
                     },
@@ -5690,21 +4160,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.11b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.11c"
                         }
                       }
                     }
@@ -5715,6 +4170,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.11a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5728,11 +4186,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c"
                         }
                       }
                     },
@@ -5745,21 +4201,6 @@
                         },
                         "price": {
                           "ta10Ref": "8.12b"
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "8.12c"
                         }
                       }
                     }
@@ -5770,12 +4211,41 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "8.12a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
                 "otherItems": {
                   "ta10Ref": "8.13",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "8.13b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -5787,26 +4257,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "8.13a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "8.13c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "8.13b"
-                          },
-                          "comments": {
-                            "ta10Ref": "8.13c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }
@@ -5830,11 +4281,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c"
                         }
                       }
                     },
@@ -5847,21 +4296,6 @@
                         },
                         "price": {
                           "ta10Ref": "9.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.1c"
                         }
                       }
                     }
@@ -5872,6 +4306,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "9.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5885,11 +4322,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c"
                         }
                       }
                     },
@@ -5902,21 +4337,6 @@
                         },
                         "price": {
                           "ta10Ref": "9.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.2c"
                         }
                       }
                     }
@@ -5927,6 +4347,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "9.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5940,11 +4363,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c"
                         }
                       }
                     },
@@ -5957,21 +4378,6 @@
                         },
                         "price": {
                           "ta10Ref": "9.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.3c"
                         }
                       }
                     }
@@ -5982,6 +4388,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "9.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -5995,11 +4404,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c"
                         }
                       }
                     },
@@ -6012,21 +4419,6 @@
                         },
                         "price": {
                           "ta10Ref": "9.4b"
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "9.4c"
                         }
                       }
                     }
@@ -6037,6 +4429,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "9.4a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 }
@@ -6060,11 +4455,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c"
                         }
                       }
                     },
@@ -6077,21 +4470,6 @@
                         },
                         "price": {
                           "ta10Ref": "10.1b"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.1c"
                         }
                       }
                     }
@@ -6102,6 +4480,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "10.1a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -6115,11 +4496,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c"
                         }
                       }
                     },
@@ -6132,21 +4511,6 @@
                         },
                         "price": {
                           "ta10Ref": "10.2b"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.2c"
                         }
                       }
                     }
@@ -6157,6 +4521,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "10.2a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 },
@@ -6170,11 +4537,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c"
                         }
                       }
                     },
@@ -6187,21 +4552,6 @@
                         },
                         "price": {
                           "ta10Ref": "10.3b"
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "ta10Ref": "10.3c"
                         }
                       }
                     }
@@ -6212,6 +4562,9 @@
                   "properties": {
                     "isIncludedExcludedOrNone": {
                       "ta10Ref": "10.3a"
+                    },
+                    "comments": {
+                      "ta10Ref": "1.1c"
                     }
                   }
                 }
@@ -6223,6 +4576,32 @@
                 "otherItems": {
                   "ta10Ref": "11.1",
                   "items": {
+                    "discriminator": {
+                      "propertyName": "isIncludedOrExcluded"
+                    },
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Included"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "properties": {
+                          "isIncludedOrExcluded": {
+                            "enum": [
+                              "Excluded"
+                            ]
+                          },
+                          "price": {
+                            "ta10Ref": "11.1b"
+                          }
+                        }
+                      }
+                    ],
                     "required": [
                       "itemName",
                       "isIncludedOrExcluded"
@@ -6234,26 +4613,7 @@
                       "isIncludedOrExcluded": {
                         "ta10Ref": "11.1a"
                       }
-                    },
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "comments": {
-                            "ta10Ref": "11.1c"
-                          }
-                        }
-                      },
-                      {
-                        "properties": {
-                          "price": {
-                            "ta10Ref": "11.1b"
-                          },
-                          "comments": {
-                            "ta10Ref": "11.1c"
-                          }
-                        }
-                      }
-                    ]
+                    }
                   }
                 }
               }

--- a/src/schemas/v3/overlays/ta10.json
+++ b/src/schemas/v3/overlays/ta10.json
@@ -2366,7 +2366,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2406,7 +2407,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2446,7 +2448,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2486,7 +2489,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2526,7 +2530,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2566,7 +2571,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2606,7 +2612,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2703,7 +2710,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2743,7 +2751,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2783,7 +2792,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2823,7 +2833,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2863,7 +2874,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2903,7 +2915,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -2943,7 +2956,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }

--- a/src/schemas/v3/overlays/ta7.json
+++ b/src/schemas/v3/overlays/ta7.json
@@ -36,7 +36,6 @@
             "ownershipsToBeTransferred": {
               "ta7Ref": "1",
               "items": {
-                "ta7Ref": "1",
                 "discriminator": {
                   "propertyName": "ownershipType"
                 },
@@ -1339,6 +1338,7 @@
                     }
                   }
                 ],
+                "ta7Ref": "1",
                 "required": [
                   "ownershipType"
                 ],

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -10074,6 +10074,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10081,12 +10085,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10100,23 +10101,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10134,6 +10118,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10141,12 +10129,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10160,23 +10145,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10194,6 +10162,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10201,12 +10173,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10220,23 +10189,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10254,6 +10206,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10261,12 +10217,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10280,23 +10233,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10314,6 +10250,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10321,12 +10261,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10340,23 +10277,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10374,6 +10294,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10381,12 +10305,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10400,23 +10321,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10434,6 +10338,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10441,12 +10349,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10460,23 +10365,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10494,6 +10382,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10501,12 +10393,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10520,23 +10409,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10554,6 +10426,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10561,12 +10437,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10580,23 +10453,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10614,6 +10470,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10621,12 +10481,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10640,23 +10497,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10674,6 +10514,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10681,12 +10525,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10700,23 +10541,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10734,6 +10558,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10741,12 +10569,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10760,23 +10585,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10794,6 +10602,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10801,12 +10613,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10820,23 +10629,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10854,6 +10646,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10861,12 +10657,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10880,23 +10673,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10914,6 +10690,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -10921,12 +10701,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -10940,23 +10717,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -10988,10 +10748,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -11005,10 +10761,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -11034,9 +10786,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11047,7 +10812,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11055,35 +10820,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11101,7 +10838,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11109,48 +10846,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11168,9 +10864,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11181,7 +10890,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11189,35 +10898,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11235,7 +10916,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11243,48 +10924,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11302,9 +10942,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11315,7 +10968,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11323,35 +10976,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11369,7 +10994,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11377,48 +11002,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11436,9 +11020,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11449,7 +11046,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11457,35 +11054,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11503,7 +11072,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11511,48 +11080,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11570,9 +11098,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11583,7 +11124,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11591,35 +11132,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11637,7 +11150,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11645,48 +11158,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11704,9 +11176,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11717,7 +11202,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11725,35 +11210,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11771,7 +11228,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11779,48 +11236,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11838,9 +11254,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11851,7 +11280,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11859,35 +11288,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -11905,7 +11306,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11913,48 +11314,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -11972,9 +11332,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -11985,7 +11358,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -11993,35 +11366,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -12039,7 +11384,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -12047,48 +11392,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -12106,9 +11410,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -12119,7 +11436,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -12127,35 +11444,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -12173,7 +11462,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -12181,48 +11470,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -12240,9 +11488,22 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
+                    {
+                      "properties": {
+                        "isIncludedExcludedOrNone": {
+                          "enum": [
+                            "None"
+                          ]
+                        }
+                      }
+                    },
                     {
                       "properties": {
                         "isIncludedExcludedOrNone": {
@@ -12253,7 +11514,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -12261,35 +11522,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
+                          }
                         }
                       }
                     },
@@ -12307,7 +11540,7 @@
                         "fittedOrFreestanding": {
                           "type": "object",
                           "properties": {
-                            "isFittedOrFreestanding": {
+                            "fittedOrFreestanding": {
                               "title": "Fitted, Freestanding",
                               "type": "string",
                               "enum": [
@@ -12315,48 +11548,7 @@
                                 "Freestanding"
                               ]
                             }
-                          },
-                          "oneOf": [
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Fitted"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            {
-                              "properties": {
-                                "isFittedOrFreestanding": {
-                                  "enum": [
-                                    "Freestanding"
-                                  ]
-                                },
-                                "comments": {
-                                  "title": "Comments",
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          ]
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
+                          }
                         }
                       }
                     }
@@ -12392,7 +11584,7 @@
                           "fittedOrFreestanding": {
                             "type": "object",
                             "properties": {
-                              "isFittedOrFreestanding": {
+                              "fittedOrFreestanding": {
                                 "title": "Fitted, Freestanding",
                                 "type": "string",
                                 "enum": [
@@ -12404,27 +11596,19 @@
                             "oneOf": [
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": [
                                       "Fitted"
                                     ]
-                                  },
-                                  "comments": {
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               },
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": [
                                       "Freestanding"
                                     ]
-                                  },
-                                  "comments": {
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               }
@@ -12446,7 +11630,7 @@
                           "fittedOrFreestanding": {
                             "type": "object",
                             "properties": {
-                              "isFittedOrFreestanding": {
+                              "fittedOrFreestanding": {
                                 "title": "Fitted, Freestanding",
                                 "type": "string",
                                 "enum": [
@@ -12458,27 +11642,19 @@
                             "oneOf": [
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": [
                                       "Fitted"
                                     ]
-                                  },
-                                  "comments": {
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               },
                               {
                                 "properties": {
-                                  "isFittedOrFreestanding": {
+                                  "fittedOrFreestanding": {
                                     "enum": [
                                       "Freestanding"
                                     ]
-                                  },
-                                  "comments": {
-                                    "title": "Comments",
-                                    "type": "string"
                                   }
                                 }
                               }
@@ -12492,10 +11668,6 @@
                             "enum": [
                               "None"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -12520,6 +11692,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12527,12 +11703,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12546,23 +11719,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12580,6 +11736,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12587,12 +11747,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12606,23 +11763,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12640,6 +11780,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12647,12 +11791,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12666,23 +11807,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12700,6 +11824,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12707,12 +11835,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12726,23 +11851,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12760,6 +11868,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12767,12 +11879,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12786,23 +11895,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12820,6 +11912,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12827,12 +11923,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12846,23 +11939,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12880,6 +11956,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12887,12 +11967,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12906,23 +11983,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -12940,6 +12000,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -12947,12 +12011,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -12966,23 +12027,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13000,6 +12044,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13007,12 +12055,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13026,23 +12071,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13060,6 +12088,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13067,12 +12099,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13086,23 +12115,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13126,6 +12138,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13133,12 +12149,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13152,23 +12165,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13186,6 +12182,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13193,12 +12193,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13212,23 +12209,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13246,6 +12226,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13253,12 +12237,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13272,23 +12253,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13306,6 +12270,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13313,12 +12281,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13332,23 +12297,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13366,6 +12314,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13373,12 +12325,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13392,23 +12341,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13426,6 +12358,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13433,12 +12369,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13452,23 +12385,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13486,6 +12402,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -13493,12 +12413,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -13512,23 +12429,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -13560,10 +12460,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -13577,10 +12473,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -13609,6 +12501,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13618,10 +12514,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13635,23 +12527,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13669,6 +12544,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13678,10 +12557,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13695,23 +12570,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13729,6 +12587,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13738,10 +12600,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13755,23 +12613,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13789,6 +12630,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13798,10 +12643,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13815,23 +12656,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13849,6 +12673,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13858,10 +12686,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13875,23 +12699,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13909,6 +12716,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13918,10 +12729,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13935,23 +12742,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -13969,6 +12759,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -13978,10 +12772,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -13995,23 +12785,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14043,10 +12816,6 @@
                                 "enum": [
                                   "Included"
                                 ]
-                              },
-                              "comments": {
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           },
@@ -14060,10 +12829,6 @@
                               "price": {
                                 "title": "Price",
                                 "type": "number"
-                              },
-                              "comments": {
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           }
@@ -14088,6 +12853,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14097,10 +12866,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14114,23 +12879,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14148,6 +12896,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14157,10 +12909,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14174,23 +12922,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14208,6 +12939,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14217,10 +12952,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14234,23 +12965,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14268,6 +12982,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14277,10 +12995,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14294,23 +13008,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14328,6 +13025,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14337,10 +13038,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14354,23 +13051,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14388,6 +13068,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14397,10 +13081,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14414,23 +13094,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14448,6 +13111,10 @@
                             "Excluded",
                             "None"
                           ]
+                        },
+                        "comments": {
+                          "title": "Comments",
+                          "type": "string"
                         }
                       },
                       "oneOf": [
@@ -14457,10 +13124,6 @@
                               "enum": [
                                 "Included"
                               ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         },
@@ -14474,23 +13137,6 @@
                             "price": {
                               "title": "Price",
                               "type": "number"
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "isIncludedExcludedOrNone": {
-                              "enum": [
-                                "None"
-                              ]
-                            },
-                            "comments": {
-                              "title": "Comments",
-                              "type": "string"
                             }
                           }
                         }
@@ -14522,10 +13168,6 @@
                                 "enum": [
                                   "Included"
                                 ]
-                              },
-                              "comments": {
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           },
@@ -14539,10 +13181,6 @@
                               "price": {
                                 "title": "Price",
                                 "type": "number"
-                              },
-                              "comments": {
-                                "title": "Comments",
-                                "type": "string"
                               }
                             }
                           }
@@ -14570,6 +13208,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14577,12 +13219,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14596,23 +13235,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14630,6 +13252,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14637,12 +13263,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14656,23 +13279,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14690,6 +13296,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14697,12 +13307,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14716,23 +13323,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14750,6 +13340,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14757,12 +13351,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14776,23 +13367,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14810,6 +13384,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14817,12 +13395,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14836,23 +13411,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14870,6 +13428,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14877,12 +13439,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14896,23 +13455,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -14930,6 +13472,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -14937,12 +13483,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -14956,23 +13499,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15004,10 +13530,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -15021,10 +13543,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -15050,6 +13568,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15057,12 +13579,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15076,23 +13595,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15110,6 +13612,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15117,12 +13623,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15136,23 +13639,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15170,6 +13656,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15177,12 +13667,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15196,23 +13683,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15230,6 +13700,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15237,12 +13711,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15256,23 +13727,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15290,6 +13744,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15297,12 +13755,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15316,23 +13771,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15350,6 +13788,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15357,12 +13799,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15376,23 +13815,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15410,6 +13832,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15417,12 +13843,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15436,23 +13859,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15484,10 +13890,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -15501,10 +13903,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -15529,6 +13927,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15536,12 +13938,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15555,23 +13954,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15589,6 +13971,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15596,12 +13982,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15615,23 +13998,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15649,6 +14015,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15656,12 +14026,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15675,23 +14042,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15709,6 +14059,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15716,12 +14070,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15735,23 +14086,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15769,6 +14103,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15776,12 +14114,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15795,23 +14130,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15829,6 +14147,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15836,12 +14158,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15855,23 +14174,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15889,6 +14191,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15896,12 +14202,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15915,23 +14218,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -15949,6 +14235,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -15956,12 +14246,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -15975,23 +14262,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16009,6 +14279,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16016,12 +14290,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16035,23 +14306,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16069,6 +14323,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16076,12 +14334,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16095,23 +14350,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16129,6 +14367,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16136,12 +14378,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16155,23 +14394,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16189,6 +14411,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16196,12 +14422,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16215,23 +14438,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16263,10 +14469,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -16280,10 +14482,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -16308,6 +14506,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16315,12 +14517,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16334,23 +14533,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16368,6 +14550,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16375,12 +14561,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16394,23 +14577,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16428,6 +14594,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16435,12 +14605,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16454,23 +14621,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16488,6 +14638,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16495,12 +14649,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16514,23 +14665,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16554,6 +14688,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16561,12 +14699,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16580,23 +14715,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16614,6 +14732,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16621,12 +14743,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16640,23 +14759,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16674,6 +14776,10 @@
                         "Excluded",
                         "None"
                       ]
+                    },
+                    "comments": {
+                      "title": "Comments",
+                      "type": "string"
                     }
                   },
                   "oneOf": [
@@ -16681,12 +14787,9 @@
                       "properties": {
                         "isIncludedExcludedOrNone": {
                           "enum": [
-                            "Included"
+                            "Included",
+                            "None"
                           ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     },
@@ -16700,23 +14803,6 @@
                         "price": {
                           "title": "Price",
                           "type": "number"
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
-                        }
-                      }
-                    },
-                    {
-                      "properties": {
-                        "isIncludedExcludedOrNone": {
-                          "enum": [
-                            "None"
-                          ]
-                        },
-                        "comments": {
-                          "title": "Comments",
-                          "type": "string"
                         }
                       }
                     }
@@ -16754,10 +14840,6 @@
                             "enum": [
                               "Included"
                             ]
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       },
@@ -16771,10 +14853,6 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
-                          },
-                          "comments": {
-                            "title": "Comments",
-                            "type": "string"
                           }
                         }
                       }
@@ -27357,7 +25435,7 @@
                                 }
                               ]
                             },
-                            "lheLocalAuthorityReceivedANoticeOfDisposal": {
+                            "theLocalAuthorityReceivedANoticeOfDisposal": {
                               "title": "Has the Local Authority received a notice of disposal?",
                               "type": "object",
                               "properties": {
@@ -33338,11 +31416,7 @@
                                     ]
                                   },
                                   "planOnlyIndicator": {
-                                    "type": "string",
-                                    "enum": [
-                                      "true",
-                                      "false"
-                                    ]
+                                    "type": "boolean"
                                   },
                                   "filedUnder": {
                                     "type": "string"

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -12512,7 +12512,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12555,7 +12556,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12598,7 +12600,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12641,7 +12644,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12684,7 +12688,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12727,7 +12732,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12770,7 +12776,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12864,7 +12871,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12907,7 +12915,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12950,7 +12959,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -12993,7 +13003,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -13036,7 +13047,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -13079,7 +13091,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }
@@ -13122,7 +13135,8 @@
                           "properties": {
                             "isIncludedExcludedOrNone": {
                               "enum": [
-                                "Included"
+                                "Included",
+                                "None"
                               ]
                             }
                           }

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -1447,110 +1447,97 @@
         "otherItems": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
       "kitchen": {
         "hob": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "extractorHood": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "ovenGrill": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "cooker": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "microwave": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "refrigeratorFridgeFreezer": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "freezer": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "dishwasher": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "tumbleDryer": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "washingMachine": {
           "isIncludedExcludedOrNone": {},
+          "comments": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         },
         "otherItems": {
           "itemName": {},
           "isIncludedOrExcluded": {},
           "fittedOrFreestanding": {
-            "isFittedOrFreestanding": {},
-            "comments": {}
+            "fittedOrFreestanding": {}
           },
-          "price": {},
-          "comments": {}
+          "price": {}
         }
       },
       "bathroom": {
@@ -1644,7 +1631,6 @@
         "otherRooms": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
@@ -1688,7 +1674,6 @@
           "otherRooms": {
             "itemName": {},
             "isIncludedOrExcluded": {},
-            "comments": {},
             "price": {}
           }
         },
@@ -1731,7 +1716,6 @@
           "otherRooms": {
             "itemName": {},
             "isIncludedOrExcluded": {},
-            "comments": {},
             "price": {}
           }
         }
@@ -1775,7 +1759,6 @@
         "otherRooms": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
@@ -1818,7 +1801,6 @@
         "otherRooms": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
@@ -1886,7 +1868,6 @@
         "otherItems": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
@@ -1933,7 +1914,6 @@
         "otherItems": {
           "itemName": {},
           "isIncludedOrExcluded": {},
-          "comments": {},
           "price": {}
         }
       },
@@ -3326,7 +3306,7 @@
                 "yesNo": {},
                 "details": {}
               },
-              "lheLocalAuthorityReceivedANoticeOfDisposal": {
+              "theLocalAuthorityReceivedANoticeOfDisposal": {
                 "yesNo": {},
                 "details": {}
               },

--- a/src/utils/extractOverlay.js
+++ b/src/utils/extractOverlay.js
@@ -64,43 +64,60 @@ const extractOverlay = (sourceSchema, ref) => {
     if (path === "/") path = "";
     if (element[refName]) {
       jp.set(returnSchema, `${path}/${refName}`, element[refName]);
-      overlayIncludeProperties.forEach((property) => {
-        if (element[property]) {
-          jp.set(returnSchema, `${path}/${property}`, element[property]);
-        }
-      });
 
-      const { discriminator } = element;
-      if (discriminator) {
-        const { propertyName } = discriminator;
-        element.oneOf.forEach((item, index) => {
-          const discriminatorProperty = item.properties[propertyName];
-          // copy const discriminator as-is
-          if (discriminatorProperty.const) {
+      if (element.discriminator) {
+        jp.set(returnSchema, `${path}/discriminator`, element.discriminator);
+        const { propertyName } = element.discriminator;
+        element.oneOf.forEach((oneOf, index) => {
+          const discriminatorProperty = oneOf.properties[propertyName];
+          // must be an enum
+          const discriminatorEnumPath = `${path}/oneOf/${index}/properties/${propertyName}/enum`;
+          // if a refEnum use that
+          const refEnum = `${ref}Enum`;
+          if (discriminatorProperty[refEnum]) {
             jp.set(
               returnSchema,
-              `${path}/oneOf/${index}/properties/${propertyName}/const`,
-              discriminatorProperty.const
+              discriminatorEnumPath,
+              discriminatorProperty[refEnum]
             );
           } else {
-            // must be an enum
-            const discriminatorEnumPath = `${path}/oneOf/${index}/properties/${propertyName}/enum`;
-            // if a refEnum use that
-            const refEnum = `${ref}Enum`;
-            if (discriminatorProperty[refEnum]) {
-              jp.set(
-                returnSchema,
-                discriminatorEnumPath,
-                discriminatorProperty[refEnum]
-              );
-            } else {
-              // use the base enum
-              jp.set(
-                returnSchema,
-                discriminatorEnumPath,
-                discriminatorProperty.enum
-              );
-            }
+            // use the base enum
+            jp.set(
+              returnSchema,
+              discriminatorEnumPath,
+              discriminatorProperty.enum
+            );
+          }
+        });
+      }
+
+      // also handle discriminator properties nested in items
+      if (element.items?.discriminator) {
+        jp.set(
+          returnSchema,
+          `${path}/items/discriminator`,
+          element.items.discriminator
+        );
+        const { propertyName } = element.items.discriminator;
+        element.items.oneOf.forEach((oneOf, index) => {
+          const discriminatorProperty = oneOf.properties[propertyName];
+          // must be an enum
+          const discriminatorEnumPath = `${path}/items/oneOf/${index}/properties/${propertyName}/enum`;
+          // if a refEnum use that
+          const refEnum = `${ref}Enum`;
+          if (discriminatorProperty[refEnum]) {
+            jp.set(
+              returnSchema,
+              discriminatorEnumPath,
+              discriminatorProperty[refEnum]
+            );
+          } else {
+            // use the base enum
+            jp.set(
+              returnSchema,
+              discriminatorEnumPath,
+              discriminatorProperty.enum
+            );
           }
         });
       }


### PR DESCRIPTION
A number of changes which:

* Fix some bugs in the way `extractOverlay.js` extracted `discriminator` and `oneOf` segments when inside `items` arrays, which was causing validation with overlays to fail
* Simplify the TA10 structure
* Fix a typo in a CON29R field `lheLocalAuthorityReceivedANoticeOfDisposal`
* Fix a boolean HMLR field `planOnlyIndicator' that had not been converted when we did the rest for v3.0.0