### PR TITLE
Add "Not available" to `councilTaxBand` 

### DIFF
--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -8182,7 +8182,8 @@
                 "F",
                 "G",
                 "H",
-                "I"
+                "I",
+                "Not available"
               ]
             },
             "councilTaxAffectingAlterations": {


### PR DESCRIPTION
resolves #176 
resolves #80 

I think there is still a discussion to be had here on two points:

- Do we add "Not available" to TA6 overlay as this is not valid answer in form.
- Do we add a details section when "Not available" is selected. I didnt do this here as i think it would drive another object unless we called the details `notAvailableDetails`. The below is probs cleaner but a breaking change:
```
    "councilTax": {
      "councilTaxBand": {
        "allocation": "Not available",  # A, B ...
        "details": "new build property"
      },
      "councilTaxAffectingAlterations": {
        "yesNo": "No"
      }
    },
```
