### PR TITLE
titlesToBeSold.registerExtract.ocSummaryData.propertyAddress supports array

### DIFF
--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -684,14 +684,18 @@
               "commonholdIndicator": false
             },
             "officialCopyDateTime": "2021-12-16T08:39:52",
-            "propertyAddress": {
-              "postcodeZone": {
-                "postcode": "AL3 5AF"
+            "propertyAddress": [
+              {
+                "postcodeZone": {
+                  "postcode": "AL3 5AF"
+                }
               },
-              "addressLine": {
-                "line": ["47 Park Road", "Harpenden"]
+              {
+                "addressLine": {
+                  "line": ["47 Park Road", "Harpenden"]
+                }
               }
-            },
+            ],
             "proprietorship": {
               "registeredProprietorParty": [
                 {

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -28435,31 +28435,66 @@
                         }
                       },
                       "propertyAddress": {
-                        "type": "object",
-                        "oc1Required": ["addressLine"],
-                        "properties": {
-                          "postcodeZone": {
-                            "type": "object",
-                            "oc1Required": ["postcode"],
-                            "properties": {
-                              "postcode": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "addressLine": {
-                            "type": "object",
-                            "properties": {
-                              "line": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "oc1Required": ["addressLine"],
+                              "properties": {
+                                "postcodeZone": {
+                                  "type": "object",
+                                  "oc1Required": ["postcode"],
+                                  "properties": {
+                                    "postcode": {
+                                      "type": "string"
+                                    }
+                                  }
                                 },
-                                "minItems": 0
+                                "addressLine": {
+                                  "type": "object",
+                                  "properties": {
+                                    "line": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minItems": 0
+                          },
+                          {
+                            "type": "object",
+                            "oc1Required": ["addressLine"],
+                            "properties": {
+                              "postcodeZone": {
+                                "type": "object",
+                                "oc1Required": ["postcode"],
+                                "properties": {
+                                  "postcode": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "addressLine": {
+                                "type": "object",
+                                "properties": {
+                                  "line": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 0
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "type": "object",

--- a/src/schemas/v3/overlays/oc1.json
+++ b/src/schemas/v3/overlays/oc1.json
@@ -37,16 +37,34 @@
                         }
                       },
                       "propertyAddress": {
-                        "required": [
-                          "addressLine"
-                        ],
-                        "properties": {
-                          "postcodeZone": {
+                        "oneOf": [
+                          {
+                            "items": {
+                              "required": [
+                                "addressLine"
+                              ],
+                              "properties": {
+                                "postcodeZone": {
+                                  "required": [
+                                    "postcode"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          {
                             "required": [
-                              "postcode"
-                            ]
+                              "addressLine"
+                            ],
+                            "properties": {
+                              "postcodeZone": {
+                                "required": [
+                                  "postcode"
+                                ]
+                              }
+                            }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "required": [

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -25685,29 +25685,62 @@
                         }
                       },
                       "propertyAddress": {
-                        "type": "object",
-                        "properties": {
-                          "postcodeZone": {
-                            "type": "object",
-                            "properties": {
-                              "postcode": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "addressLine": {
-                            "type": "object",
-                            "properties": {
-                              "line": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "postcodeZone": {
+                                  "type": "object",
+                                  "properties": {
+                                    "postcode": {
+                                      "type": "string"
+                                    }
+                                  }
                                 },
-                                "minItems": 0
+                                "addressLine": {
+                                  "type": "object",
+                                  "properties": {
+                                    "line": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minItems": 0
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "postcodeZone": {
+                                "type": "object",
+                                "properties": {
+                                  "postcode": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "addressLine": {
+                                "type": "object",
+                                "properties": {
+                                  "line": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 0
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "type": "object",


### PR DESCRIPTION
resolves #179 

Needs to be support an array as some title responses have more than one addressLine objects.