### PR TITLE
Add 'additionalDocuments' to titles

### DIFF
--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -38206,6 +38206,39 @@
                     }
                   }
                 }
+              }, 
+              "additionalDocuments": {
+                "title": "Additional documents referred to in title register",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "documentType": {
+                      "title": "Human-readable document type",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentTypeCode": {
+                      "title": "HMLR document type code",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentDate": {
+                      "title": "Date of original document",
+                      "type": "string",
+                      "fornat": "date"
+                    },
+                    "retrievedOn": {
+                      "title": "Datetime retrieved from HMLR",
+                      "type": "string",
+                      "fornat": "date-time"
+                    },
+                    "filedUnder": {
+                      "title": "Related title number",
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -33403,6 +33403,39 @@
                     }
                   }
                 }
+              },
+              "additionalDocuments": {
+                "title": "Additional documents referred to in title register",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "documentType": {
+                      "title": "Human-readable document type",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentTypeCode": {
+                      "title": "HMLR document type code",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentDate": {
+                      "title": "Date of original document",
+                      "type": "string",
+                      "fornat": "date"
+                    },
+                    "retrievedOn": {
+                      "title": "Datetime retrieved from HMLR",
+                      "type": "string",
+                      "fornat": "date-time"
+                    },
+                    "filedUnder": {
+                      "title": "Related title number",
+                      "type": "string"
+                    }
+                  }
+                }
               }
             }
           }

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -3986,6 +3986,13 @@
             }
           }
         }
+      },
+      "additionalDocuments": {
+        "documentType": {},
+        "documentTypeCode": {},
+        "documentDate": {},
+        "retrievedOn": {},
+        "filedUnder": {}
       }
     },
     "searches": {


### PR DESCRIPTION
Adds an `additionalDocuments` section to the `titlesToBeSold` property to allow references to downloaded OC2 documents, to facilitate sharing with lawyers etc.