### PR TITLE
Extend role and capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ The short term goal for the schema is to encompass all of the requirements of th
 
 A parallel repository for this one has been created for the [Open API Specifications](https://github.com/Property-Data-Trust-Framework/api) for the data exchanges themselves, which will evolve independently.
 
+This repository is intended to be a living document, with the schema evolving over time as the requirements of the framework are refined and extended. The schema is versioned to allow for backwards compatibility and to enable the evolution of the schema over time.
+
+## Licensing
+The schema is licenced under the permissive [MIT License](https://opensource.org/license/MIT), but note that overlays and references are included which contain fields from [BASPI](https://homebuyingsellingcouncil.co.uk/wp-content/uploads/2021/03/Terms-of-Licence-mandatory-download-for-use-of-BASPI.pdf), [PIQ](https://www.propertymark.co.uk/static/14e7c154-98de-4230-957f09bd8d5ddeec/f542b10a-7710-4c37-b3958ccaeec25d4b/property-information-questionnaire-residential-sales.pdf) and [Law Society TA](https://www.lawsociety.org.uk/topics/property/transaction-forms) forms. If you intend to render data described by the schema into one of these forms, you should ensure that you comply with the terms of the respective licences.
+

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const ajv = new Ajv({
 // Adds date formats among other types to the validator.
 addFormats(ajv);
 
-const verifiedClaimsSchema = require("./src/schemas/v1/pdtf-verified-claims.json");
+const verifiedClaimsSchema = require("./src/schemas/verifiedClaims/pdtf-verified-claims.json");
 const v2CoreSchema = require("./src/schemas/v2/pdtf-transaction.json");
 const v3CoreSchema = require("./src/schemas/v3/pdtf-transaction.json");
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { dereference } = require("@jdw/jst");
 const merge = require("deepmerge");
 const Ajv = require("ajv");
 const addFormats = require("ajv-formats");
@@ -33,7 +32,8 @@ const overlaysMap = {
     null: {},
   },
   "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json": {
-    baspiV4: require("./src/schemas/v3/overlays/baspi.json"),
+    baspiV4: require("./src/schemas/v3/overlays/baspi4.json"),
+    baspiV5: require("./src/schemas/v3/overlays/baspi5.json"),
     ta6ed4: require("./src/schemas/v3/overlays/ta6.json"),
     ta7ed3: require("./src/schemas/v3/overlays/ta7.json"),
     ta10ed3: require("./src/schemas/v3/overlays/ta10.json"),
@@ -47,6 +47,7 @@ const overlaysMap = {
     rdsV333: require("./src/schemas/v3/overlays/rds.json"),
     oc1v21: require("./src/schemas/v3/overlays/oc1.json"),
     piqV3: require("./src/schemas/v3/overlays/piq.json"),
+    sr24: require("./src/schemas/v3/overlays/sr24.json"),
     null: {},
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pdtf/schemas",
-  "version": "2.3.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pdtf/schemas",
-      "version": "2.3.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@jdw/jst": "^2.0.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Property Data Trust Framework Schemas and Utilities",
   "main": "index.js",
   "directories": {

--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -5,16 +5,21 @@
   "participants": [
     {
       "name": {
+        "title": "Mr",
         "firstName": "Peter",
         "lastName": "Hetherington-Smythe"
       },
       "dateOfBirth": "1975-12-25",
       "phone": "07777 222333",
       "email": "peter@theseller.com",
-      "address": { "line1": "47 Park Road", "postcode": "AL3 5AF" },
+      "address": {
+        "line1": "47 Park Road",
+        "postcode": "AL3 5AF",
+        "countryCode": "GBR"
+      },
       "role": "Seller",
       "sellersCapacity": { "capacity": "Legal Owner" },
-      "externalIds": { "MoveReady": "123434" }
+      "externalIds": { "Moverly": "123434" }
     },
     {
       "role": "Seller's Conveyancer",
@@ -23,7 +28,8 @@
         "line1": "123 Sweet St",
         "line2": "Test building",
         "town": "London",
-        "postcode": "SW1A 1AA"
+        "postcode": "SW1A 1AA",
+        "countryCode": "GBR"
       },
       "email": "johnny@suemme.co.uk",
       "organisation": "Suemme and Profitt",
@@ -37,9 +43,14 @@
       "line2": "",
       "line3": "",
       "town": "HARPENDEN",
-      "postcode": "AL3 5AF"
+      "postcode": "AL3 5AF",
+      "homeNation": "England"
     },
-    "localAuthority": { "localAuthorityName": "Neverland Hook" },
+    "localAuthority": {
+      "localAuthorityName": "Neverland Hook",
+      "districtCouncil": "Neverland Hook",
+      "countyCouncil": "Neverland County Council"
+    },
     "priceInformation": {
       "price": 1260000,
       "priceQualifier": "Offers in excess of"
@@ -683,14 +694,18 @@
               "commonholdIndicator": false
             },
             "officialCopyDateTime": "2021-12-16T08:39:52",
-            "propertyAddress": {
-              "postcodeZone": {
-                "postcode": "AL3 5AF"
+            "propertyAddress": [
+              {
+                "postcodeZone": {
+                  "postcode": "AL3 5AF"
+                }
               },
-              "addressLine": {
-                "line": ["47 Park Road", "Harpenden"]
+              {
+                "addressLine": {
+                  "line": ["47 Park Road", "Harpenden"]
+                }
               }
-            },
+            ],
             "proprietorship": {
               "registeredProprietorParty": [
                 {

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -4,7 +4,8 @@
   "type": "object",
   "title": "Property Data Trust Framework Transaction Schema",
   "description": "A schema defining the PDTF transaction data structure, supporting mapping to BASPI, Law Society and RICS Data Schema elements. The schema currently supports transactions conducted in England and Wales only.",
-  "baspiRequired": ["participants", "propertyPack"],
+  "baspi4Required": ["participants", "propertyPack"],
+  "baspi5Required": ["participants", "propertyPack"],
   "ta6Required": ["participants", "propertyPack"],
   "ntsRequired": ["propertyPack"],
   "ntslRequired": ["propertyPack"],
@@ -34,19 +35,29 @@
       ]
     },
     "participants": {
+      "baspi4Ref": "B1",
+      "baspi5Ref": "B1",
+      "piqRef": "B1",
       "title": "Transaction participants",
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
         "title": "Participant Details",
-        "baspiRequired": ["name", "email", "role"],
+        "baspi4Required": ["name", "email", "role"],
+        "baspi5Required": ["name", "email", "role"],
         "properties": {
           "name": {
             "title": "Name",
             "type": "object",
-            "baspiRequired": ["firstName", "lastName"],
+            "baspi4Required": ["firstName", "lastName"],
+            "baspi5Required": ["firstName", "lastName"],
             "properties": {
+              "title": {
+                "title": "Title or honorific",
+                "type": "string",
+                "enum": ["Mr", "Mrs", "Miss", "Ms", "Mx", "Dr"]
+              },
               "firstName": {
                 "title": "First name",
                 "type": "string",
@@ -60,6 +71,10 @@
                 "title": "lastName",
                 "type": "string",
                 "minLength": 1
+              },
+              "maidenName": {
+                "title": "Middle name(s)",
+                "type": "string"
               },
               "preferredName": {
                 "title": "Preferred name / known as",
@@ -85,6 +100,24 @@
             "title": "Address",
             "type": "object",
             "properties": {
+              "buildingNumber": {
+                "title": "Building number",
+                "type": "string",
+                "minLength": 1
+              },
+              "buildingName": {
+                "title": "Building name",
+                "type": "string"
+              },
+              "subBuilding": {
+                "title": "Sub building name",
+                "type": "string"
+              },
+              "street": {
+                "title": "Street",
+                "type": "string",
+                "minLength": 1
+              },
               "line1": {
                 "title": "Address 1",
                 "type": "string",
@@ -106,9 +139,22 @@
                 "title": "Postcode",
                 "type": "string",
                 "minLength": 1
+              },
+              "homeNation": {
+                "title": "Home nation",
+                "type": "string",
+                "enum": ["England", "Wales", "Scotland", "Northern Ireland"]
+              },
+              "countryCode": {
+                "title": "Country code",
+                "description": "ISO 3166-1 alpha-3 country code",
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 3
               }
             },
-            "baspiRequired": ["line1", "postcode"]
+            "baspi4Required": ["line1", "postcode"],
+            "baspi5Required": ["line1", "postcode"]
           },
           "organisation": {
             "title": "Organisation",
@@ -138,89 +184,166 @@
           },
           "externalIds": {
             "type": "object"
-          },
-          "sellersCapacity": {
-            "baspiRef": "B1.3",
-            "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
-            "piqRef": "B1.3.1",
-            "title": "Capacity in which the Seller sells",
-            "type": "object",
-            "baspiRequired": ["capacity"],
+          }
+        },
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "oneOf": [
+          {
             "properties": {
-              "capacity": {
-                "baspiRef": "B1.3.1",
-                "type": "string",
-                "title": "",
+              "role": {
                 "enum": [
-                  "Legal Owner",
-                  "Personal Representative for a Deceased Owner",
-                  "Under Power of Attorney",
-                  "Mortgagee in Possession",
-                  "Other"
+                  "Buyer",
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": ["Seller"]
+              },
+              "sellersCapacity": {
+                "baspi4Ref": "B1.3",
+                "baspi5Ref": "B1.3",
+                "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+                "piqRef": "B1.3.1",
+                "title": "Capacity in which the Seller sells",
+                "type": "object",
+                "baspi4Required": ["capacity"],
+                "baspi5Required": ["capacity"],
+                "properties": {
+                  "capacity": {
+                    "baspi4Ref": "B1.3.1",
+                    "baspi5Ref": "B1.3.1",
+                    "type": "string",
+                    "title": "",
+                    "enum": [
+                      "Legal Owner",
+                      "Personal Representative for a Deceased Owner",
+                      "Under Power of Attorney",
+                      "Mortgagee in Possession",
+                      "Other"
+                    ]
+                  }
+                },
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": ["Legal Owner", "Mortgagee in Possession"]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2",
+                        "baspi5Ref": "B1.3.2",
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details if applicable",
+                        "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3",
+                        "baspi5Ref": "B1.3.3",
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2",
+                        "baspi5Ref": "B1.3.2",
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3",
+                        "baspi5Ref": "B1.3.3",
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      }
+                    },
+                    "baspi4Required": ["sellersCapacityDetails", "attachments"],
+                    "baspi5Required": ["sellersCapacityDetails", "attachments"]
+                  }
                 ]
               }
             },
-            "discriminator": {
-              "propertyName": "capacity"
-            },
-            "oneOf": [
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": ["Legal Owner", "Mortgagee in Possession"]
-                  },
-                  "sellersCapacityDetails": {
-                    "baspiRef": "B1.3.2",
-                    "rdsRef": "Participants/OtherDocumentation",
-                    "title": "Please provide details if applicable",
-                    "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
-                    "type": "string"
-                  },
-                  "attachments": {
-                    "baspiRef": "B1.3.3",
-                    "title": "Attachments",
-                    "type": "string",
-                    "enum": ["Attached", "To follow"]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Personal Representative for a Deceased Owner",
-                      "Under Power of Attorney",
-                      "Other"
-                    ]
-                  },
-                  "sellersCapacityDetails": {
-                    "baspiRef": "B1.3.2",
-                    "rdsRef": "Participants/OtherDocumentation",
-                    "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
-                    "type": "string"
-                  },
-                  "attachments": {
-                    "baspiRef": "B1.3.3",
-                    "title": "Attachments",
-                    "type": "string",
-                    "enum": ["Attached", "To follow"]
-                  }
-                },
-                "baspiRequired": ["sellersCapacityDetails", "attachments"]
-              }
-            ]
+            "baspi4Required": ["sellersCapacity"],
+            "baspi5Required": ["sellersCapacity"]
           }
-        }
+        ]
       }
     },
     "propertyPack": {
-      "baspiRef": "0",
+      "baspi4Ref": "0",
+      "baspi5Ref": "0",
       "ta6Ref": "0",
       "ntsRef": "0",
       "ntslRef": "0",
       "title": "Property Pack",
       "type": "object",
-      "baspiRequired": [
+      "baspi4Required": [
+        "uprn",
+        "address",
+        "delayFactors",
+        "ownership",
+        "parking",
+        "listingAndConservation",
+        "typeOfConstruction",
+        "energyEfficiency",
+        "councilTax",
+        "disputesAndComplaints",
+        "alterationsAndChanges",
+        "notices",
+        "specialistIssues",
+        "fixturesAndFittings",
+        "waterAndDrainage",
+        "electricity",
+        "connectivity",
+        "heating",
+        "insurance",
+        "rightsAndInformalArrangements",
+        "environmentalIssues",
+        "otherIssues",
+        "additionalInformation",
+        "consumerProtectionRegulationsDeclaration",
+        "legalOwners",
+        "legalBoundaries",
+        "servicesCrossing",
+        "electricalWorks",
+        "smartHomeSystems",
+        "guaranteesWarrantiesAndIndemnityInsurances",
+        "occupiers",
+        "completionAndMoving",
+        "confirmationOfAccuracyByOwners"
+      ],
+      "baspi5Required": [
         "uprn",
         "address",
         "delayFactors",
@@ -315,7 +438,8 @@
       "ta7Required": ["ownership"],
       "properties": {
         "address": {
-          "baspiRef": "A1.1",
+          "baspi4Ref": "A1.1",
+          "baspi5Ref": "A1.1",
           "ta6Ref": "0.1",
           "ta7Ref": "0.1",
           "ta10Ref": "0.1",
@@ -324,11 +448,30 @@
           "title": "Property Address",
           "type": "object",
           "properties": {
+            "buildingNumber": {
+              "title": "Building number",
+              "type": "string",
+              "minLength": 1
+            },
+            "buildingName": {
+              "title": "Building name",
+              "type": "string"
+            },
+            "subBuilding": {
+              "title": "Sub building name",
+              "type": "string"
+            },
+            "street": {
+              "title": "Street",
+              "type": "string",
+              "minLength": 1
+            },
             "line1": {
               "ta6Ref": "0.1.1",
               "ta7Ref": "0.1.1",
               "ta10Ref": "0.1.1",
-              "baspiRef": "A1.1.1",
+              "baspi4Ref": "A1.1.1",
+              "baspi5Ref": "A1.1.1",
               "piqRef": "A1.1.1",
               "title": "Address line 1",
               "type": "string",
@@ -338,7 +481,8 @@
               "ta6Ref": "0.1.2",
               "ta7Ref": "0.1.2",
               "ta10Ref": "0.1.2",
-              "baspiRef": "A1.1.2",
+              "baspi4Ref": "A1.1.2",
+              "baspi5Ref": "A1.1.2",
               "piqRef": "A1.1.2",
               "title": "Address line 2",
               "type": "string"
@@ -347,7 +491,8 @@
               "ta6Ref": "0.1.3",
               "ta7Ref": "0.1.3",
               "ta10Ref": "0.1.3",
-              "baspiRef": "A1.1.3",
+              "baspi4Ref": "A1.1.3",
+              "baspi5Ref": "A1.1.3",
               "title": "Address line 3",
               "type": "string"
             },
@@ -355,7 +500,8 @@
               "ta6Ref": "0.1.4",
               "ta7Ref": "0.1.4",
               "ta10Ref": "0.1.4",
-              "baspiRef": "A1.1.4",
+              "baspi4Ref": "A1.1.4",
+              "baspi5Ref": "A1.1.4",
               "piqRef": "A1.1.3",
               "title": "Town",
               "type": "string"
@@ -364,18 +510,33 @@
               "ta6Ref": "0.1.5",
               "ta7Ref": "0.1.5",
               "ta10Ref": "0.1.5",
-              "baspiRef": "A1.1.5",
+              "baspi4Ref": "A1.1.5",
+              "baspi5Ref": "A1.1.5",
               "piqRef": "A1.1.5",
               "title": "Postcode",
               "type": "string",
               "minLength": 1
+            },
+            "homeNation": {
+              "title": "Home nation",
+              "type": "string",
+              "enum": ["England", "Wales", "Scotland", "Northern Ireland"]
+            },
+            "countryCode": {
+              "title": "Country code",
+              "description": "ISO 3166-1 alpha-3 country code",
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3
             }
           },
-          "baspiRequired": ["line1", "postcode"],
+          "baspi4Required": ["line1", "postcode"],
+          "baspi5Required": ["line1", "postcode"],
           "ta6Required": ["line1", "postcode"]
         },
         "uprn": {
-          "baspiRef": "A1.1.5",
+          "baspi4Ref": "A1.1.5",
+          "baspi5Ref": "A1.1.5",
           "rdsRef": "Property/GUID/{name='UPRN',id=?}",
           "title": "Unique Property Reference Number",
           "type": "integer"
@@ -451,6 +612,19 @@
           "properties": {
             "localAuthorityName": {
               "title": "Local authority name",
+              "description": "The name of the local authority responsible for searches and planning (district or unitary as applicable)",
+              "type": "string"
+            },
+            "districtCouncil": {
+              "title": "Name of the district council, if not unitary",
+              "type": "string"
+            },
+            "countyCouncil": {
+              "title": "Name of the county council, if not unitary",
+              "type": "string"
+            },
+            "unitaryAuthority": {
+              "title": "Unitary authority name, if applicable",
               "type": "string"
             },
             "localAuthorityReference": {
@@ -501,6 +675,11 @@
                 "Modern Method of Auction",
                 "Private treaty"
               ]
+            },
+            "saleAtUndervalue": {
+              "title": "Is the property being sold at undervalue?",
+              "type": "string",
+              "enum": ["Yes", "No"]
             }
           }
         },
@@ -555,7 +734,8 @@
           "type": "array",
           "items": {
             "type": "object",
-            "baspiRequired": ["mediaUrl"],
+            "baspi4Required": ["mediaUrl"],
+            "baspi5Required": ["mediaUrl"],
             "properties": {
               "mediaType": {
                 "title": "Type of media",
@@ -585,6 +765,7 @@
         "buildInformation": {
           "ntsRef": "B1.1",
           "ntslRef": "B1.1",
+          "baspi5Ref": "A1.8",
           "title": "About the property building",
           "type": "object",
           "ntsRequired": ["building", "roomDimensions"],
@@ -593,8 +774,10 @@
             "building": {
               "ntsRef": "B1.1.1",
               "ntslRef": "B1.1.1",
+              "baspi5Ref": "A1.8",
               "title": "Building information",
               "type": "object",
+              "baspi5Required": ["propertyType"],
               "ntsRequired": ["builtForm", "propertyType"],
               "ntslRequired": ["builtForm", "propertyType"],
               "properties": {
@@ -615,6 +798,7 @@
                   "ntsRef": "B1.1.1.1",
                   "ntslRef": "B1.1.1.1",
                   "title": "Property type",
+                  "baspi5Ref": "A1.8",
                   "type": "string",
                   "enum": [
                     "House",
@@ -661,12 +845,14 @@
                     "numberOfFloors": {
                       "ntsRef": "B1.1.3",
                       "ntslRef": "B1.1.3",
+                      "baspi5Ref": "A1.8.5.2",
                       "title": "Number of floors in the building",
                       "type": "integer"
                     },
                     "entranceFloor": {
                       "ntsRef": "B1.1.4",
                       "ntslRef": "B1.1.4",
+                      "baspi5Ref": "A1.8.5.1",
                       "title": "Entrance floor",
                       "description": "Floor level of the entrance floor relative to the lowest level of the property (0 for ground floor). If there is a basement, the basement is level 0 and the other floors are from 1 upwards",
                       "type": "integer"
@@ -681,14 +867,16 @@
                     "overCommercialPremises": {
                       "ntsRef": "B1.1.6",
                       "ntslRef": "B1.1.6",
+                      "baspi5Ref": "A1.8.6",
                       "title": "Located over commercial premises?",
                       "type": "object",
                       "properties": {
                         "isLocatedOverCommercialPremises": {
                           "ntsRef": "B1.1.6.1",
                           "ntslRef": "B1.1.6.1",
+                          "baspi5Ref": "A1.8.6.1",
                           "type": "string",
-                          "title": "Is the property located over commercial premises?",
+                          "title": "Is the property located in a building which includes commercial property E.g. shops, offices etc?",
                           "enum": ["Yes", "No"]
                         }
                       },
@@ -712,17 +900,24 @@
                             "details": {
                               "ntsRef": "B1.1.6.2",
                               "ntslRef": "B1.1.6.2",
+                              "baspi5Ref": "A1.8.6.2",
                               "title": "Please provide details",
                               "type": "string",
                               "minLength": 1
                             }
                           },
+                          "baspi5Required": ["details"],
                           "ntsRequired": ["details"],
                           "ntslRequired": ["details"]
                         }
                       ]
                     }
                   },
+                  "baspi5Required": [
+                    "numberOfFloors",
+                    "entranceFloor",
+                    "overCommercialPremises"
+                  ],
                   "ntsRequired": [
                     "numberOfFloors",
                     "entranceFloor",
@@ -767,6 +962,16 @@
                   "enum": ["Yes", "No"]
                 }
               }
+            },
+            "isHMO": {
+              "title": "Is the property a House in Multiple Occupation (HMO)?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            },
+            "isStudentAccommodation": {
+              "title": "Is the property student accommodation?",
+              "type": "string",
+              "enum": ["Yes", "No"]
             },
             "roomDimensions": {
               "ntsRef": "B2",
@@ -1234,25 +1439,30 @@
           }
         },
         "delayFactors": {
-          "baspiRef": "A1.2",
+          "baspi4Ref": "A1.2",
+          "baspi5Ref": "A1.2",
           "title": "Delay factors",
           "type": "object",
-          "baspiRequired": ["hasDelayFactors"],
+          "baspi4Required": ["hasDelayFactors"],
+          "baspi5Required": ["hasDelayFactors"],
           "properties": {
             "hasDelayFactors": {
-              "baspiRef": "A1.2.1",
+              "baspi4Ref": "A1.2.1",
+              "baspi5Ref": "A1.2.1",
               "title": "Are you aware of any factors which might delay or complicate the sale?",
               "description": "E.g. family split, pending application for grant of probate, absent seller or unregistered title?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.1.1",
+                  "baspi4Ref": "A10.1.1",
+                  "baspi5Ref": "A10.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1270,60 +1480,95 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A1.2.2",
+                      "baspi4Ref": "A1.2.2",
+                      "baspi5Ref": "A1.2.2",
                       "title": "Provide details and likely timescale for delay",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.2.3",
+                      "baspi4Ref": "A1.2.3",
+                      "baspi5Ref": "A1.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             }
           }
         },
         "ownership": {
-          "baspiRef": "A1.3",
+          "baspi4Ref": "A1.3",
+          "baspi5Ref": "A1.3",
           "ta7Ref": "1",
           "ntsRef": "A3",
           "title": "Ownership",
           "type": "object",
-          "baspiRequired": ["ownershipsToBeTransferred"],
+          "baspi4Required": ["ownershipsToBeTransferred"],
+          "baspi5Required": ["ownershipsToBeTransferred"],
           "ntsRequired": ["ownershipsToBeTransferred"],
           "ta7Required": ["ownershipsToBeTransferred"],
           "properties": {
+            "numberOfSellers": {
+              "title": "How many sellers are involved in the transaction?",
+              "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
+              "type": "integer"
+            },
+            "numberOfNonUkResidentSellers": {
+              "title": "How many sellers are involved in the transaction who are resident outside the UK?",
+              "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
+              "type": "integer"
+            },
+            "hasHelpToBuyEquityLoan": {
+              "title": "Is the property being sold with a Help to Buy equity loan outstanding?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            },
+            "isFirstRegistration": {
+              "title": "Is this the first time the property is to be registered with HMLR?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            },
+            "isLimitedCompanySale": {
+              "title": "Is the property being sold by a Limited Company?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            },
             "ownershipsToBeTransferred": {
-              "baspiRef": "A1.3",
+              "baspi4Ref": "A1.3",
+              "baspi5Ref": "A1.3",
               "ta7Ref": "1",
               "ntsRef": "A3",
               "title": "Ownerships to be transferred on sale",
               "type": "array",
               "minItems": 1,
               "items": {
-                "baspiRef": "A1.3.0",
+                "baspi4Ref": "A1.3.0",
+                "baspi5Ref": "A1.3.0",
                 "ntsRef": "A3.1",
                 "ta7Ref": "1",
                 "title": "Ownership to be transferred",
                 "type": "object",
-                "baspiRequired": ["ownershipType"],
+                "baspi4Required": ["ownershipType"],
+                "baspi5Required": ["ownershipType"],
                 "ta7Required": ["ownershipType"],
                 "ntsRequired": ["ownershipType"],
                 "properties": {
                   "titleNumber": {
-                    "baspiRef": "A1.3.0.1",
+                    "baspi4Ref": "A1.3.0.1",
+                    "baspi5Ref": "A1.3.0.1",
                     "title": "Title number (if registered)",
                     "type": "string",
                     "minLength": 1
                   },
                   "ownershipType": {
                     "ntsRef": "A3.1",
-                    "baspiRef": "A1.3.0.2",
+                    "baspi4Ref": "A1.3.0.2",
+                    "baspi5Ref": "A1.3.0.2",
                     "rdsRef": "Tenure/Tenure",
                     "ta7Ref": "1.1",
                     "piqRef": "A1.2",
@@ -1349,18 +1594,21 @@
                         "enum": ["Freehold"]
                       },
                       "wholeFreeholdForSale": {
-                        "baspiRef": "A1.3.0.2.1",
+                        "baspi4Ref": "A1.3.0.2.1",
+                        "baspi5Ref": "A1.3.0.2.1",
                         "title": "Is the entire freehold being sold?",
                         "type": "object",
                         "properties": {
                           "yesNo": {
-                            "baspiRef": "A1.3.0.2.1",
+                            "baspi4Ref": "A1.3.0.2.1",
+                            "baspi5Ref": "A1.3.0.2.1",
                             "type": "string",
                             "title": "",
                             "enum": ["Yes", "No"]
                           }
                         },
-                        "baspiRequired": ["yesNo"],
+                        "baspi4Required": ["yesNo"],
+                        "baspi5Required": ["yesNo"],
                         "discriminator": {
                           "propertyName": "yesNo"
                         },
@@ -1378,18 +1626,21 @@
                                 "enum": ["No"]
                               },
                               "details": {
-                                "baspiRef": "A1.3.0.2.2",
+                                "baspi4Ref": "A1.3.0.2.2",
+                                "baspi5Ref": "A1.3.0.2.2",
                                 "title": "Describe the share for sale (e.g. Ground floor flat only)",
                                 "type": "string",
                                 "minLength": 1
                               }
                             },
-                            "baspiRequired": ["details"]
+                            "baspi4Required": ["details"],
+                            "baspi5Required": ["details"]
                           }
                         ]
                       }
                     },
-                    "baspiRequired": ["wholeFreeholdForSale"]
+                    "baspi4Required": ["wholeFreeholdForSale"],
+                    "baspi5Required": ["wholeFreeholdForSale"]
                   },
                   {
                     "properties": {
@@ -1399,7 +1650,8 @@
                       "managedFreeholdOrCommonholdInformation": {
                         "title": "Managed freehold or commonhold information",
                         "ntsRef": "A3.2",
-                        "baspiRef": "A1.5",
+                        "baspi4Ref": "A1.5",
+                        "baspi5Ref": "A1.5",
                         "type": "object",
                         "fme1Required": [
                           "contactDetails",
@@ -1410,12 +1662,14 @@
                           "requiredDocuments",
                           "confirmation"
                         ],
-                        "baspiRequired": ["contactDetails", "serviceCharge"],
+                        "baspi4Required": ["contactDetails", "serviceCharge"],
+                        "baspi5Required": ["contactDetails", "serviceCharge"],
                         "ntsRequired": ["serviceCharge"],
                         "properties": {
                           "contactDetails": {
                             "fme1Ref": "1",
-                            "baspiRef": "A1.5.1",
+                            "baspi4Ref": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "title": "Contact Details",
                             "description": "Complete the details for the relevant parties",
                             "type": "object",
@@ -1425,21 +1679,28 @@
                               "dealsWithDayToDayMaintenanceOfManagedArea",
                               "organisesManagedAreaInsurance"
                             ],
-                            "baspiRequired": [
+                            "baspi4Required": [
+                              "rentchargeOwner",
+                              "managingAgent"
+                            ],
+                            "baspi5Required": [
                               "rentchargeOwner",
                               "managingAgent"
                             ],
                             "properties": {
                               "rentchargeOwner": {
-                                "baspiRef": "A1.5.4",
+                                "baspi4Ref": "A1.5.4",
+                                "baspi5Ref": "A1.5.4",
                                 "fme1Ref": "1.1",
                                 "title": "Rentcharge Owner",
                                 "type": "object",
                                 "fme1Required": ["contact"],
-                                "baspiRequired": ["contact"],
+                                "baspi4Required": ["contact"],
+                                "baspi5Required": ["contact"],
                                 "properties": {
                                   "contact": {
-                                    "baspiRef": "A1.5.4.1",
+                                    "baspi4Ref": "A1.5.4.1",
+                                    "baspi5Ref": "A1.5.4.1",
                                     "type": "object",
                                     "fme1Required": [
                                       "nameOrOrganisation",
@@ -1447,53 +1708,66 @@
                                       "telephone",
                                       "emailAddress"
                                     ],
-                                    "baspiRequired": [
+                                    "baspi4Required": [
+                                      "nameOrOrganisation",
+                                      "address",
+                                      "emailAddress"
+                                    ],
+                                    "baspi5Required": [
                                       "nameOrOrganisation",
                                       "address",
                                       "emailAddress"
                                     ],
                                     "properties": {
                                       "nameOrOrganisation": {
-                                        "baspiRef": "A1.5.4.1.1",
+                                        "baspi4Ref": "A1.5.4.1.1",
+                                        "baspi5Ref": "A1.5.4.1.1",
                                         "title": "Name or organisation",
                                         "type": "string",
                                         "minLength": 1
                                       },
                                       "address": {
-                                        "baspiRef": "A1.5.4.1.2",
+                                        "baspi4Ref": "A1.5.4.1.2",
+                                        "baspi5Ref": "A1.5.4.1.2",
                                         "title": "Address",
                                         "type": "object",
                                         "properties": {
                                           "line1": {
-                                            "baspiRef": "A1.5.4.1.2.1",
+                                            "baspi4Ref": "A1.5.4.1.2.1",
+                                            "baspi5Ref": "A1.5.4.1.2.1",
                                             "title": "Address line 1",
                                             "type": "string",
                                             "minLength": 1
                                           },
                                           "line2": {
-                                            "baspiRef": "A1.5.4.1.2.2",
+                                            "baspi4Ref": "A1.5.4.1.2.2",
+                                            "baspi5Ref": "A1.5.4.1.2.2",
                                             "title": "Address line 2",
                                             "type": "string"
                                           },
                                           "line3": {
-                                            "baspiRef": "A1.5.4.1.2.3",
+                                            "baspi4Ref": "A1.5.4.1.2.3",
+                                            "baspi5Ref": "A1.5.4.1.2.3",
                                             "title": "Address line 3",
                                             "type": "string"
                                           },
                                           "town": {
-                                            "baspiRef": "A1.5.4.1.2.4",
+                                            "baspi4Ref": "A1.5.4.1.2.4",
+                                            "baspi5Ref": "A1.5.4.1.2.4",
                                             "title": "Town",
                                             "type": "string"
                                           },
                                           "postcode": {
-                                            "baspiRef": "A1.5.4.1.2.5",
+                                            "baspi4Ref": "A1.5.4.1.2.5",
+                                            "baspi5Ref": "A1.5.4.1.2.5",
                                             "title": "Postcode",
                                             "type": "string",
                                             "minLength": 1
                                           }
                                         },
                                         "fme1Required": ["line1", "postcode"],
-                                        "baspiRequired": ["line1", "postcode"]
+                                        "baspi4Required": ["line1", "postcode"],
+                                        "baspi5Required": ["line1", "postcode"]
                                       },
                                       "telephone": {
                                         "title": "Telephone",
@@ -1501,7 +1775,8 @@
                                         "minLength": 1
                                       },
                                       "emailAddress": {
-                                        "baspiRef": "A1.5.5.1.3",
+                                        "baspi4Ref": "A1.5.5.1.3",
+                                        "baspi5Ref": "A1.5.5.1.3",
                                         "title": "Email address",
                                         "type": "string",
                                         "format": "email"
@@ -1642,69 +1917,85 @@
                                 }
                               },
                               "managingAgent": {
-                                "baspiRef": "A1.5.5",
+                                "baspi4Ref": "A1.5.5",
+                                "baspi5Ref": "A1.5.5",
                                 "fme1Ref": "1.3",
                                 "piqRef": "A1.4.1",
                                 "title": "Managing Agent",
                                 "type": "object",
                                 "fme1Required": ["contact"],
-                                "baspiRequired": ["contact"],
+                                "baspi4Required": ["contact"],
+                                "baspi5Required": ["contact"],
                                 "properties": {
                                   "contact": {
-                                    "baspiRef": "A1.5.5.1",
+                                    "baspi4Ref": "A1.5.5.1",
+                                    "baspi5Ref": "A1.5.5.1",
                                     "type": "object",
                                     "fme1Required": [
                                       "nameOrOrganisation",
                                       "telephone",
                                       "emailAddress"
                                     ],
-                                    "baspiRequired": [
+                                    "baspi4Required": [
+                                      "nameOrOrganisation",
+                                      "telephone",
+                                      "emailAddress"
+                                    ],
+                                    "baspi5Required": [
                                       "nameOrOrganisation",
                                       "telephone",
                                       "emailAddress"
                                     ],
                                     "properties": {
                                       "nameOrOrganisation": {
-                                        "baspiRef": "A1.5.5.1.1",
+                                        "baspi4Ref": "A1.5.5.1.1",
+                                        "baspi5Ref": "A1.5.5.1.1",
                                         "title": "Name or organisation",
                                         "type": "string",
                                         "minLength": 1
                                       },
                                       "address": {
-                                        "baspiRef": "A1.5.5.1.2",
+                                        "baspi4Ref": "A1.5.5.1.2",
+                                        "baspi5Ref": "A1.5.5.1.2",
                                         "title": "Address",
                                         "type": "object",
                                         "properties": {
                                           "line1": {
-                                            "baspiRef": "A1.5.5.1.2.1",
+                                            "baspi4Ref": "A1.5.5.1.2.1",
+                                            "baspi5Ref": "A1.5.5.1.2.1",
                                             "title": "Address line 1",
                                             "type": "string",
                                             "minLength": 1
                                           },
                                           "line2": {
-                                            "baspiRef": "A1.5.5.1.2.2",
+                                            "baspi4Ref": "A1.5.5.1.2.2",
+                                            "baspi5Ref": "A1.5.5.1.2.2",
                                             "title": "Address line 2",
                                             "type": "string"
                                           },
                                           "line3": {
-                                            "baspiRef": "A1.5.5.1.2.3",
+                                            "baspi4Ref": "A1.5.5.1.2.3",
+                                            "baspi5Ref": "A1.5.5.1.2.3",
                                             "title": "Address line 3",
                                             "type": "string"
                                           },
                                           "town": {
-                                            "baspiRef": "A1.5.5.1.2.4",
+                                            "baspi4Ref": "A1.5.5.1.2.4",
+                                            "baspi5Ref": "A1.5.5.1.2.4",
                                             "title": "Town",
                                             "type": "string"
                                           },
                                           "postcode": {
-                                            "baspiRef": "A1.5.5.1.2.5",
+                                            "baspi4Ref": "A1.5.5.1.2.5",
+                                            "baspi5Ref": "A1.5.5.1.2.5",
                                             "title": "Postcode",
                                             "type": "string",
                                             "minLength": 1
                                           }
                                         },
                                         "fme1Required": ["line1", "postcode"],
-                                        "baspiRequired": ["line1", "postcode"]
+                                        "baspi4Required": ["line1", "postcode"],
+                                        "baspi5Required": ["line1", "postcode"]
                                       },
                                       "telephone": {
                                         "title": "Telephone",
@@ -1712,7 +2003,8 @@
                                         "minLength": 1
                                       },
                                       "emailAddress": {
-                                        "baspiRef": "A1.5.5.1.3",
+                                        "baspi4Ref": "A1.5.5.1.3",
+                                        "baspi5Ref": "A1.5.5.1.3",
                                         "title": "Email address",
                                         "type": "string",
                                         "format": "email"
@@ -2293,19 +2585,22 @@
                               },
                               "requirementsToBeMemberOfManagementCompany": {
                                 "fme1Ref": "2.3",
-                                "baspiRef": "A1.5.6",
+                                "baspi4Ref": "A1.5.6",
+                                "baspi5Ref": "A1.5.6",
                                 "title": "Is the incoming Owner required to take a share in, or become a member of, the Management Company?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.6.1",
+                                    "baspi4Ref": "A1.5.6.1",
+                                    "baspi5Ref": "A1.5.6.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
                                   }
                                 },
                                 "fme1Required": ["yesNo"],
-                                "baspiRequired": ["yesNo"],
+                                "baspi4Required": ["yesNo"],
+                                "baspi5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -2342,7 +2637,8 @@
                             }
                           },
                           "serviceCharge": {
-                            "baspiRef": "A1.5.1",
+                            "baspi4Ref": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "ntsRef": "A3.1.1",
                             "fme1Ref": "3",
                             "piqRef": "A1.4.2",
@@ -2364,7 +2660,12 @@
                               "japaneseKnotweedAffectingManagedAreas",
                               "transferFees"
                             ],
-                            "baspiRequired": [
+                            "baspi4Required": [
+                              "annualServiceCharge",
+                              "largeAdditionalExpense",
+                              "reserveFund"
+                            ],
+                            "baspi5Required": [
                               "annualServiceCharge",
                               "largeAdditionalExpense",
                               "reserveFund"
@@ -2373,7 +2674,8 @@
                             "properties": {
                               "annualServiceCharge": {
                                 "ntsRef": "A3.1.2",
-                                "baspiRef": "A1.5.1.1.2",
+                                "baspi4Ref": "A1.5.1.1.2",
+                                "baspi5Ref": "A1.5.1.1.2",
                                 "fme1Ref": "3.1",
                                 "title": "What is the annual Service Charge payable by this Property?",
                                 "description": "This should include any sums payable for the maintenance of the managed area",
@@ -2385,19 +2687,22 @@
                                 "title": "If there is also a ‘fixed’ Rentcharge, please confirm the amount and explain why."
                               },
                               "largeAdditionalExpense": {
-                                "baspiRef": "A1.5.2.1",
+                                "baspi4Ref": "A1.5.2.1",
+                                "baspi5Ref": "A1.5.3.1",
                                 "title": "Does the seller know of any expense (e.g. the cost of redecoration of outside or communal areas not usually incurred annually) likely to be shown in the service charge accounts within the next three years?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.2.2",
+                                    "baspi4Ref": "A1.5.2.2",
+                                    "baspi5Ref": "A1.5.3.2",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
                                   }
                                 },
                                 "fme1Required": ["yesNo"],
-                                "baspiRequired": ["yesNo"],
+                                "baspi4Required": ["yesNo"],
+                                "baspi5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -2415,13 +2720,15 @@
                                         "enum": ["Yes"]
                                       },
                                       "details": {
-                                        "baspiRef": "A1.5.2.3",
+                                        "baspi4Ref": "A1.5.2.3",
+                                        "baspi5Ref": "A1.5.3.3",
                                         "title": "Details",
                                         "type": "string"
                                       }
                                     },
                                     "fme1Required": ["details"],
-                                    "baspiRequired": ["details"]
+                                    "baspi4Required": ["details"],
+                                    "baspi5Required": ["details"]
                                   }
                                 ]
                               },
@@ -2916,19 +3223,24 @@
                               },
                               "transferFees": {
                                 "fme1Ref": "3.13",
-                                "baspiRef": "A1.5.3",
+                                "baspi4Ref": "A1.5.3",
+                                "baspi5Ref": "A1.5.4",
                                 "title": "Are there any transfer fees, deferred charges or similar fees, expressed as a percentage of the Property's value payable on an event such as resale or subletting?",
+                                "baspi4Title": "Additional fees payable on sale or letting, if known",
+                                "baspi5Title": "Additional fees payable on sale or letting, if known",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.3.1",
+                                    "baspi4Ref": "A1.5.3.1",
+                                    "baspi5Ref": "A1.5.4.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
                                   }
                                 },
                                 "fme1Required": ["yesNo"],
-                                "baspiRequired": ["yesNo"],
+                                "baspi4Required": ["yesNo"],
+                                "baspi5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -2947,7 +3259,8 @@
                                       },
                                       "details": {
                                         "fme1Ref": "3.13.1",
-                                        "baspiRef": "A1.5.3.2",
+                                        "baspi4Ref": "A1.5.3.2",
+                                        "baspi5Ref": "A1.5.4.2",
                                         "title": "Provide details.",
                                         "type": "string",
                                         "minLength": 1
@@ -3553,7 +3866,10 @@
                       }
                     },
                     "fme1Required": ["managedFreeholdOrCommonholdInformation"],
-                    "baspiRequired": ["managedFreeholdOrCommonholdInformation"]
+                    "baspi4Required": [
+                      "managedFreeholdOrCommonholdInformation"
+                    ],
+                    "baspi5Required": ["managedFreeholdOrCommonholdInformation"]
                   },
                   {
                     "properties": {
@@ -3561,7 +3877,8 @@
                         "enum": ["Leasehold"]
                       },
                       "leaseholdInformation": {
-                        "baspiRef": "A1.5",
+                        "baspi4Ref": "A1.5",
+                        "baspi5Ref": "A1.5",
                         "ntsRef": "A3.2",
                         "title": "Leasehold information",
                         "type": "object",
@@ -3579,7 +3896,15 @@
                           "requiredDocuments",
                           "confirmationOfAccuracy"
                         ],
-                        "baspiRequired": [
+                        "baspi4Required": [
+                          "sharedOwnership",
+                          "leaseTerm",
+                          "contactDetails",
+                          "groundRent",
+                          "transferAndRegistration",
+                          "serviceCharge"
+                        ],
+                        "baspi5Required": [
                           "sharedOwnership",
                           "leaseTerm",
                           "contactDetails",
@@ -3612,16 +3937,19 @@
                         ],
                         "properties": {
                           "sharedOwnership": {
-                            "baspiRef": "A1.3.1",
+                            "baspi4Ref": "A1.3.1",
+                            "baspi5Ref": "A1.3.1",
                             "ntsRef": "A3.2",
                             "type": "object",
                             "lpe1Required": ["isSharedOwnership"],
-                            "baspiRequired": ["isSharedOwnership"],
+                            "baspi4Required": ["isSharedOwnership"],
+                            "baspi5Required": ["isSharedOwnership"],
                             "ntsRequired": ["isSharedOwnership"],
                             "ta7Required": ["isSharedOwnership"],
                             "properties": {
                               "isSharedOwnership": {
-                                "baspiRef": "A1.3.1",
+                                "baspi4Ref": "A1.3.1",
+                                "baspi5Ref": "A1.3.1",
                                 "ta7Ref": "1.1",
                                 "ntsRef": "A3.2.1",
                                 "title": "Is the lease on a Shared Ownership basis?",
@@ -3646,7 +3974,8 @@
                                     "enum": ["Yes"]
                                   },
                                   "sharedOwnershipPercentage": {
-                                    "baspiRef": "A1.3.1.1",
+                                    "baspi4Ref": "A1.3.1.1",
+                                    "baspi5Ref": "A1.3.1.1",
                                     "ntsRef": "A3.7.1",
                                     "title": "Shared ownership percentage",
                                     "type": "integer",
@@ -3654,14 +3983,16 @@
                                     "exclusiveMaximum": 100
                                   },
                                   "sharedOwnershipRent": {
-                                    "baspiRef": "A1.3.1.2",
+                                    "baspi4Ref": "A1.3.1.2",
+                                    "baspi5Ref": "A1.3.1.2",
                                     "ntsRef": "A3.7.2",
                                     "title": "Shared ownership rent (£)",
                                     "type": "number",
                                     "minimum": 0
                                   },
                                   "sharedOwnershipRentFrequency": {
-                                    "baspiRef": "A1.3.1.3",
+                                    "baspi4Ref": "A1.3.1.3",
+                                    "baspi5Ref": "A1.3.1.3",
                                     "ntsRef": "A3.7.3",
                                     "title": "Shared ownership rent frequency",
                                     "type": "string",
@@ -3673,7 +4004,12 @@
                                   "sharedOwnershipRent",
                                   "sharedOwnershipRentFrequency"
                                 ],
-                                "baspiRequired": [
+                                "baspi4Required": [
+                                  "sharedOwnershipPercentage",
+                                  "sharedOwnershipRent",
+                                  "sharedOwnershipRentFrequency"
+                                ],
+                                "baspi5Required": [
                                   "sharedOwnershipPercentage",
                                   "sharedOwnershipRent",
                                   "sharedOwnershipRentFrequency"
@@ -3687,10 +4023,15 @@
                             ]
                           },
                           "leaseTerm": {
-                            "baspiRef": "A1.4.1",
+                            "baspi4Ref": "A1.4.1",
+                            "baspi5Ref": "A1.4.1",
                             "ntsRef": "A3.2.2",
                             "type": "object",
-                            "baspiRequired": [
+                            "baspi4Required": [
+                              "startYearOfLease",
+                              "lengthOfLeaseInYears"
+                            ],
+                            "baspi5Required": [
                               "startYearOfLease",
                               "lengthOfLeaseInYears"
                             ],
@@ -3700,13 +4041,15 @@
                             ],
                             "properties": {
                               "startYearOfLease": {
-                                "baspiRef": "A1.4.1.1",
+                                "baspi4Ref": "A1.4.1.1",
+                                "baspi5Ref": "A1.4.1.1",
                                 "ntsRef": "A3.2.2.1",
                                 "title": "Year that the lease commenced",
                                 "type": "integer"
                               },
                               "lengthOfLeaseInYears": {
-                                "baspiRef": "A1.4.1.2",
+                                "baspi4Ref": "A1.4.1.2",
+                                "baspi5Ref": "A1.4.1.2",
                                 "ntsRef": "A3.2.2.2",
                                 "piqRef": "A1.3.1",
                                 "title": "Length of lease (years)",
@@ -3715,7 +4058,8 @@
                             }
                           },
                           "contactDetails": {
-                            "baspiRef": "A1.5.4",
+                            "baspi4Ref": "A1.5.4",
+                            "baspi5Ref": "A1.5.4",
                             "ta7Ref": "4.1",
                             "lpe1Ref": "1",
                             "title": "Contact Details",
@@ -3724,23 +4068,27 @@
                               "contacts",
                               "serviceContactAssignments"
                             ],
-                            "baspiRequired": ["contacts"],
+                            "baspi4Required": ["contacts"],
+                            "baspi5Required": ["contacts"],
                             "ta7Required": [
                               "contacts",
                               "serviceContactAssignments"
                             ],
                             "properties": {
                               "contacts": {
-                                "baspiRef": "A1.5.4.",
+                                "baspi4Ref": "A1.5.4",
+                                "baspi5Ref": "A1.5.4",
                                 "ta7Ref": "4.1",
                                 "lpe1Ref": "1",
                                 "type": "object",
                                 "title": "Contacts",
                                 "description": "Complete the details for the relevant parties",
-                                "baspiRequired": ["landlord", "managingAgent"],
+                                "baspi4Required": ["landlord", "managingAgent"],
+                                "baspi5Required": ["landlord", "managingAgent"],
                                 "properties": {
                                   "landlord": {
-                                    "baspiRef": "A1.5.4",
+                                    "baspi4Ref": "A1.5.4",
+                                    "baspi5Ref": "A1.5.5",
                                     "ta7Ref": "4.1a",
                                     "lpe1Ref": "1.1",
                                     "piqRef": "A1.4.4",
@@ -3748,10 +4096,12 @@
                                     "description": "The landlord (or freeholder) may be, for example, a private individual, a housing association, or a management company owned by the residents",
                                     "type": "object",
                                     "lpe1Required": ["contact"],
-                                    "baspiRequired": ["contact"],
+                                    "baspi4Required": ["contact"],
+                                    "baspi5Required": ["contact"],
                                     "properties": {
                                       "contact": {
-                                        "baspiRef": "A1.5.4.1",
+                                        "baspi4Ref": "A1.5.4.1",
+                                        "baspi5Ref": "A1.5.5.1",
                                         "ta7Ref": "4.1a",
                                         "type": "object",
                                         "lpe1Required": [
@@ -3760,52 +4110,64 @@
                                           "telephone",
                                           "emailAddress"
                                         ],
-                                        "baspiRequired": [
+                                        "baspi4Required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
+                                        "baspi5Required": [
                                           "nameOrOrganisation",
                                           "address",
                                           "emailAddress"
                                         ],
                                         "properties": {
                                           "nameOrOrganisation": {
-                                            "baspiRef": "A1.5.4.1.1",
+                                            "baspi4Ref": "A1.5.4.1.1",
+                                            "baspi5Ref": "A1.5.5.1.1",
                                             "ta7Ref": "4.1a.1",
                                             "title": "Name or organisation",
                                             "type": "string",
                                             "minLength": 1
                                           },
                                           "address": {
-                                            "baspiRef": "A1.5.4.1.2",
+                                            "baspi4Ref": "A1.5.4.1.2",
+                                            "baspi5Ref": "A1.5.5.1.2",
                                             "ta7Ref": "4.1a.0",
                                             "title": "Address",
                                             "type": "object",
                                             "properties": {
                                               "line1": {
-                                                "baspiRef": "A1.5.4.1.2.1",
+                                                "baspi4Ref": "A1.5.4.1.2.1",
+                                                "baspi5Ref": "A1.5.5.1.2.1",
                                                 "ta7Ref": "4.1a.2",
                                                 "title": "Address line 1",
                                                 "type": "string",
                                                 "minLength": 1
                                               },
                                               "line2": {
-                                                "baspiRef": "A1.5.4.1.2.2",
+                                                "baspi4Ref": "A1.5.4.1.2.2",
+                                                "baspi5Ref": "A1.5.5.1.2.2",
                                                 "ta7Ref": "4.1a.3",
                                                 "title": "Address line 2",
                                                 "type": "string"
                                               },
                                               "line3": {
-                                                "baspiRef": "A1.5.4.1.2.3",
+                                                "baspi4Ref": "A1.5.4.1.2.3",
+                                                "baspi5Ref": "A1.5.5.1.2.3",
                                                 "ta7Ref": "4.1a.4",
                                                 "title": "Address line 3",
                                                 "type": "string"
                                               },
                                               "town": {
-                                                "baspiRef": "A1.5.4.1.2.4",
+                                                "baspi4Ref": "A1.5.4.1.2.4",
+                                                "baspi5Ref": "A1.5.5.1.2.4",
                                                 "ta7Ref": "4.1a.5",
                                                 "title": "Town",
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "baspiRef": "A1.5.4.1.2.5",
+                                                "baspi4Ref": "A1.5.4.1.2.5",
+                                                "baspi5Ref": "A1.5.5.1.2.5",
                                                 "ta7Ref": "4.1a.6",
                                                 "title": "Postcode",
                                                 "type": "string",
@@ -3816,7 +4178,11 @@
                                               "line1",
                                               "postcode"
                                             ],
-                                            "baspiRequired": [
+                                            "baspi4Required": [
+                                              "line1",
+                                              "postcode"
+                                            ],
+                                            "baspi5Required": [
                                               "line1",
                                               "postcode"
                                             ]
@@ -3828,7 +4194,8 @@
                                             "minLength": 1
                                           },
                                           "emailAddress": {
-                                            "baspiRef": "A1.5.4.3",
+                                            "baspi4Ref": "A1.5.4.3",
+                                            "baspi5Ref": "A1.5.5.3",
                                             "ta7Ref": "4.1a.8",
                                             "title": "Email address",
                                             "type": "string",
@@ -4083,16 +4450,19 @@
                                     }
                                   },
                                   "managingAgent": {
-                                    "baspiRef": "A1.5.5",
+                                    "baspi4Ref": "A1.5.5",
+                                    "baspi5Ref": "A1.5.6",
                                     "ta7Ref": "4.1c",
                                     "lpe1Ref": "1.3",
                                     "title": "Managing Agent",
                                     "description": "A managing agent may be employed by the landlord or by the tenants’ management company to collect the rent and/or manage the building.",
                                     "type": "object",
-                                    "baspiRequired": ["contact"],
+                                    "baspi4Required": ["contact"],
+                                    "baspi5Required": ["contact"],
                                     "properties": {
                                       "contact": {
-                                        "baspiRef": "A1.5.5.1",
+                                        "baspi4Ref": "A1.5.5.1",
+                                        "baspi5Ref": "A1.5.6.1",
                                         "ta7Ref": "4.1c",
                                         "type": "object",
                                         "lpe1Required": [
@@ -4101,52 +4471,64 @@
                                           "telephone",
                                           "emailAddress"
                                         ],
-                                        "baspiRequired": [
+                                        "baspi4Required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
+                                        "baspi5Required": [
                                           "nameOrOrganisation",
                                           "address",
                                           "emailAddress"
                                         ],
                                         "properties": {
                                           "nameOrOrganisation": {
-                                            "baspiRef": "A1.5.5.1.1",
+                                            "baspi4Ref": "A1.5.5.1.1",
+                                            "baspi5Ref": "A1.5.6.1.1",
                                             "ta7Ref": "4.1c.1",
                                             "title": "Name or organisation",
                                             "type": "string",
                                             "minLength": 1
                                           },
                                           "address": {
-                                            "baspiRef": "A1.5.5.1.2",
+                                            "baspi4Ref": "A1.5.5.1.2",
+                                            "baspi5Ref": "A1.5.6.1.2",
                                             "ta7Ref": "4.1c.0",
                                             "title": "Address",
                                             "type": "object",
                                             "properties": {
                                               "line1": {
-                                                "baspiRef": "A1.5.5.1.2.1",
+                                                "baspi4Ref": "A1.5.5.1.2.1",
+                                                "baspi5Ref": "A1.5.6.1.2.1",
                                                 "ta7Ref": "4.1c.2",
                                                 "title": "Address line 1",
                                                 "type": "string",
                                                 "minLength": 1
                                               },
                                               "line2": {
-                                                "baspiRef": "A1.5.5.1.2.2",
+                                                "baspi4Ref": "A1.5.5.1.2.2",
+                                                "baspi5Ref": "A1.5.6.1.2.2",
                                                 "ta7Ref": "4.1c.3",
                                                 "title": "Address line 2",
                                                 "type": "string"
                                               },
                                               "line3": {
-                                                "baspiRef": "A1.5.5.1.2.3",
+                                                "baspi4Ref": "A1.5.5.1.2.3",
+                                                "baspi5Ref": "A1.5.6.1.2.3",
                                                 "ta7Ref": "4.1c.4",
                                                 "title": "Address line 3",
                                                 "type": "string"
                                               },
                                               "town": {
-                                                "baspiRef": "A1.5.5.1.2.4",
+                                                "baspi4Ref": "A1.5.5.1.2.4",
+                                                "baspi5Ref": "A1.5.6.1.2.4",
                                                 "ta7Ref": "4.1c.5",
                                                 "title": "Town",
                                                 "type": "string"
                                               },
                                               "postcode": {
-                                                "baspiRef": "A1.5.5.1.2.5",
+                                                "baspi4Ref": "A1.5.5.1.2.5",
+                                                "baspi5Ref": "A1.5.6.1.2.5",
                                                 "ta7Ref": "4.1c.6",
                                                 "title": "Postcode",
                                                 "type": "string",
@@ -4157,7 +4539,11 @@
                                               "line1",
                                               "postcode"
                                             ],
-                                            "baspiRequired": [
+                                            "baspi4Required": [
+                                              "line1",
+                                              "postcode"
+                                            ],
+                                            "baspi5Required": [
                                               "line1",
                                               "postcode"
                                             ]
@@ -4169,7 +4555,8 @@
                                             "minLength": 1
                                           },
                                           "emailAddress": {
-                                            "baspiRef": "A1.5.5.1.3",
+                                            "baspi4Ref": "A1.5.5.1.3",
+                                            "baspi5Ref": "A1.5.6.1.3",
                                             "ta7Ref": "4.1c.8",
                                             "title": "Email address",
                                             "type": "string",
@@ -4285,7 +4672,12 @@
                                           "telephone",
                                           "emailAddress"
                                         ],
-                                        "baspiRequired": [
+                                        "baspi4Required": [
+                                          "nameOrOrganisation",
+                                          "line1",
+                                          "postcode"
+                                        ],
+                                        "baspi5Required": [
                                           "nameOrOrganisation",
                                           "line1",
                                           "postcode"
@@ -5221,7 +5613,8 @@
                           },
                           "transferAndRegistration": {
                             "lpe1Ref": "2",
-                            "baspiRef": "A1.5.6",
+                            "baspi4Ref": "A1.5.6",
+                            "baspi5Ref": "A1.5.6",
                             "title": "Transfer and Registration",
                             "type": "object",
                             "lpe1Required": [
@@ -5231,7 +5624,10 @@
                               "requirementsToBeMemberOfManagementCompany",
                               "procedureForObtainingCertificate"
                             ],
-                            "baspiRequired": [
+                            "baspi4Required": [
+                              "requirementsToBeMemberOfManagementCompany"
+                            ],
+                            "baspi5Required": [
                               "requirementsToBeMemberOfManagementCompany"
                             ],
                             "properties": {
@@ -5360,20 +5756,25 @@
                               },
 
                               "requirementsToBeMemberOfManagementCompany": {
-                                "baspiRef": "A1.5.6",
+                                "baspi4Ref": "A1.5.6",
+                                "baspi5Ref": "A1.5.7",
                                 "lpe1Ref": "2.5",
                                 "title": "Is the incoming Lessee required to take a share in, or become a member of, the Management Company?",
+                                "baspi4Title": "Is the owner of the Property required to become a director in a management company for the maintenance of shared amenities?",
+                                "baspi5Title": "Is the owner of the Property required to become a director in a management company for the maintenance of shared amenities?",
                                 "type": "object",
                                 "properties": {
                                   "yesNoNotApplicable": {
-                                    "baspiRef": "A1.5.6.1",
+                                    "baspi4Ref": "A1.5.6.1",
+                                    "baspi5Ref": "A1.5.7.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No", "Not applicable"]
                                   }
                                 },
                                 "lpe1Required": ["yesNoNotApplicable"],
-                                "baspiRequired": ["yesNoNotApplicable"],
+                                "baspi4Required": ["yesNoNotApplicable"],
+                                "baspi5Required": ["yesNoNotApplicable"],
                                 "discriminator": {
                                   "propertyName": "yesNoNotApplicable"
                                 },
@@ -5408,7 +5809,8 @@
                             }
                           },
                           "groundRent": {
-                            "baspiRef": "A1.4.2",
+                            "baspi4Ref": "A1.4.2",
+                            "baspi5Ref": "A1.4.2",
                             "ta7Ref": "1.2",
                             "lpe1Ref": "3",
                             "piqRef": "A1.3.3",
@@ -5416,12 +5818,14 @@
                             "title": "Ground Rent",
                             "type": "object",
                             "lpe1Required": ["isGroundRentPayable"],
-                            "baspiRequired": ["isGroundRentPayable"],
+                            "baspi4Required": ["isGroundRentPayable"],
+                            "baspi5Required": ["isGroundRentPayable"],
                             "ta7Required": ["isGroundRentPayable"],
                             "ntsRequired": ["isGroundRentPayable"],
                             "properties": {
                               "isGroundRentPayable": {
-                                "baspiRef": "A1.4.2.1",
+                                "baspi4Ref": "A1.4.2.1",
+                                "baspi5Ref": "A1.4.2.1",
                                 "ta7Ref": "1.2.1",
                                 "ntsRef": "A3.4.1",
                                 "title": "Does the seller pay ground rent for the property?",
@@ -5446,7 +5850,8 @@
                                     "enum": ["Yes"]
                                   },
                                   "annualGroundRent": {
-                                    "baspiRef": "A1.4.2.2",
+                                    "baspi4Ref": "A1.4.2.2",
+                                    "baspi5Ref": "A1.4.2.2",
                                     "ta7Ref": "1.2a",
                                     "ntsRef": "A3.4.2",
                                     "lpe1Ref": "3.1",
@@ -5462,7 +5867,8 @@
                                     "type": "string"
                                   },
                                   "rentSubjectToIncrease": {
-                                    "baspiRef": "A1.4.2.3",
+                                    "baspi4Ref": "A1.4.2.3",
+                                    "baspi5Ref": "A1.4.2.3",
                                     "ntsRef": "A3.4.4",
                                     "ta7Ref": "1.2c",
                                     "piqRef": "A1.3.4",
@@ -5470,7 +5876,8 @@
                                     "title": "Is the ground rent subject to increase?",
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "A1.4.2.3.1",
+                                        "baspi4Ref": "A1.4.2.3.1",
+                                        "baspi5Ref": "A1.4.2.3.1",
                                         "piqRef": "A1.3.4.1",
                                         "ta7Ref": "1.2c.1",
                                         "ntsRef": "A3.4.4.1",
@@ -5481,7 +5888,8 @@
                                     },
                                     "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
-                                    "baspiRequired": ["yesNo"],
+                                    "baspi4Required": ["yesNo"],
+                                    "baspi5Required": ["yesNo"],
                                     "ntsRequired": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
@@ -5500,14 +5908,16 @@
                                             "enum": ["Yes"]
                                           },
                                           "rentReviewFrequency": {
-                                            "baspiRef": "A1.4.2.3.2",
+                                            "baspi4Ref": "A1.4.2.3.2",
+                                            "baspi5Ref": "A1.4.2.3.2",
                                             "ta7Ref": "1.2d",
                                             "ntsRef": "A3.4.4.2",
                                             "title": "How often is the rent reviewed?",
                                             "type": "string"
                                           },
                                           "rentIncreaseCalculated": {
-                                            "baspiRef": "A1.4.2.3.3",
+                                            "baspi4Ref": "A1.4.2.3.3",
+                                            "baspi5Ref": "A1.4.2.3.3",
                                             "piqRef": "A1.3.4.2",
                                             "ta7Ref": "1.2e",
                                             "ntsRef": "A3.4.4.3",
@@ -5520,7 +5930,11 @@
                                           "rentReviewFrequency",
                                           "rentIncreaseCalculated"
                                         ],
-                                        "baspiRequired": [
+                                        "baspi4Required": [
+                                          "rentReviewFrequency",
+                                          "rentIncreaseCalculated"
+                                        ],
+                                        "baspi5Required": [
                                           "rentReviewFrequency",
                                           "rentIncreaseCalculated"
                                         ],
@@ -5593,7 +6007,11 @@
                                   "groundRentPaidUpToDate",
                                   "lastDemandPeriod"
                                 ],
-                                "baspiRequired": [
+                                "baspi4Required": [
+                                  "annualGroundRent",
+                                  "rentSubjectToIncrease"
+                                ],
+                                "baspi5Required": [
                                   "annualGroundRent",
                                   "rentSubjectToIncrease"
                                 ],
@@ -5733,7 +6151,8 @@
                             }
                           },
                           "serviceCharge": {
-                            "baspiRef": "A1.5.1",
+                            "baspi4Ref": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "lpe1Ref": "4",
                             "ta7Ref": "5.4",
                             "ntsRef": "A3.5",
@@ -5742,14 +6161,18 @@
                             "lpe1Required": [
                               "sellerContributesToServiceCharge"
                             ],
-                            "baspiRequired": [
+                            "baspi4Required": [
+                              "sellerContributesToServiceCharge"
+                            ],
+                            "baspi5Required": [
                               "sellerContributesToServiceCharge"
                             ],
                             "ntsRequired": ["sellerContributesToServiceCharge"],
                             "ta7Required": ["sellerContributesToServiceCharge"],
                             "properties": {
                               "sellerContributesToServiceCharge": {
-                                "baspiRef": "A1.5.1.1",
+                                "baspi4Ref": "A1.5.1.1",
+                                "baspi5Ref": "A1.5.1.1",
                                 "ta7Ref": "5.4",
                                 "ntsRef": "A3.5.1",
                                 "title": "Does the seller contribute to the cost of maintaining the building (a service charge)?",
@@ -5774,20 +6197,23 @@
                                     "enum": ["Yes"]
                                   },
                                   "annualServiceCharge": {
-                                    "baspiRef": "A1.5.1.1.2",
+                                    "baspi4Ref": "A1.5.1.1.2",
+                                    "baspi5Ref": "A1.5.1.1.2",
                                     "lpe1Ref": "4.1.1",
                                     "ntsRef": "A3.5.1.1",
                                     "title": "Amount of current annual service charge (£)",
                                     "type": "number"
                                   },
                                   "largeAdditionalExpense": {
-                                    "baspiRef": "A1.5.2.1",
+                                    "baspi4Ref": "A1.5.2.1",
+                                    "baspi5Ref": "A1.5.2.1",
                                     "ta7Ref": "5.5",
                                     "title": "Does the seller know of any expense (e.g. the cost of redecoration of outside or communal areas not usually incurred annually) likely to be shown in the service charge accounts within the next three years?",
                                     "type": "object",
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "A1.5.2.2",
+                                        "baspi4Ref": "A1.5.2.2",
+                                        "baspi5Ref": "A1.5.2.2",
                                         "ta7Ref": "5.5.1",
                                         "type": "string",
                                         "title": "",
@@ -5796,7 +6222,8 @@
                                     },
                                     "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
-                                    "baspiRequired": ["yesNo"],
+                                    "baspi4Required": ["yesNo"],
+                                    "baspi5Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -5814,14 +6241,16 @@
                                             "enum": ["Yes"]
                                           },
                                           "details": {
-                                            "baspiRef": "A1.5.2.3",
+                                            "baspi4Ref": "A1.5.2.3",
+                                            "baspi5Ref": "A1.5.2.3",
                                             "ta7Ref": "5.5.2",
                                             "title": "Details",
                                             "type": "string"
                                           }
                                         },
                                         "lpe1Required": ["details"],
-                                        "baspiRequired": ["details"],
+                                        "baspi4Required": ["details"],
+                                        "baspi5Required": ["details"],
                                         "ta7Required": ["details"]
                                       }
                                     ]
@@ -6139,20 +6568,25 @@
                                     ]
                                   },
                                   "reserveFund": {
-                                    "baspiRef": "1.5.2.1",
+                                    "baspi4Ref": "1.5.2.1",
+                                    "baspi5Ref": "1.5.2.1",
                                     "lpe1Ref": "4.6",
                                     "type": "object",
                                     "title": "Does a Reserve Fund apply to the Managed Area?",
+                                    "baspi4Title": "Is there a reserve fund (also known as sinking fund or replacement fund)?",
+                                    "baspi5Title": "Is there a reserve fund (also known as sinking fund or replacement fund)?",
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "1.5.2.1.1",
+                                        "baspi4Ref": "1.5.2.1.1",
+                                        "baspi5Ref": "1.5.2.1.1",
                                         "type": "string",
                                         "title": "",
                                         "enum": ["Yes", "No"]
                                       }
                                     },
                                     "lpe1Required": ["yesNo"],
-                                    "baspiRequired": ["yesNo"],
+                                    "baspi4Required": ["yesNo"],
+                                    "baspi5Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -6174,6 +6608,12 @@
                                             "title": "Confirm the amount collected from Lessees of the Property, currently held in the Reserve Fund:",
                                             "type": "string",
                                             "minLength": 1
+                                          },
+                                          "contributionIncludedInServiceCharge": {
+                                            "baspi5Ref": "1.5.2.1.2",
+                                            "title": "Is the annual contribution included in the stated service charge?",
+                                            "type": "string",
+                                            "enum": ["Yes", "No"]
                                           },
                                           "sufficentToCoverSection20Expenditure": {
                                             "lpe1Ref": "4.6.2",
@@ -6440,20 +6880,23 @@
                                   },
                                   "transferFees": {
                                     "lpe1Ref": "4.12",
-                                    "baspiRef": "A1.5.3",
+                                    "baspi4Ref": "A1.5.3",
+                                    "baspi5Ref": "A1.5.3",
                                     "title": "Are there any transfer fees deferred service charges or similar fees, expressed as a percentage of the Property's value, payable on an event such as resale or subletting?",
                                     "type": "object",
                                     "properties": {
                                       "yesNo": {
                                         "lpe1Ref": "4.12.1",
-                                        "baspiRef": "A1.5.3.1",
+                                        "baspi4Ref": "A1.5.3.1",
+                                        "baspi5Ref": "A1.5.3.1",
                                         "type": "string",
                                         "title": "",
                                         "enum": ["Yes", "No"]
                                       }
                                     },
                                     "lpe1Required": ["yesNo"],
-                                    "baspiRequired": ["yesNo"],
+                                    "baspi4Required": ["yesNo"],
+                                    "baspi5Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -6472,7 +6915,8 @@
                                           },
                                           "details": {
                                             "lpe1Ref": "4.12.2",
-                                            "baspiRef": "A1.5.3.2",
+                                            "baspi4Ref": "A1.5.3.2",
+                                            "baspi5Ref": "A1.5.3.2",
                                             "title": "Provide details.",
                                             "type": "string",
                                             "minLength": 1
@@ -6553,7 +6997,12 @@
                                   "serviceChargeOwed",
                                   "lastDecoratedPeriod"
                                 ],
-                                "baspiRequired": [
+                                "baspi4Required": [
+                                  "annualServiceCharge",
+                                  "largeAdditionalExpense",
+                                  "reserveFund"
+                                ],
+                                "baspi5Required": [
                                   "annualServiceCharge",
                                   "largeAdditionalExpense",
                                   "reserveFund"
@@ -8331,7 +8780,8 @@
                       }
                     },
                     "lpe1Required": ["leaseholdInformation"],
-                    "baspiRequired": ["leaseholdInformation"],
+                    "baspi4Required": ["leaseholdInformation"],
+                    "baspi5Required": ["leaseholdInformation"],
                     "ta7Required": ["leaseholdInformation"]
                   },
                   {
@@ -8341,13 +8791,15 @@
                       },
                       "otherOwnershipDetails": {
                         "ntsRef": "A3.5",
-                        "baspiRef": "A1.3.2",
+                        "baspi4Ref": "A1.3.2",
+                        "baspi5Ref": "A1.3.2",
                         "title": "Details of the ownership type",
                         "type": "string",
                         "minLength": 1
                       }
                     },
-                    "baspiRequired": ["otherOwnershipDetails"],
+                    "baspi4Required": ["otherOwnershipDetails"],
+                    "baspi5Required": ["otherOwnershipDetails"],
                     "ntsRequired": ["otherOwnershipDetails"]
                   }
                 ]
@@ -8358,12 +8810,18 @@
         "parking": {
           "ntsRef": "B4",
           "ntslRef": "B4",
-          "baspiRef": "A1.6",
+          "baspi4Ref": "A1.6",
+          "baspi5Ref": "A1.6",
           "rdsRef": "Services/Parking",
           "ta6Ref": "9",
           "title": "Parking",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "parkingArrangements",
+            "controlledParking",
+            "electricVehicleChargingPoint"
+          ],
+          "baspi5Required": [
             "parkingArrangements",
             "controlledParking",
             "electricVehicleChargingPoint"
@@ -8385,7 +8843,8 @@
             "parkingArrangements": {
               "ntsRef": "B4.1",
               "ntslRef": "B4.1",
-              "baspiRef": "A1.6.0",
+              "baspi4Ref": "A1.6.0",
+              "baspi5Ref": "A1.6.0",
               "ta6Ref": "9.1",
               "piqRef": "A1.5",
               "type": "array",
@@ -8429,7 +8888,8 @@
             "controlledParking": {
               "ntsRef": "B4.3",
               "ntslRef": "B4.3",
-              "baspiRef": "A1.6.2",
+              "baspi4Ref": "A1.6.0.2",
+              "baspi5Ref": "A1.6.0.2",
               "ta6Ref": "9.2",
               "title": "Is the property in a controlled parking zone or within a local authority parking scheme?",
               "type": "object",
@@ -8437,44 +8897,132 @@
                 "yesNo": {
                   "ntsRef": "B4.3.1",
                   "ntslRef": "B4.3.1",
-                  "baspiRef": "A1.6.2.1",
+                  "baspi4Ref": "A1.6.0.2.1",
+                  "baspi5Ref": "A1.6.0.2.1",
                   "ta6Ref": "9.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not known"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
-              "ta6Required": ["yesNo"]
+              "ta6Required": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No", "Not known"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "annualCostOfPermit": {
+                      "baspi5Ref": "A1.6.0.2.2",
+                      "title": "Annual cost of permit (£)",
+                      "type": "number"
+                    }
+                  },
+                  "baspi5Required": ["annualCostOfPermit"]
+                }
+              ]
+            },
+            "vehicleTypeRestriction": {
+              "baspi5Ref": "A1.6.0.3",
+              "title": "Is there a restriction on the types of vehicle which may be parked?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "baspi5Ref": "A1.6.0.3.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "baspi5Required": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "baspi5Ref": "A1.6.0.3.2",
+                      "title": "Please provide details of the restriction",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "baspi5Required": ["details"]
+                }
+              ]
             },
             "electricVehicleChargingPoint": {
               "ntsRef": "B4.4",
               "ntslRef": "B4.4",
-              "baspiRef": "A1.6.1",
+              "baspi4Ref": "A1.6.1",
+              "baspi5Ref": "A1.6.1",
               "title": "Is there an electric vehicle charging point belonging to the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "ntsRef": "B4.4.1",
                   "ntslRef": "B4.4.1",
-                  "baspiRef": "A1.6.1.1",
+                  "baspi4Ref": "A1.6.1.1",
+                  "baspi5Ref": "A1.6.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"]
+            },
+            "locatedInUlez": {
+              "baspi4Ref": "A1.6.2",
+              "baspi5Ref": "A1.6.2",
+              "title": "Is the property and/or parking located in an Ultra Low Emission Zone (ULEZ)?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.6.2.1",
+                  "baspi5Ref": "A1.6.2.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"]
             }
           }
         },
         "listingAndConservation": {
           "ntsRef": "C2.1",
           "ntslRef": "C2.1",
-          "baspiRef": "A1.7",
+          "baspi4Ref": "A1.7",
+          "baspi5Ref": "A1.7",
           "ta6Ref": "4.7",
           "title": "Listing and Conservation",
           "type": "object",
@@ -8488,7 +9036,12 @@
             "isConservationArea",
             "hasTreePreservationOrder"
           ],
-          "baspiRequired": [
+          "baspi4Required": [
+            "isListed",
+            "isConservationArea",
+            "hasTreePreservationOrder"
+          ],
+          "baspi5Required": [
             "isListed",
             "isConservationArea",
             "hasTreePreservationOrder"
@@ -8502,7 +9055,8 @@
             "isListed": {
               "ntsRef": "C2.1.1",
               "ntslRef": "C2.1.1",
-              "baspiRef": "A1.7.1",
+              "baspi4Ref": "A1.7.1",
+              "baspi5Ref": "A1.7.1",
               "rdsRef": "Protections",
               "ta6Ref": "4.7a",
               "piqRef": "A1.6.1",
@@ -8512,7 +9066,8 @@
                 "yesNo": {
                   "ntsRef": "C2.1.1.1",
                   "ntslRef": "C2.1.1.1",
-                  "baspiRef": "A1.7.1.1",
+                  "baspi4Ref": "A1.7.1.1",
+                  "baspi5Ref": "A1.7.1.1",
                   "ta6Ref": "4.7a1",
                   "piqRef": "A1.6.1.1",
                   "type": "string",
@@ -8522,7 +9077,8 @@
                   "ntslEnum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -8545,14 +9101,16 @@
                     "details": {
                       "ntsRef": "C2.1.1.2",
                       "ntslRef": "C2.1.1.2",
-                      "baspiRef": "A1.7.1.2",
+                      "baspi4Ref": "A1.7.1.2",
+                      "baspi5Ref": "A1.7.1.2",
                       "ta6Ref": "4.7a2",
                       "title": "Please provide details of the listing",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.7.1.3",
+                      "baspi4Ref": "A1.7.1.3",
+                      "baspi5Ref": "A1.7.1.3",
                       "ta6Ref": "4.7a3",
                       "title": "Attachments",
                       "type": "string",
@@ -8561,7 +9119,8 @@
                   },
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"],
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details", "attachments"]
                 }
               ]
@@ -8569,7 +9128,8 @@
             "isConservationArea": {
               "ntsRef": "C2.1.2",
               "ntslRef": "C2.1.2",
-              "baspiRef": "A1.7.2",
+              "baspi4Ref": "A1.7.2",
+              "baspi5Ref": "A1.7.2",
               "rdsRef": "Protections",
               "ta6Ref": "4.7b",
               "piqRef": "A1.6.2",
@@ -8579,7 +9139,8 @@
                 "yesNo": {
                   "ntsRef": "C2.1.2.1",
                   "ntslRef": "C2.1.2.1",
-                  "baspiRef": "A1.7.2.1",
+                  "baspi4Ref": "A1.7.2.1",
+                  "baspi5Ref": "A1.7.2.1",
                   "piqRef": "A1.6.2.1",
                   "ta6Ref": "4.7b1",
                   "type": "string",
@@ -8589,7 +9150,8 @@
                   "ntslEnum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -8612,14 +9174,16 @@
                     "details": {
                       "ntsRef": "C2.1.2.2",
                       "ntslRef": "C2.1.2.2",
-                      "baspiRef": "A1.7.2.2",
+                      "baspi4Ref": "A1.7.2.2",
+                      "baspi5Ref": "A1.7.2.2",
                       "ta6Ref": "4.7b2",
                       "title": "Please provide details of the listing",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.7.2.3",
+                      "baspi4Ref": "A1.7.2.3",
+                      "baspi5Ref": "A1.7.2.3",
                       "ta6Ref": "4.7b3",
                       "title": "Attachments",
                       "type": "string",
@@ -8628,7 +9192,8 @@
                   },
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"],
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details", "attachments"]
                 }
               ]
@@ -8636,7 +9201,8 @@
             "hasTreePreservationOrder": {
               "ntsRef": "C2.1.3",
               "ntslRef": "C2.1.3",
-              "baspiRef": "A1.7.3",
+              "baspi4Ref": "A1.7.3",
+              "baspi5Ref": "A1.7.3",
               "rdsRef": "Property/Flags",
               "ta6Ref": "4.8",
               "piqRef": "A1.6.3",
@@ -8646,7 +9212,8 @@
                 "yesNo": {
                   "ntsRef": "C2.1.3.1",
                   "ntslRef": "C2.1.3.1",
-                  "baspiRef": "A1.7.3.1",
+                  "baspi4Ref": "A1.7.3.1",
+                  "baspi5Ref": "A1.7.3.1",
                   "ta6Ref": "4.8.1",
                   "piqRef": "A1.6.3.1",
                   "type": "string",
@@ -8656,7 +9223,8 @@
                   "ntslEnum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -8679,7 +9247,8 @@
                     "workCarriedOut": {
                       "ntsRef": "C2.1.3.2",
                       "ntslRef": "C2.1.3.2",
-                      "baspiRef": "A1.7.3.2",
+                      "baspi4Ref": "A1.7.3.2",
+                      "baspi5Ref": "A1.7.3.2",
                       "rdsRef": "WorksAlterationsChanges",
                       "ta6Ref": "4.8a",
                       "piqRef": "A1.6.4",
@@ -8687,7 +9256,8 @@
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A1.7.3.2.1",
+                          "baspi4Ref": "A1.7.3.2.1",
+                          "baspi5Ref": "A1.7.3.2.1",
                           "ta6Ref": "4.8a1",
                           "piqRef": "A1.6.4.1",
                           "type": "string",
@@ -8695,7 +9265,8 @@
                           "enum": ["Yes", "No"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ntsRequired": ["yesNo"],
                       "ntslRequired": ["yesNo"],
                       "ta6Required": ["yesNo"],
@@ -8718,7 +9289,8 @@
                             "consentsObtained": {
                               "ntsRef": "C2.1.3.3",
                               "ntslRef": "C2.1.3.3",
-                              "baspiRef": "A1.7.3.3",
+                              "baspi4Ref": "A1.7.3.3",
+                              "baspi5Ref": "A1.7.3.3",
                               "ta6Ref": "4.8a2",
                               "title": "Were the relevant consents obtained?",
                               "rdsRef": "Protections",
@@ -8726,7 +9298,8 @@
                               "enum": ["Yes", "No", "Not known"]
                             },
                             "attachments": {
-                              "baspiRef": "A1.7.3.4",
+                              "baspi4Ref": "A1.7.3.4",
+                              "baspi5Ref": "A1.7.3.4",
                               "ta6Ref": "4.8a3",
                               "title": "Provide any relevant documentation",
                               "type": "string",
@@ -8735,13 +9308,15 @@
                           },
                           "ntsRequired": ["consentsObtained"],
                           "ntslRequired": ["consentsObtained"],
-                          "baspiRequired": ["consentsObtained"],
+                          "baspi4Required": ["consentsObtained"],
+                          "baspi5Required": ["consentsObtained"],
                           "ta6Required": ["consentsObtained"]
                         }
                       ]
                     }
                   },
-                  "baspiRequired": ["workCarriedOut"],
+                  "baspi4Required": ["workCarriedOut"],
+                  "baspi5Required": ["workCarriedOut"],
                   "ta6Required": ["workCarriedOut"]
                 }
               ]
@@ -8749,12 +9324,18 @@
           }
         },
         "typeOfConstruction": {
-          "baspiRef": "A1.8",
+          "baspi4Ref": "A1.8",
+          "baspi5Ref": "A1.8",
           "ntsRef": "A1.2",
           "ntslRef": "A1.2",
           "title": "Type of Construction",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "isStandardForm",
+            "buildingSafety",
+            "sprayFoamInsulation"
+          ],
+          "baspi5Required": [
             "isStandardForm",
             "buildingSafety",
             "sprayFoamInsulation"
@@ -8763,7 +9344,8 @@
           "ntslRequired": ["isStandardForm", "buildingSafety"],
           "properties": {
             "isStandardForm": {
-              "baspiRef": "A1.8.1",
+              "baspi4Ref": "A1.8.1",
+              "baspi5Ref": "A1.8.1",
               "ntsRef": "A1.2.1",
               "ntslRef": "A1.2.1",
               "rdsRef": "Buildings,BuildingSections/ConstructionType,ConstructionMaterials",
@@ -8773,7 +9355,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.8.1.1",
+                  "baspi4Ref": "A1.8.1.1",
+                  "baspi5Ref": "A1.8.1.1",
                   "ntsRef": "A1.2.1.1",
                   "ntslRef": "A1.2.1.1",
                   "piqRef": "A5.5.1",
@@ -8782,7 +9365,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "discriminator": {
@@ -8802,7 +9386,8 @@
                       "enum": ["No"]
                     },
                     "details": {
-                      "baspiRef": "A1.8.1.2",
+                      "baspi4Ref": "A1.8.1.2",
+                      "baspi5Ref": "A1.8.1.2",
                       "ntsRef": "A1.2.1.2",
                       "ntslRef": "A1.2.1.2",
                       "title": "Details",
@@ -8810,7 +9395,8 @@
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"]
                 }
@@ -8819,10 +9405,12 @@
             "buildingSafety": {
               "ntsRef": "C1",
               "ntslRef": "C1",
-              "baspiRef": "A1.8.2",
+              "baspi4Ref": "A1.8.2",
+              "baspi5Ref": "A1.8.2",
               "ta7Ref": "11.1",
               "title": "Are you aware of any building safety issues?",
-              "baspiTitle": "Are you aware of any remediation required to the property due to building safety?",
+              "baspi4Title": "Are you aware of any remediation required to the property due to building safety?",
+              "baspi5Title": "Are you aware of any remediation required to the property due to building safety?",
               "ta7Title": "Have any remediation works on the building been proposed or carried out?",
               "description": "For example issues related to unsafe cladding, integrity of building materials used in construction (e.g. asbestos), risk of collapse (e.g. damaged roofs or structural failures), at-risk wooden decking for external structures (including balconies), lack of emergency lighting where required or insufficient fire/smoke alarm systems",
               "type": "object",
@@ -8830,20 +9418,23 @@
                 "yesNo": {
                   "ntsRef": "C1.1",
                   "ntslRef": "C1.1",
-                  "baspiRef": "A1.8.2.1",
+                  "baspi4Ref": "A1.8.2.1",
+                  "baspi5Ref": "A1.8.2.1",
                   "ta7Ref": "11.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not applicable"],
                   "ta7Enum": ["Yes", "No", "Not applicable"],
-                  "baspiEnum": ["Yes", "No"],
+                  "baspi4Enum": ["Yes", "No"],
+                  "baspi5Enum": ["Yes", "No"],
                   "ntsEnum": ["Yes", "No"],
                   "ntslEnum": ["Yes", "No"]
                 }
               },
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta7Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -8865,7 +9456,8 @@
                     "details": {
                       "ntsRef": "C1.2",
                       "ntslRef": "C1.2",
-                      "baspiRef": "A1.8.2.2",
+                      "baspi4Ref": "A1.8.2.2",
+                      "baspi5Ref": "A1.8.2.2",
                       "ta7Ref": "11.1.2",
                       "title": "What are the defects or hazards?",
                       "ta7Title": "Please provide details of the remediation works proposed and evidence of any carried out.",
@@ -8875,7 +9467,8 @@
                     "workAlreadyDone": {
                       "ntsRef": "C1.3",
                       "ntslRef": "C1.3",
-                      "baspiRef": "A1.8.2.2",
+                      "baspi4Ref": "A1.8.2.2",
+                      "baspi5Ref": "A1.8.2.2",
                       "ta7Ref": "11.1.2",
                       "title": "What work has already been done?",
                       "type": "string",
@@ -8884,7 +9477,8 @@
                     "workToBeDone": {
                       "ntsRef": "C1.4",
                       "ntslRef": "C1.4",
-                      "baspiRef": "A1.8.2.2",
+                      "baspi4Ref": "A1.8.2.2",
+                      "baspi5Ref": "A1.8.2.2",
                       "ta7Ref": "11.1.2",
                       "title": "What work is required to be done?",
                       "type": "string",
@@ -8893,7 +9487,8 @@
                     "potentialCost": {
                       "ntsRef": "C1.5",
                       "ntslRef": "C1.5",
-                      "baspiRef": "A1.8.2.2",
+                      "baspi4Ref": "A1.8.2.2",
+                      "baspi5Ref": "A1.8.2.2",
                       "ta7Ref": "11.1.2",
                       "title": "What will the potential cost be?",
                       "type": "string",
@@ -8902,14 +9497,16 @@
                     "abilityToResideAtProperty": {
                       "ntsRef": "C1.6",
                       "ntslRef": "C1.6",
-                      "baspiRef": "A1.8.2.2",
+                      "baspi4Ref": "A1.8.2.2",
+                      "baspi5Ref": "A1.8.2.2",
                       "ta7Ref": "11.1.2",
                       "title": "Will the work impact the ability to reside at the property?",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.8.2.3",
+                      "baspi4Ref": "A1.8.2.3",
+                      "baspi5Ref": "A1.8.2.3",
                       "ta7Ref": "11.1.3",
                       "title": "Attachments",
                       "description": "Please attach evidence in support of the above",
@@ -8917,7 +9514,8 @@
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ntsRequired": [
                     "details",
                     "workAlreadyDone",
@@ -8936,18 +9534,21 @@
               ]
             },
             "sprayFoamInsulation": {
-              "baspiRef": "A1.8.4",
+              "baspi4Ref": "A1.8.4",
+              "baspi5Ref": "A1.8.4",
               "title": "Has spray foam insulation been installed at the property?",
               "type": "object",
               "properties": {
                 "hasSprayFoamInstalled": {
-                  "baspiRef": "A1.8.4.1",
+                  "baspi4Ref": "A1.8.4.1",
+                  "baspi5Ref": "A1.8.4.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["hasSprayFoamInstalled"],
+              "baspi4Required": ["hasSprayFoamInstalled"],
+              "baspi5Required": ["hasSprayFoamInstalled"],
               "discriminator": {
                 "propertyName": "hasSprayFoamInstalled"
               },
@@ -8965,23 +9566,27 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A1.8.4.2",
+                      "baspi4Ref": "A1.8.4.2",
+                      "baspi5Ref": "A1.8.4.2",
                       "title": "Please give details together with certification from BBA or KIWA and the installation warranty for the work carried out",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.8.4.3",
+                      "baspi4Ref": "A1.8.4.3",
+                      "baspi5Ref": "A1.8.4.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
             "accessibilityAndAdaptations": {
+              "baspi5Ref": "A12.2",
               "ntsRef": "C5",
               "ntslRef": "C5",
               "title": "Are there any adaptations or features that provide easier access to, and within, the property?",
@@ -9004,14 +9609,16 @@
           }
         },
         "energyEfficiency": {
-          "baspiRef": "A1.8.3",
+          "baspi4Ref": "A1.8.3",
+          "baspi5Ref": "A1.8.3",
           "ta6Ref": "7.6",
           "ntsRef": "A4",
           "ntslRef": "A4",
           "rdsRef": "Certificates/{category='energyEfficiency',standard='EPC',gradeLevelRating=?},Certificates/{category='energyEfficiency',standard='EPC',status='exempt'},",
           "title": "Energy Efficiency",
           "type": "object",
-          "baspiRequired": ["certificate", "greenDealLoan"],
+          "baspi4Required": ["certificate", "greenDealLoan"],
+          "baspi5Required": ["certificate", "greenDealLoan"],
           "ntsRequired": ["certificate"],
           "ntslRequired": ["certificate"],
           "ta6Required": ["certificateIsSupplied", "greenDealLoan"],
@@ -9023,11 +9630,13 @@
               "enum": ["Attached", "To follow", "Already supplied"]
             },
             "certificate": {
-              "baspiRef": "A1.8.3.1",
+              "baspi4Ref": "A1.8.3.1",
+              "baspi5Ref": "A1.8.3.1",
               "ntsRef": "A4.1",
               "ntslRef": "A4.1",
               "type": "object",
-              "baspiRequired": ["currentEnergyRating"],
+              "baspi4Required": ["currentEnergyRating"],
+              "baspi5Required": ["currentEnergyRating"],
               "ntsRequired": ["currentEnergyRating"],
               "ntslRequired": ["currentEnergyRating"],
               "properties": {
@@ -9077,7 +9686,8 @@
                   "type": "integer"
                 },
                 "currentEnergyRating": {
-                  "baspiRef": "A1.8.3.1.1",
+                  "baspi4Ref": "A1.8.3.1.1",
+                  "baspi5Ref": "A1.8.3.1.1",
                   "ntsRef": "A4.1.1",
                   "ntslRef": "A4.1.1",
                   "title": "Current energy efficiency rating",
@@ -9362,23 +9972,27 @@
               }
             },
             "greenDealLoan": {
-              "baspiRef": "A7.3",
+              "baspi4Ref": "A7.3",
+              "baspi5Ref": "A7.3",
               "ta6Ref": "7.7",
               "piqRef": "A11.4",
               "rdsRef": "RightsHolders/Loans,RightsHolders/OtherDocumentation",
               "title": "Green Deal Loan",
               "type": "object",
-              "baspiRequired": ["hasGreenDealLoan"],
+              "baspi4Required": ["hasGreenDealLoan"],
+              "baspi5Required": ["hasGreenDealLoan"],
               "ta6Required": ["hasGreenDealLoan"],
               "properties": {
                 "hasGreenDealLoan": {
-                  "baspiRef": "A7.3",
+                  "baspi4Ref": "A7.3",
+                  "baspi5Ref": "A7.3",
                   "ta6Ref": "7.7.0",
                   "title": "Is this property subject to a Green Deal loan or other financed home improvement scheme?",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.3.1",
+                      "baspi4Ref": "A7.3.1",
+                      "baspi5Ref": "A7.3.1",
                       "ta6Ref": "7.7.1",
                       "piqRef": "A11.4.1",
                       "type": "string",
@@ -9386,7 +10000,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -9405,21 +10020,24 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A7.3.2",
+                          "baspi4Ref": "A7.3.2",
+                          "baspi5Ref": "A7.3.2",
                           "ta6Ref": "7.7.2",
                           "title": "Please provide details below including any outstanding payments for the renewable devices and any feed-in tariffs and a copy of your last electricity bill",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "A7.3.3",
+                          "baspi4Ref": "A7.3.3",
+                          "baspi5Ref": "A7.3.3",
                           "ta6Ref": "7.7.3",
                           "title": "Attachments",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details", "attachments"],
+                      "baspi4Required": ["details", "attachments"],
+                      "baspi5Required": ["details", "attachments"],
                       "ta6Required": ["details", "attachments"]
                     }
                   ]
@@ -9429,18 +10047,27 @@
           }
         },
         "councilTax": {
-          "baspiRef": "A1.9",
+          "baspi4Ref": "A1.9",
+          "baspi5Ref": "A1.9",
           "ntsRef": "A1",
           "ntslRef": "A1",
           "piqRef": "B2",
           "title": "Council Tax",
           "type": "object",
-          "baspiRequired": ["councilTaxBand", "councilTaxAffectingAlterations"],
+          "baspi4Required": [
+            "councilTaxBand",
+            "councilTaxAffectingAlterations"
+          ],
+          "baspi5Required": [
+            "councilTaxBand",
+            "councilTaxAffectingAlterations"
+          ],
           "ntsRequired": ["councilTaxBand", "councilTaxAffectingAlterations"],
           "ntslRequired": ["councilTaxBand", "councilTaxAffectingAlterations"],
           "properties": {
             "councilTaxBand": {
-              "baspiRef": "A1.9.1",
+              "baspi4Ref": "A1.9.1",
+              "baspi5Ref": "A1.9.1",
               "ntsRef": "A1.1",
               "ntslRef": "A1.1",
               "rdsRef": "TenureAgreements/Taxes/{banding=?}",
@@ -9451,7 +10078,8 @@
               "enum": ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
             },
             "councilTaxAffectingAlterations": {
-              "baspiRef": "A1.9.2",
+              "baspi4Ref": "A1.9.2",
+              "baspi5Ref": "A1.9.2",
               "ntsRef": "A1.2",
               "ntslRef": "A1.2",
               "rdsRef": "TenureAgreements/Taxes/WorksAlterationsChanges",
@@ -9459,7 +10087,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.9.2.1",
+                  "baspi4Ref": "A1.9.2.1",
+                  "baspi5Ref": "A1.9.2.1",
                   "ntsRef": "A1.2.1",
                   "ntslRef": "A1.2.1",
                   "type": "string",
@@ -9467,7 +10096,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "discriminator": {
@@ -9487,7 +10117,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A1.9.2.2",
+                      "baspi4Ref": "A1.9.2.2",
+                      "baspi5Ref": "A1.9.2.2",
                       "ntsRef": "A1.2.2",
                       "ntslRef": "A1.2.2",
                       "title": "Please give details",
@@ -9495,7 +10126,8 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A1.9.2.3",
+                      "baspi4Ref": "A1.9.2.3",
+                      "baspi5Ref": "A1.9.2.3",
                       "ntsRef": "A1.2.3",
                       "ntslRef": "A1.2.3",
                       "title": "Attachments",
@@ -9503,7 +10135,8 @@
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"]
                 }
@@ -9516,11 +10149,16 @@
           }
         },
         "disputesAndComplaints": {
-          "baspiRef": "A2",
+          "baspi4Ref": "A2",
+          "baspi5Ref": "A2",
           "ta6Ref": "2",
           "title": "Disputes and Complaints",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "hasDisputesAndComplaints",
+            "leadingToDisputesAndComplaints"
+          ],
+          "baspi5Required": [
             "hasDisputesAndComplaints",
             "leadingToDisputesAndComplaints"
           ],
@@ -9530,7 +10168,8 @@
           ],
           "properties": {
             "hasDisputesAndComplaints": {
-              "baspiRef": "A2.1.1",
+              "baspi4Ref": "A2.1.1",
+              "baspi5Ref": "A2.1.1",
               "rdsRef": "Tenure/DisputesComplaints,Tenure/LegalClaims",
               "ta6Ref": "2.1",
               "piqRef": "A2.1",
@@ -9541,7 +10180,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A2.1.1.1",
+                  "baspi4Ref": "A2.1.1.1",
+                  "baspi5Ref": "A2.1.1.1",
                   "ta6Ref": "2.1.1",
                   "piqRef": "A2.1.1",
                   "type": "string",
@@ -9549,7 +10189,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -9568,7 +10209,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A2.1.1.2",
+                      "baspi4Ref": "A2.1.1.2",
+                      "baspi5Ref": "A2.1.1.2",
                       "ta6Ref": "2.1.2",
                       "piqRef": "A2.1.1.2",
                       "title": "Please give details",
@@ -9576,27 +10218,31 @@
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "leadingToDisputesAndComplaints": {
-              "baspiRef": "A2.1.2",
+              "baspi4Ref": "A2.1.2",
+              "baspi5Ref": "A2.1.2",
               "rdsRef": "Tenure/DisputesComplaints,Tenure/LegalClaims",
               "ta6Ref": "2.2",
               "title": "Is the seller aware of anything which might lead to a dispute about the property or a property nearby?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A2.1.2.1",
+                  "baspi4Ref": "A2.1.2.1",
+                  "baspi5Ref": "A2.1.2.1",
                   "ta6Ref": "2.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -9615,14 +10261,16 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A2.1.2.2",
+                      "baspi4Ref": "A2.1.2.2",
+                      "baspi5Ref": "A2.1.2.2",
                       "ta6Ref": "2.2.2",
                       "title": "Please give details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -9630,12 +10278,22 @@
           }
         },
         "alterationsAndChanges": {
-          "baspiRef": "A3",
+          "baspi4Ref": "A3",
+          "baspi5Ref": "A3",
           "ta6Ref": "4.1",
           "title": "Alterations and Changes to the Property",
           "description": "Have any of the following changes been made to the whole or any part of the property (including the garden)?",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "hasStructuralAlterations",
+            "changeOfUse",
+            "windowReplacementsSince2002",
+            "hasAddedConservatory",
+            "worksUnfinished",
+            "planningPermissionBreaches",
+            "unresolvedPlanningIssues"
+          ],
+          "baspi5Required": [
             "hasStructuralAlterations",
             "changeOfUse",
             "windowReplacementsSince2002",
@@ -9655,7 +10313,8 @@
           ],
           "properties": {
             "hasStructuralAlterations": {
-              "baspiRef": "A3.1",
+              "baspi4Ref": "A3.1",
+              "baspi5Ref": "A3.1",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1a",
               "piqRef": "A3.1",
@@ -9663,7 +10322,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.1.1",
+                  "baspi4Ref": "A3.1.1",
+                  "baspi5Ref": "A3.1.1",
                   "ta6Ref": "4.1a1",
                   "piqRef": "A3.1.1",
                   "type": "string",
@@ -9671,7 +10331,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -9690,7 +10351,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.1.2",
+                      "baspi4Ref": "A3.1.2",
+                      "baspi5Ref": "A3.1.2",
                       "ta6Ref": "4.1a2",
                       "piqRef": "A3.1.2",
                       "title": "Please give details including dates of all work undertaken",
@@ -9698,21 +10360,24 @@
                       "minLength": 1
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi4Ref": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "title": "Was Building Regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1",
+                          "baspi4Ref": "A3.5.1.1",
+                          "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -9724,14 +10389,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -9740,7 +10407,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2",
+                              "baspi4Ref": "A3.5.1.2",
+                              "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. the work was exempt from Building Regulations",
@@ -9748,27 +10416,31 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi4Ref": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2.1",
                       "title": "Was planning permission obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1",
+                          "baspi4Ref": "A3.5.2.1",
+                          "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -9780,14 +10452,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3",
+                              "baspi4Ref": "A3.5.2.3",
+                              "baspi5Ref": "A3.5.2.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -9796,7 +10470,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2",
+                              "baspi4Ref": "A3.5.2.2",
+                              "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
@@ -9804,25 +10479,29 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi4Ref": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1",
+                          "baspi4Ref": "A3.5.3.1",
+                          "baspi5Ref": "A3.5.3.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -9833,13 +10512,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -9848,30 +10529,35 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2",
+                              "baspi4Ref": "A3.5.3.2",
+                              "baspi5Ref": "A3.5.3.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi4Ref": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1",
+                          "baspi4Ref": "A3.5.4.1",
+                          "baspi5Ref": "A3.5.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -9882,13 +10568,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -9896,18 +10584,27 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2",
+                              "baspi4Ref": "A3.5.4.2",
+                              "baspi5Ref": "A3.5.4.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "buildingRegApproval",
                     "planningPermission",
@@ -9919,21 +10616,24 @@
               ]
             },
             "changeOfUse": {
-              "baspiRef": "A3.2",
+              "baspi4Ref": "A3.2",
+              "baspi5Ref": "A3.2",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1b",
               "title": "Has there been any change of use (e.g. from an office to a residence)?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.2.1",
+                  "baspi4Ref": "A3.2.1",
+                  "baspi5Ref": "A3.2.1",
                   "ta6Ref": "4.1b1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -9952,33 +10652,38 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.2.2",
+                      "baspi4Ref": "A3.2.2",
+                      "baspi5Ref": "A3.2.2",
                       "title": "Please outline the nature of the work",
                       "type": "string",
                       "minLength": 1
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.2.3",
+                      "baspi4Ref": "A3.2.3",
+                      "baspi5Ref": "A3.2.3",
                       "ta6Ref": "4.1b2",
                       "title": "What year was the change completed?",
                       "type": "integer"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi4Ref": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "title": "Was building regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1",
+                          "baspi4Ref": "A3.5.1.1",
+                          "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -9990,14 +10695,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10006,7 +10713,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2",
+                              "baspi4Ref": "A3.5.1.2",
+                              "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. the work was exempt from Building Regulations",
@@ -10014,27 +10722,31 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi4Ref": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "title": "Was planning permission obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1",
+                          "baspi4Ref": "A3.5.2.1",
+                          "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -10046,14 +10758,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10062,7 +10776,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2",
+                              "baspi4Ref": "A3.5.2.2",
+                              "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
@@ -10070,25 +10785,29 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi4Ref": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1",
+                          "baspi4Ref": "A3.5.3.1",
+                          "baspi5Ref": "A3.5.3.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10099,13 +10818,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10113,30 +10834,35 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2",
+                              "baspi4Ref": "A3.5.3.2",
+                              "baspi5Ref": "A3.5.3.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi4Ref": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1",
+                          "baspi4Ref": "A3.5.4.1",
+                          "baspi5Ref": "A3.5.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10147,13 +10873,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10161,18 +10889,28 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2",
+                              "baspi4Ref": "A3.5.4.2",
+                              "baspi5Ref": "A3.5.4.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "yearCompleted",
                     "buildingRegApproval",
@@ -10185,7 +10923,8 @@
               ]
             },
             "windowReplacementsSince2002": {
-              "baspiRef": "A3.3",
+              "baspi4Ref": "A3.3",
+              "baspi5Ref": "A3.3",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1c",
               "piqRef": "A3.2",
@@ -10193,7 +10932,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.3.1",
+                  "baspi4Ref": "A3.3.1",
+                  "baspi5Ref": "A3.3.1",
                   "ta6Ref": "4.1c1",
                   "piqRef": "A3.2.1",
                   "type": "string",
@@ -10201,7 +10941,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -10220,35 +10961,40 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.3.2",
+                      "baspi4Ref": "A3.3.2",
+                      "baspi5Ref": "A3.3.2",
                       "piqRef": "A3.2.2",
                       "title": "For each installation, please outline the nature of the work.",
                       "type": "string",
                       "minLength": 1
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.3.3",
+                      "baspi4Ref": "A3.3.3",
+                      "baspi5Ref": "A3.3.3",
                       "piqRef": "A3.2.3",
                       "ta6Ref": "4.1c2",
                       "title": "What year was the installation completed?",
                       "type": "integer"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi4Ref": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "title": "Was building regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1",
+                          "baspi4Ref": "A3.5.1.1",
+                          "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -10260,14 +11006,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10276,7 +11024,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2",
+                              "baspi4Ref": "A3.5.1.2",
+                              "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. the work was exempt from Building Regulations",
@@ -10284,27 +11033,31 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi4Ref": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "title": "Was planning permission obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1",
+                          "baspi4Ref": "A3.5.2.1",
+                          "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -10316,14 +11069,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3",
+                              "baspi4Ref": "A3.5.2.3",
+                              "baspi5Ref": "A3.5.2.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10332,7 +11087,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2",
+                              "baspi4Ref": "A3.5.2.2",
+                              "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
@@ -10340,25 +11096,29 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi4Ref": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1",
+                          "baspi4Ref": "A3.5.3.1",
+                          "baspi5Ref": "A3.5.3.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10369,13 +11129,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.3.3",
+                              "baspi4Ref": "A3.5.3.3",
+                              "baspi5Ref": "A3.5.3.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10383,30 +11145,35 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2",
+                              "baspi4Ref": "A3.5.3.2",
+                              "baspi5Ref": "A3.5.3.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi4Ref": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1",
+                          "baspi4Ref": "A3.5.4.1",
+                          "baspi5Ref": "A3.5.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10417,13 +11184,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.4.3",
+                              "baspi4Ref": "A3.5.4.3",
+                              "baspi5Ref": "A3.5.4.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10431,18 +11200,28 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2",
+                              "baspi4Ref": "A3.5.4.2",
+                              "baspi5Ref": "A3.5.4.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "yearCompleted",
                     "buildingRegApproval",
@@ -10455,7 +11234,8 @@
               ]
             },
             "hasAddedConservatory": {
-              "baspiRef": "A3.4",
+              "baspi4Ref": "A3.4",
+              "baspi5Ref": "A3.4",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1d",
               "piqRef": "A3.4",
@@ -10463,7 +11243,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.4.1",
+                  "baspi4Ref": "A3.4.1",
+                  "baspi5Ref": "A3.4.1",
                   "ta6Ref": "4.1d1",
                   "piqRef": "A3.4.1",
                   "type": "string",
@@ -10471,7 +11252,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -10490,21 +11272,24 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.4.2",
+                      "baspi4Ref": "A3.4.2",
+                      "baspi5Ref": "A3.4.2",
                       "piqRef": "A3.4.2",
                       "title": "Confirm whether any walls were removed, an exterior quality door separates the conservatory from the main building and, since the conservatory was added, has any replacement or refurbishment of the roof been undertaken that reduces the glazed area of the roof?",
                       "type": "string",
                       "minLength": 1
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.4.3",
+                      "baspi4Ref": "A3.4.3",
+                      "baspi5Ref": "A3.4.3",
                       "piqRef": "A3.4.3",
                       "ta6Ref": "4.1d2",
                       "title": "What year was the installation completed?",
                       "type": "integer"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi4Ref": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "piqRef": "A3.5.1",
@@ -10512,7 +11297,8 @@
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1",
+                          "baspi4Ref": "A3.5.1.1",
+                          "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
                           "piqRef": "A3.5.1.1",
                           "type": "string",
@@ -10520,7 +11306,8 @@
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -10532,14 +11319,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3",
+                              "baspi4Ref": "A3.5.1.3",
+                              "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10548,7 +11337,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2",
+                              "baspi4Ref": "A3.5.1.2",
+                              "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
                               "piqRef": "A3.5.1.2",
                               "title": "Please outline the reasons why",
@@ -10557,13 +11347,15 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi4Ref": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
                       "piqRef": "A3.5.2",
@@ -10571,7 +11363,8 @@
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1",
+                          "baspi4Ref": "A3.5.2.1",
+                          "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
                           "piqRef": "A3.5.2.1",
                           "type": "string",
@@ -10579,7 +11372,8 @@
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -10591,14 +11385,16 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3",
+                              "baspi4Ref": "A3.5.2.3",
+                              "baspi5Ref": "A3.5.2.3",
                               "ta6Ref": "4.2a",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"],
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"],
                           "ta6Required": ["attachments"]
                         },
                         {
@@ -10607,7 +11403,8 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2",
+                              "baspi4Ref": "A3.5.2.2",
+                              "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
@@ -10615,27 +11412,31 @@
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"],
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"],
                           "ta6Required": ["details"]
                         }
                       ]
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi4Ref": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "piqRef": "A3.5.3",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1",
+                          "baspi4Ref": "A3.5.3.1",
+                          "baspi5Ref": "A3.5.3.1",
                           "piqRef": "A3.5.3.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10646,13 +11447,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.3.3",
+                              "baspi4Ref": "A3.5.3.3",
+                              "baspi5Ref": "A3.5.3.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10660,32 +11463,37 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2",
+                              "baspi4Ref": "A3.5.3.2",
+                              "baspi5Ref": "A3.5.3.2",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi4Ref": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "piqRef": "A3.5.4",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1",
+                          "baspi4Ref": "A3.5.4.1",
+                          "baspi5Ref": "A3.5.4.1",
                           "piqRef": "A3.5.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -10696,13 +11504,15 @@
                               "enum": ["Yes"]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.4.3",
+                              "baspi4Ref": "A3.5.4.3",
+                              "baspi5Ref": "A3.5.4.3",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["attachments"]
+                          "baspi4Required": ["attachments"],
+                          "baspi5Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -10710,19 +11520,29 @@
                               "enum": ["No", "Not required"]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2",
+                              "baspi4Ref": "A3.5.4.2",
+                              "baspi5Ref": "A3.5.4.2",
                               "piqRef": "A3.5.5",
                               "title": "Please outline the reasons why",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "yearCompleted",
                     "buildingRegApproval",
@@ -10735,7 +11555,8 @@
               ]
             },
             "worksUnfinished": {
-              "baspiRef": "A3.6",
+              "baspi4Ref": "A3.6",
+              "baspi5Ref": "A3.6",
               "rdsRef": "WorksAlterationsChanges/isIncomplete",
               "ta6Ref": "4.3",
               "piqRef": "A3.6",
@@ -10743,7 +11564,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.6.1",
+                  "baspi4Ref": "A3.6.1",
+                  "baspi5Ref": "A3.6.1",
                   "ta6Ref": "4.3.1",
                   "piqRef": "A3.6.1",
                   "type": "string",
@@ -10751,7 +11573,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -10770,7 +11593,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.6.2",
+                      "baspi4Ref": "A3.6.2",
+                      "baspi5Ref": "A3.6.2",
                       "ta6Ref": "4.3.2",
                       "piqRef": "A3.6.2",
                       "title": "Please provide details and explain why",
@@ -10778,19 +11602,22 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A3.6.3",
+                      "baspi4Ref": "A3.6.3",
+                      "baspi5Ref": "A3.6.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "planningPermissionBreaches": {
-              "baspiRef": "A3.7",
+              "baspi4Ref": "A3.7",
+              "baspi5Ref": "A3.7",
               "rdsRef": "Property/Flags",
               "ta6Ref": "4.4",
               "piqRef": "A3.7",
@@ -10798,7 +11625,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.7.1",
+                  "baspi4Ref": "A3.7.1",
+                  "baspi5Ref": "A3.7.1",
                   "ta6Ref": "4.4.1",
                   "piqRef": "A3.7.1",
                   "type": "string",
@@ -10806,7 +11634,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -10824,7 +11653,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.7.2",
+                      "baspi4Ref": "A3.7.2",
+                      "baspi5Ref": "A3.7.2",
                       "ta6Ref": "4.4.2",
                       "piqRef": "A3.7.2",
                       "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
@@ -10833,20 +11663,27 @@
                       "minLength": 1
                     },
                     "willingToInsure": {
-                      "baspiRef": "A3.9",
+                      "baspi4Ref": "A3.9",
+                      "baspi5Ref": "A3.9",
                       "rdsRef": "Insurance/isWillingToProvide",
                       "title": "Confirm whether you will pay for an insurance policy if the Local Authority still have power to enforce the breach. Your property lawyer can obtain a quote for you. (If you already have a policy please give it to your property lawyer and include details in Question 6 of Section B) [*Note: It will be a term of the insurance policy that the Local Authority is not contacted so if you have contacted the Local Authority the option of indemnity insurance will not be available.]",
                       "type": "string",
                       "enum": ["Yes", "No"]
                     },
                     "attachments": {
-                      "baspiRef": "A3.7.3",
+                      "baspi4Ref": "A3.7.3",
+                      "baspi5Ref": "A3.7.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "attachments",
+                    "willingToInsure"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "attachments",
                     "willingToInsure"
@@ -10857,7 +11694,8 @@
               "ta6Required": ["yesNo"]
             },
             "unresolvedPlanningIssues": {
-              "baspiRef": "A3.8",
+              "baspi4Ref": "A3.8",
+              "baspi5Ref": "A3.8",
               "ta6Ref": "4.5",
               "piqRef": "A3.8",
               "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
@@ -10865,7 +11703,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.8.1",
+                  "baspi4Ref": "A3.8.1",
+                  "baspi5Ref": "A3.8.1",
                   "ta6Ref": "4.5.1",
                   "piqRef": "A3.8.1",
                   "type": "string",
@@ -10873,7 +11712,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -10892,7 +11732,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A3.8.2",
+                      "baspi4Ref": "A3.8.2",
+                      "baspi5Ref": "A3.8.2",
                       "ta6Ref": "4.5.2",
                       "piqRef": "A3.8.2",
                       "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
@@ -10901,20 +11742,27 @@
                       "minLength": 1
                     },
                     "willingToInsure": {
-                      "baspiRef": "A3.9",
+                      "baspi4Ref": "A3.9",
+                      "baspi5Ref": "A3.9",
                       "rdsRef": "Insurance/isWillingToProvide",
                       "title": "Confirm whether you will pay for an insurance policy if the Local Authority still have power to enforce the breach. Your property lawyer can obtain a quote for you. (If you already have a policy please give it to your property lawyer and include details in Question 6 of Section B) [*Note: It will be a term of the insurance policy that the Local Authority is not contacted so if you have contacted the Local Authority the option of indemnity insurance will not be available.]",
                       "type": "string",
                       "enum": ["Yes", "No"]
                     },
                     "attachments": {
-                      "baspiRef": "A3.8.3",
+                      "baspi4Ref": "A3.8.3",
+                      "baspi5Ref": "A3.8.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "details",
+                    "attachments",
+                    "willingToInsure"
+                  ],
+                  "baspi5Required": [
                     "details",
                     "attachments",
                     "willingToInsure"
@@ -10926,14 +11774,24 @@
           }
         },
         "notices": {
-          "baspiRef": "A4",
+          "baspi4Ref": "A4",
+          "baspi5Ref": "A4",
           "ta6Ref": "3",
           "ntsRef": "C4",
           "ntslRef": "C4",
           "title": "Notices which Affect the Property",
           "description": "Are you aware of, or have you received, any of the following notices?",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "neighbourDevelopment",
+            "planningApplication",
+            "requiredMaintenance",
+            "listedBuildingApplication",
+            "infrastructureProject",
+            "partyWallAct",
+            "otherNotices"
+          ],
+          "baspi5Required": [
             "neighbourDevelopment",
             "planningApplication",
             "requiredMaintenance",
@@ -10951,7 +11809,8 @@
           ],
           "properties": {
             "neighbourDevelopment": {
-              "baspiRef": "A4.1",
+              "baspi4Ref": "A4.1",
+              "baspi5Ref": "A4.1",
               "ntsRef": "C4.1",
               "ntslRef": "C4.1",
               "ta6Ref": "3.2",
@@ -10964,7 +11823,8 @@
                 "yesNo": {
                   "ntsRef": "C4.1.1",
                   "ntslRef": "C4.1.1",
-                  "baspiRef": "A4.1.1",
+                  "baspi4Ref": "A4.1.1",
+                  "baspi5Ref": "A4.1.1",
                   "piqRef": "A4.1.1",
                   "ta6Ref": "3.2.1",
                   "type": "string",
@@ -10972,7 +11832,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -10995,20 +11856,23 @@
                     "details": {
                       "ntsRef": "C4.1.2",
                       "ntslRef": "C4.1.2",
-                      "baspiRef": "A4.1.2",
+                      "baspi4Ref": "A4.1.2",
+                      "baspi5Ref": "A4.1.2",
                       "ta6Ref": "3.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.1.3",
+                      "baspi4Ref": "A4.1.3",
+                      "baspi5Ref": "A4.1.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"],
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"]
@@ -11018,7 +11882,8 @@
             "planningApplication": {
               "ntsRef": "C4.2",
               "ntslRef": "C4.2",
-              "baspiRef": "A4.2",
+              "baspi4Ref": "A4.2",
+              "baspi5Ref": "A4.2",
               "rdsRef": "Property/Flags,Planning",
               "ta6Ref": "3.1",
               "piqRef": "A4.2",
@@ -11028,7 +11893,8 @@
                 "yesNo": {
                   "ntsRef": "C4.2.1",
                   "ntslRef": "C4.2.1",
-                  "baspiRef": "A4.2.1",
+                  "baspi4Ref": "A4.2.1",
+                  "baspi5Ref": "A4.2.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.2.1",
                   "type": "string",
@@ -11036,7 +11902,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -11059,20 +11926,23 @@
                     "details": {
                       "ntsRef": "C4.2.2",
                       "ntslRef": "C4.2.2",
-                      "baspiRef": "A4.2.2",
+                      "baspi4Ref": "A4.2.2",
+                      "baspi5Ref": "A4.2.2",
                       "ta6Ref": "3.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.2.3",
+                      "baspi4Ref": "A4.2.3",
+                      "baspi5Ref": "A4.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"],
                   "ntsRequired": ["details"],
                   "ntslRequired": ["details"]
@@ -11080,7 +11950,8 @@
               ]
             },
             "requiredMaintenance": {
-              "baspiRef": "A4.3",
+              "baspi4Ref": "A4.3",
+              "baspi5Ref": "A4.3",
               "rdsRef": "Property/Flags,Notifications",
               "ta6Ref": "3.1",
               "piqRef": "A4.3",
@@ -11088,7 +11959,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.3.1",
+                  "baspi4Ref": "A4.3.1",
+                  "baspi5Ref": "A4.3.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.3.1",
                   "type": "string",
@@ -11096,7 +11968,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -11115,26 +11988,30 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A4.3.2",
+                      "baspi4Ref": "A4.3.2",
+                      "baspi5Ref": "A4.3.2",
                       "ta6Ref": "3.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.3.3",
+                      "baspi4Ref": "A4.3.3",
+                      "baspi5Ref": "A4.3.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "listedBuildingApplication": {
-              "baspiRef": "A4.4",
+              "baspi4Ref": "A4.4",
+              "baspi5Ref": "A4.4",
               "rdsRef": "Property/Flags,Protections",
               "ta6Ref": "3.1",
               "piqRef": "A4.4",
@@ -11142,7 +12019,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.4.1",
+                  "baspi4Ref": "A4.4.1",
+                  "baspi5Ref": "A4.4.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.4.1",
                   "type": "string",
@@ -11150,7 +12028,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -11169,26 +12048,30 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A4.4.2",
+                      "baspi4Ref": "A4.4.2",
+                      "baspi5Ref": "A4.4.2",
                       "ta6Ref": "3.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.4.3",
+                      "baspi4Ref": "A4.4.3",
+                      "baspi5Ref": "A4.4.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "infrastructureProject": {
-              "baspiRef": "A4.5",
+              "baspi4Ref": "A4.5",
+              "baspi5Ref": "A4.5",
               "rdsRef": "Property/Flags,Planning",
               "ta6Ref": "3.1",
               "piqRef": "A4.5",
@@ -11196,7 +12079,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.5.1",
+                  "baspi4Ref": "A4.5.1",
+                  "baspi5Ref": "A4.5.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.5.1",
                   "type": "string",
@@ -11204,7 +12088,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -11223,40 +12108,46 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A4.5.2",
+                      "baspi4Ref": "A4.5.2",
+                      "baspi5Ref": "A4.5.2",
                       "ta6Ref": "3.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.5.3",
+                      "baspi4Ref": "A4.5.3",
+                      "baspi5Ref": "A4.5.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "partyWallAct": {
-              "baspiRef": "A4.6",
+              "baspi4Ref": "A4.6",
+              "baspi5Ref": "A4.6",
               "rdsRef": "Property/Flags,Notifications",
               "ta6Ref": "1.6",
               "title": "Notice under the Party Wall Act 1996 in respect of any shared or party boundaries?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.6.1",
+                  "baspi4Ref": "A4.6.1",
+                  "baspi5Ref": "A4.6.1",
                   "ta6Ref": "1.6.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -11275,27 +12166,31 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A4.6.2",
+                      "baspi4Ref": "A4.6.2",
+                      "baspi5Ref": "A4.6.2",
                       "ta6Ref": "1.6.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.6.3",
+                      "baspi4Ref": "A4.6.3",
+                      "baspi5Ref": "A4.6.3",
                       "ta6Ref": "1.6.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "otherNotices": {
-              "baspiRef": "A4.7",
+              "baspi4Ref": "A4.7",
+              "baspi5Ref": "A4.7",
               "rdsRef": "Property/Flags,Notifications",
               "ta6Ref": "3.1",
               "piqRef": "A4.6",
@@ -11303,7 +12198,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.7.1",
+                  "baspi4Ref": "A4.7.1",
+                  "baspi5Ref": "A4.7.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.6.1",
                   "type": "string",
@@ -11311,7 +12207,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -11330,20 +12227,23 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A4.7.2",
+                      "baspi4Ref": "A4.7.2",
+                      "baspi5Ref": "A4.7.2",
                       "ta6Ref": "3.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A4.7.3",
+                      "baspi4Ref": "A4.7.3",
+                      "baspi5Ref": "A4.7.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -11351,10 +12251,18 @@
           }
         },
         "specialistIssues": {
-          "baspiRef": "A5",
+          "baspi4Ref": "A5",
+          "baspi5Ref": "A5",
           "title": "Specialist Issues",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "dryRotEtcTreatment",
+            "containsAsbestos",
+            "japaneseKnotweed",
+            "subsidenceOrStructuralFault",
+            "ongoingHealthOrSafetyIssue"
+          ],
+          "baspi5Required": [
             "dryRotEtcTreatment",
             "containsAsbestos",
             "japaneseKnotweed",
@@ -11364,21 +12272,24 @@
           "ta6Required": ["japaneseKnotweed"],
           "properties": {
             "dryRotEtcTreatment": {
-              "baspiRef": "A5.1",
+              "baspi4Ref": "A5.1",
+              "baspi5Ref": "A5.1",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues",
               "piqRef": "A5.1",
               "title": "To your knowledge, has there been any preventative work for, or treatment of dry rot, wet rot or damp carried out at the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.1.1",
+                  "baspi4Ref": "A5.1.1",
+                  "baspi5Ref": "A5.1.1",
                   "piqRef": "A5.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11396,36 +12307,42 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A5.1.2",
+                      "baspi4Ref": "A5.1.2",
+                      "baspi5Ref": "A5.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A5.1.3",
+                      "baspi4Ref": "A5.1.3",
+                      "baspi5Ref": "A5.1.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
             "containsAsbestos": {
-              "baspiRef": "A5.2",
+              "baspi4Ref": "A5.2",
+              "baspi5Ref": "A5.2",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues",
               "title": "To your knowledge, does any part of your property contain asbestos?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.2.1",
+                  "baspi4Ref": "A5.2.1",
+                  "baspi5Ref": "A5.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11443,24 +12360,28 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A5.2.2",
+                      "baspi4Ref": "A5.2.2",
+                      "baspi5Ref": "A5.2.2",
                       "title": "Please state whether there is a management plan in place and attach a copy",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A5.2.3",
+                      "baspi4Ref": "A5.2.3",
+                      "baspi5Ref": "A5.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
             "japaneseKnotweed": {
-              "baspiRef": "A5.3",
+              "baspi4Ref": "A5.3",
+              "baspi5Ref": "A5.3",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues,Use/EnvironmentalIssues",
               "ta6Ref": "7.8",
               "piqRef": "A5.3",
@@ -11469,16 +12390,19 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.3.1",
+                  "baspi4Ref": "A5.3.1",
+                  "baspi5Ref": "A5.3.1",
                   "ta6Ref": "7.8.1",
                   "piqRef": "A5.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not known"],
-                  "baspiEnum": ["Yes", "No"]
+                  "baspi4Enum": ["Yes", "No"],
+                  "baspi5Enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11496,42 +12420,48 @@
                       "enum": ["Yes"]
                     },
                     "managementPlanInPlace": {
-                      "baspiRef": "A5.3.2",
+                      "baspi4Ref": "A5.3.2",
+                      "baspi5Ref": "A5.3.2",
                       "ta6Ref": "7.8.2",
                       "title": "Is there a Japanese Knotweed management and treatment plan in place?",
                       "type": "string",
                       "enum": ["Yes", "No", "Not known"]
                     },
                     "attachments": {
-                      "baspiRef": "A5.3.3",
+                      "baspi4Ref": "A5.3.3",
+                      "baspi5Ref": "A5.3.3",
                       "ta6Ref": "7.8.3",
                       "title": "Please supply a copy with any insurance cover linked to the plan.",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["managementPlanInPlace"],
+                  "baspi4Required": ["managementPlanInPlace"],
+                  "baspi5Required": ["managementPlanInPlace"],
                   "ta6Required": ["managementPlanInPlace", "attachments"]
                 }
               ],
               "ta6Required": ["yesNo"]
             },
             "subsidenceOrStructuralFault": {
-              "baspiRef": "A5.4",
+              "baspi4Ref": "A5.4",
+              "baspi5Ref": "A5.4",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues",
               "piqRef": "A5.4",
               "title": "To your knowledge, has the property ever been subject to subsidence or structural fault?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.4.1",
+                  "baspi4Ref": "A5.4.1",
+                  "baspi5Ref": "A5.4.1",
                   "piqRef": "A5.4.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11549,36 +12479,42 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A5.4.2",
+                      "baspi4Ref": "A5.4.2",
+                      "baspi5Ref": "A5.4.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A5.4.3",
+                      "baspi4Ref": "A5.4.3",
+                      "baspi5Ref": "A5.4.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
             "ongoingHealthOrSafetyIssue": {
-              "baspiRef": "A5.5",
+              "baspi4Ref": "A5.5",
+              "baspi5Ref": "A5.5",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues",
               "title": "Have you been notified by a relevant authority or qualified expert of an on-going health or safety issue with the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.5.1",
+                  "baspi4Ref": "A5.5.1",
+                  "baspi5Ref": "A5.5.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11596,31 +12532,36 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A5.5.2",
+                      "baspi4Ref": "A5.5.2",
+                      "baspi5Ref": "A5.5.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A5.5.3",
+                      "baspi4Ref": "A5.5.3",
+                      "baspi5Ref": "A5.5.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             }
           }
         },
         "fixturesAndFittings": {
-          "baspiRef": "A6",
+          "baspi4Ref": "A6",
+          "baspi5Ref": "A6",
           "ta10Ref": "0",
           "title": "Fixtures and Fittings",
           "description": "This is so a buyer’s offer can take into account whether you are taking something of value or leaving extra items.  A full list will need to be completed after the sale is agreed.",
           "type": "object",
-          "baspiRequired": ["itemsToRemove", "itemsToInclude"],
+          "baspi4Required": ["itemsToRemove", "itemsToInclude"],
+          "baspi5Required": ["itemsToRemove", "itemsToInclude"],
           "ta10Required": [
             "basicFittings",
             "kitchen",
@@ -11636,21 +12577,24 @@
           ],
           "properties": {
             "itemsToRemove": {
-              "baspiRef": "A6.1",
+              "baspi4Ref": "A6.1",
+              "baspi5Ref": "A6.1",
               "rdsRef": "Objects/{isIncludedInExchange='no',class='fixture|fitting}",
               "piqRef": "A6.1",
               "title": "Are there any items, which would be considered a fixture or fitting, that you intend to take? E.g. Carpets, curtains, light fittings, fitted cupboards, etc",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A6.1.1",
+                  "baspi4Ref": "A6.1.1",
+                  "baspi5Ref": "A6.1.1",
                   "piqRef": "A6.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11668,33 +12612,38 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A6.1.2",
+                      "baspi4Ref": "A6.1.2",
+                      "baspi5Ref": "A6.1.2",
                       "piqRef": "A6.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "itemsToInclude": {
-              "baspiRef": "A6.2",
+              "baspi4Ref": "A6.2",
+              "baspi5Ref": "A6.2",
               "rdsRef": "Objects/{isIncludedInExchange='true',class='equipment|furniture}",
               "piqRef": "A6.2",
               "title": "Are there additional furniture items or possessions are you very likely to include in the sale, irrespective of sale price?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A6.2.1",
+                  "baspi4Ref": "A6.2.1",
+                  "baspi5Ref": "A6.2.1",
                   "piqRef": "A6.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11712,14 +12661,16 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A6.2.2",
+                      "baspi4Ref": "A6.2.2",
+                      "baspi5Ref": "A6.2.2",
                       "piqRef": "A6.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
@@ -16583,7 +17534,8 @@
           }
         },
         "electricity": {
-          "baspiRef": "A7.1.0.1",
+          "baspi4Ref": "A7.1.0.1",
+          "baspi5Ref": "A7.1.0.1",
           "ntsRef": "B3.1",
           "ntslRef": "B3.1",
           "ta6Ref": "13.1",
@@ -16593,11 +17545,13 @@
           "type": "object",
           "ntsRequired": ["mainsElectricity", "solarPanels", "otherSources"],
           "ntslRequired": ["mainsElectricity", "solarPanels", "otherSources"],
-          "baspiRequired": ["mainsElectricity", "solarPanels", "otherSources"],
+          "baspi4Required": ["mainsElectricity", "solarPanels", "otherSources"],
+          "baspi5Required": ["mainsElectricity", "solarPanels", "otherSources"],
           "ta6Required": ["mainsElectricity", "solarPanels"],
           "properties": {
             "mainsElectricity": {
-              "baspiRef": "A7.1.0.1",
+              "baspi4Ref": "A7.1.0.1",
+              "baspi5Ref": "A7.1.0.1",
               "ntsRef": "B3.1",
               "ntslRef": "B3.1",
               "ta6Ref": "13.1",
@@ -16609,7 +17563,8 @@
                 "yesNo": {
                   "ntsRef": "B3.1.1",
                   "ntslRef": "B3.1.1",
-                  "baspiRef": "A7.1.0.1.1",
+                  "baspi4Ref": "A7.1.0.1.1",
+                  "baspi5Ref": "A7.1.0.1.1",
                   "ta6Ref": "13.1.1",
                   "type": "string",
                   "title": "",
@@ -16619,7 +17574,8 @@
                   "ta6Enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ta6Required": ["yesNo"],
@@ -16640,30 +17596,35 @@
                       "enum": ["Yes"]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.1.2",
+                      "baspi4Ref": "A7.1.0.1.2",
+                      "baspi5Ref": "A7.1.0.1.2",
                       "ta6Ref": "13.1.2",
                       "piqRef": "A7.1.2",
                       "title": "Supplier",
                       "type": "string"
                     },
                     "electricityMeter": {
-                      "baspiRef": "B4.4",
+                      "baspi4Ref": "B4.4",
+                      "baspi5Ref": "B4.4",
                       "ta6Ref": "13.1b",
                       "rdsRef": "Objects/class='meters|'&access=?&accessLocation=?",
                       "title": "Location of electricity meter",
                       "type": "object",
                       "ta6Required": ["location"],
-                      "baspiRequired": ["location"],
+                      "baspi4Required": ["location"],
+                      "baspi5Required": ["location"],
                       "properties": {
                         "location": {
-                          "baspiRef": "4.4.1",
+                          "baspi4Ref": "4.4.1",
+                          "baspi5Ref": "4.4.1",
                           "ta6Ref": "13.1b1",
                           "title": "Describe the location of the meter",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "4.4.2",
+                          "baspi4Ref": "4.4.2",
+                          "baspi5Ref": "4.4.2",
                           "title": "Photograph of meter location",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
@@ -16677,7 +17638,8 @@
                     }
                   },
                   "ta6Required": ["supplier", "electricityMeter"],
-                  "baspiRequired": ["electricityMeter"]
+                  "baspi4Required": ["electricityMeter"],
+                  "baspi5Required": ["electricityMeter"]
                 },
                 {
                   "properties": {
@@ -16685,27 +17647,31 @@
                       "enum": ["To be connected"]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.1.3",
+                      "baspi4Ref": "A7.1.0.1.3",
+                      "baspi5Ref": "A7.1.0.1.3",
                       "title": "Date to be connected",
                       "type": "string",
                       "format": "date"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.1.2",
+                      "baspi4Ref": "A7.1.0.1.2",
+                      "baspi5Ref": "A7.1.0.1.2",
                       "ta6Ref": "13.1.2",
                       "piqRef": "A7.1.2",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["dateToBeConnected"]
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
                 }
               ]
             },
             "solarPanels": {
               "ntsRef": "B3.7",
               "ntslRef": "B3.7",
-              "baspiRef": "A7.1.0.8",
+              "baspi4Ref": "A7.1.0.8",
+              "baspi5Ref": "A7.1.0.8",
               "piqRef": "A7.1.17",
               "ta6Ref": "4.6",
               "title": "Solar or photovoltaic panels",
@@ -16714,7 +17680,8 @@
                 "yesNo": {
                   "ntsRef": "B3.7.1",
                   "ntslRef": "B3.7.1",
-                  "baspiRef": "A7.1.0.8.1",
+                  "baspi4Ref": "A7.1.0.8.1",
+                  "baspi5Ref": "A7.1.0.8.1",
                   "ta6Ref": "4.6",
                   "type": "string",
                   "title": "",
@@ -16723,7 +17690,8 @@
                   "ntslEnum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
@@ -16744,12 +17712,14 @@
                       "enum": ["Yes"]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.8.2",
+                      "baspi4Ref": "A7.1.0.8.2",
+                      "baspi5Ref": "A7.1.0.8.2",
                       "title": "Supplier",
                       "type": "string"
                     },
                     "yearInstalled": {
-                      "baspiRef": "B4.3.1",
+                      "baspi4Ref": "B4.3.1",
+                      "baspi5Ref": "B4.3.1",
                       "ta6Ref": "4.6a",
                       "rdsRef": "Objects/Installation",
                       "piqRef": "B4.4.2",
@@ -16757,7 +17727,8 @@
                       "type": "integer"
                     },
                     "panelsOwnedOutright": {
-                      "baspiRef": "B4.3.2",
+                      "baspi4Ref": "B4.3.2",
+                      "baspi5Ref": "B4.3.2",
                       "ta6Ref": "4.6b",
                       "rdsRef": "Objects/Ownership",
                       "piqRef": "B4.4.3",
@@ -16765,14 +17736,16 @@
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B4.3.2.1",
+                          "baspi4Ref": "B4.3.2.1",
+                          "baspi5Ref": "B4.3.2.1",
                           "ta6Ref": "4.6b1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -16791,24 +17764,28 @@
                               "enum": ["No"]
                             },
                             "details": {
-                              "baspiRef": "B4.3.2.2",
+                              "baspi4Ref": "B4.3.2.2",
+                              "baspi5Ref": "B4.3.2.2",
                               "title": "Provide details of who owns them and the relevant documentation",
                               "type": "string",
                               "minLength": 1
                             },
                             "attachments": {
-                              "baspiRef": "B4.3.2.3",
+                              "baspi4Ref": "B4.3.2.3",
+                              "baspi5Ref": "B4.3.2.3",
                               "title": "Attachments",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["details", "attachments"]
+                          "baspi4Required": ["details", "attachments"],
+                          "baspi5Required": ["details", "attachments"]
                         }
                       ]
                     },
                     "panelProviderLease": {
-                      "baspiRef": "B4.3.3",
+                      "baspi4Ref": "B4.3.3",
+                      "baspi5Ref": "B4.3.3",
                       "ta6Ref": "4.6c",
                       "rdsRef": "Objects/Ownership",
                       "piqRef": "B4.4.4",
@@ -16816,14 +17793,16 @@
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "4.3.3.1",
+                          "baspi4Ref": "4.3.3.1",
+                          "baspi5Ref": "4.3.3.1",
                           "ta6Ref": "4.6c1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
@@ -16842,13 +17821,15 @@
                               "enum": ["Yes"]
                             },
                             "details": {
-                              "baspiRef": "4.3.3.2",
+                              "baspi4Ref": "4.3.3.2",
+                              "baspi5Ref": "4.3.3.2",
                               "title": "Name of the provider",
                               "type": "string",
                               "minLength": 1
                             },
                             "attachments": {
-                              "baspiRef": "4.3.3.3",
+                              "baspi4Ref": "4.3.3.3",
+                              "baspi5Ref": "4.3.3.3",
                               "ta6Ref": "4.6c2",
                               "piqRef": "B4.4.5",
                               "title": "Please supply copies of the relevant documents",
@@ -16856,32 +17837,37 @@
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["details", "attachments"],
+                          "baspi4Required": ["details", "attachments"],
+                          "baspi5Required": ["details", "attachments"],
                           "ta6Required": ["attachments"]
                         }
                       ]
                     },
                     "lastMaintained": {
-                      "baspiRef": "B4.3.4",
+                      "baspi4Ref": "B4.3.4",
+                      "baspi5Ref": "B4.3.4",
                       "rdsRef": "Objects/Servicing",
                       "title": "When was the system last maintained or serviced?",
                       "type": "string",
                       "format": "date"
                     },
                     "inGoodWorkingOrder": {
-                      "baspiRef": "B4.3.5",
+                      "baspi4Ref": "B4.3.5",
+                      "baspi5Ref": "B4.3.5",
                       "rdsRef": "Objects/isNotWorking=yes|no|true|false",
                       "title": "Is the system in good working order to your satisfaction?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B4.3.5.1",
+                          "baspi4Ref": "B4.3.5.1",
+                          "baspi5Ref": "B4.3.5.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -16899,37 +17885,43 @@
                               "enum": ["No"]
                             },
                             "details": {
-                              "baspiRef": "B4.3.5.2",
+                              "baspi4Ref": "B4.3.5.2",
+                              "baspi5Ref": "B4.3.5.2",
                               "title": "Details",
                               "type": "string",
                               "minLength": 1
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         }
                       ]
                     },
                     "isConnectedToNationalGrid": {
-                      "baspiRef": "B4.3.6",
+                      "baspi4Ref": "B4.3.6",
+                      "baspi5Ref": "B4.3.6",
                       "rdsRef": "Objects/isExternallyConnected=yes|no|true|false,Connection,Objects/ExternalConnection",
                       "title": "Is the system connected to the National Grid e.g. for feed-in tariffs (FiT) or Smart Export Guarantee (SEG)",
                       "type": "string",
                       "enum": ["Yes (FiT)", "Yes (SEG)", "No"]
                     },
                     "photovoltaicMeterPanelLocation": {
-                      "baspiRef": "B4.7",
+                      "baspi4Ref": "B4.7",
+                      "baspi5Ref": "B4.7",
                       "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
                       "title": "Location of photovoltaic panel meter (if any)",
                       "type": "object",
                       "properties": {
                         "description": {
-                          "baspiRef": "4.7.1",
+                          "baspi4Ref": "4.7.1",
+                          "baspi5Ref": "4.7.1",
                           "title": "Describe the location of the meter",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "4.7.2",
+                          "baspi4Ref": "4.7.2",
+                          "baspi5Ref": "4.7.2",
                           "title": "Photograph of meter location",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
@@ -16937,19 +17929,22 @@
                       }
                     },
                     "photovoltaicBatteriesLocation": {
-                      "baspiRef": "B4.8",
+                      "baspi4Ref": "B4.8",
+                      "baspi5Ref": "B4.8",
                       "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
                       "title": "Location of photovoltaic batteries (if any)",
                       "type": "object",
                       "properties": {
                         "description": {
-                          "baspiRef": "4.8.1",
+                          "baspi4Ref": "4.8.1",
+                          "baspi5Ref": "4.8.1",
                           "title": "Describe the location of the batteries",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "4.8.2",
+                          "baspi4Ref": "4.8.2",
+                          "baspi5Ref": "4.8.2",
                           "title": "Photograph of batteries location",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
@@ -16957,7 +17952,15 @@
                       }
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "yearInstalled",
+                    "panelsOwnedOutright",
+                    "panelProviderLease",
+                    "lastMaintained",
+                    "inGoodWorkingOrder",
+                    "isConnectedToNationalGrid"
+                  ],
+                  "baspi5Required": [
                     "yearInstalled",
                     "panelsOwnedOutright",
                     "panelProviderLease",
@@ -16977,36 +17980,39 @@
                       "enum": ["To be connected"]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.8.3",
+                      "baspi4Ref": "A7.1.0.8.3",
+                      "baspi5Ref": "A7.1.0.8.3",
                       "title": "Date to be connected",
                       "type": "string",
                       "format": "date"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.8.2",
+                      "baspi4Ref": "A7.1.0.8.2",
+                      "baspi5Ref": "A7.1.0.8.2",
                       "piqRef": "A7.1.18",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["dateToBeConnected"]
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
                 }
               ]
             },
-            "otherSources": {
+            "heatPump": {
               "ntsRef": "B3.8",
               "ntslRef": "B3.8",
-              "baspiRef": "A7.1.0.9",
-              "rdsRef": "Services/Other",
+              "baspi4Ref": "A7.1.0.9",
+              "baspi5Ref": "A7.1.0.9",
               "piqRef": "A7.1.19",
-              "title": "Other sources",
-              "description": "Other sources include wind turbines, generators and other renewable technologies, for example ground source heat pumps. If you receive Renewable Heat Incentives please provide details and note that you will need to advise Ofgem when you complete the sale",
+              "title": "Ground or air source heat pump",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "ntsRef": "B3.8.1",
                   "ntslRef": "B3.8.1",
-                  "baspiRef": "A7.1.0.9.1",
+                  "baspi4Ref": "A7.1.0.10.1",
+                  "baspi5Ref": "A7.1.0.10.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "To be connected", "No"],
@@ -17014,7 +18020,8 @@
                   "ntslEnum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "discriminator": {
@@ -17040,7 +18047,116 @@
                       "type": "string"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.9.2",
+                      "baspi4Ref": "A7.1.0.10.2",
+                      "baspi5Ref": "A7.1.0.10.2",
+                      "title": "Supplier",
+                      "type": "string"
+                    },
+                    "dateInstalled": {
+                      "baspi4Ref": "A7.1.0.10.3",
+                      "baspi5Ref": "A7.1.0.10.3",
+                      "title": "Date installed",
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A7.1.0.10.4",
+                      "baspi5Ref": "A7.1.0.10.4",
+                      "title": "If after 2013 please provide Building Regulations approval / MCS Certificate or equivalent.",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not applicable"]
+                    }
+                  },
+                  "baspi4Required": ["dateInstalled", "attachments"],
+                  "baspi5Required": ["dateInstalled", "attachments"],
+                  "ntsRequired": ["details"],
+                  "ntslRequired": ["details"]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["To be connected"]
+                    },
+                    "details": {
+                      "baspi4Ref": "A7.1.0.10.2",
+                      "baspi5Ref": "A7.1.0.10.2",
+                      "ntsRef": "3.8.2",
+                      "ntslRef": "3.8.2",
+                      "title": "Details",
+                      "type": "string"
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.10.3",
+                      "baspi5Ref": "A7.1.0.10.3",
+                      "title": "Date to be connected",
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.10.4",
+                      "baspi5Ref": "A7.1.0.10.4",
+                      "piqRef": "A7.1.20",
+                      "title": "Supplier",
+                      "type": "string"
+                    }
+                  },
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
+                }
+              ]
+            },
+            "otherSources": {
+              "ntsRef": "B3.9",
+              "ntslRef": "B3.9",
+              "baspi4Ref": "A7.1.0.9",
+              "baspi5Ref": "A7.1.0.9",
+              "rdsRef": "Services/Other",
+              "piqRef": "A7.1.19",
+              "title": "Other sources",
+              "description": "Other sources include wind turbines, generators and other renewable technologies. If you receive Renewable Heat Incentives please provide details and note that you will need to advise Ofgem when you complete the sale",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "B3.9.1",
+                  "ntslRef": "B3.9.1",
+                  "baspi4Ref": "A7.1.0.9.1",
+                  "baspi5Ref": "A7.1.0.9.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "To be connected", "No"],
+                  "ntsEnum": ["Yes", "No"],
+                  "ntslEnum": ["Yes", "No"]
+                }
+              },
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
+              "ntsRequired": ["yesNo"],
+              "ntslRequired": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ntsRef": "B3.9.2",
+                      "ntslRef": "B3.9.2",
+                      "title": "Details",
+                      "type": "string"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.9.2",
+                      "baspi5Ref": "A7.1.0.9.2",
                       "title": "Supplier",
                       "type": "string"
                     }
@@ -17054,26 +18170,30 @@
                       "enum": ["To be connected"]
                     },
                     "details": {
-                      "baspiRef": "A7.1.0.9.2",
-                      "ntsRef": "3.8.2",
-                      "ntslRef": "3.8.2",
+                      "baspi4Ref": "A7.1.0.9.2",
+                      "baspi5Ref": "A7.1.0.9.2",
+                      "ntsRef": "B3.9.2",
+                      "ntslRef": "B3.9.2",
                       "title": "Details",
                       "type": "string"
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.9.3",
+                      "baspi4Ref": "A7.1.0.9.3",
+                      "baspi5Ref": "A7.1.0.9.3",
                       "title": "Date to be connected",
                       "type": "string",
                       "format": "date"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.9.4",
+                      "baspi4Ref": "A7.1.0.9.4",
+                      "baspi5Ref": "A7.1.0.9.4",
                       "piqRef": "A7.1.20",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["dateToBeConnected"]
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
                 }
               ]
             }
@@ -17082,13 +18202,15 @@
         "waterAndDrainage": {
           "ntsRef": "B3.2",
           "ntslRef": "B3.2",
-          "baspiRef": "A7.1.0",
+          "baspi4Ref": "A7.1.0",
+          "baspi5Ref": "A7.1.0",
           "ta6Ref": "13",
           "con29DWRef": "0",
           "title": "Water and Drainage",
           "description": "Please describe the water and drainage services that are connected to the property.",
           "type": "object",
-          "baspiRequired": ["water", "drainage", "maintenanceAgreements"],
+          "baspi4Required": ["water", "drainage", "maintenanceAgreements"],
+          "baspi5Required": ["water", "drainage", "maintenanceAgreements"],
           "ta6Required": ["water", "drainage"],
           "ntsRequired": ["water", "drainage"],
           "ntslRequired": ["water", "drainage"],
@@ -17120,12 +18242,14 @@
             "water": {
               "ntsRef": "B3.2",
               "ntslRef": "B3.2",
-              "baspiRef": "A7.1.0.10",
+              "baspi4Ref": "A7.1.0.10",
+              "baspi5Ref": "A7.1.0.10",
               "ta6Ref": "13",
               "con29DWRef": "3",
               "title": "Water",
               "type": "object",
-              "baspiRequired": ["mainsWater"],
+              "baspi4Required": ["mainsWater"],
+              "baspi5Required": ["mainsWater"],
               "ntsRequired": ["mainsWater"],
               "ntslRequired": ["mainsWater"],
               "ta6Required": ["mainsWater"],
@@ -17140,7 +18264,8 @@
                 "mainsWater": {
                   "ntsRef": "B3.2",
                   "ntslRef": "B3.2",
-                  "baspiRef": "A7.1.0.10.0",
+                  "baspi4Ref": "A7.1.0.10.0",
+                  "baspi5Ref": "A7.1.0.10.0",
                   "ta6Ref": "13.3",
                   "piqRef": "A7.1.7",
                   "rdsRef": "Services/PotableWaterSupply",
@@ -17151,7 +18276,8 @@
                     "yesNo": {
                       "ntsRef": "B3.2.1",
                       "ntslRef": "B3.2.1",
-                      "baspiRef": "A7.1.0.10.1",
+                      "baspi4Ref": "A7.1.0.10.1",
+                      "baspi5Ref": "A7.1.0.10.1",
                       "ta6Ref": "13.3.1",
                       "con29DWRef": "3.1.1",
                       "type": "string",
@@ -17163,7 +18289,8 @@
                       "con29DWEnum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "ntslRequired": ["yesNo"],
                   "ta6Required": ["yesNo"],
@@ -17195,7 +18322,8 @@
                           "enum": ["Yes"]
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.10.2",
+                          "baspi4Ref": "A7.1.0.10.2",
+                          "baspi5Ref": "A7.1.0.10.2",
                           "ta6Ref": "13.3.2",
                           "piqRef": "A7.1.8",
                           "title": "Supplier",
@@ -17209,7 +18337,8 @@
                           "minLength": 1
                         },
                         "stopcock": {
-                          "baspiRef": "B4.6.1",
+                          "baspi4Ref": "B4.6.1",
+                          "baspi5Ref": "B4.6.1",
                           "ta6Ref": "13.3b",
                           "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
                           "title": "Location of stopcock",
@@ -17217,14 +18346,16 @@
                           "required": ["location"],
                           "properties": {
                             "location": {
-                              "baspiRef": "4.6.1.1",
+                              "baspi4Ref": "4.6.1.1",
+                              "baspi5Ref": "4.6.1.1",
                               "ta6Ref": "13.3b1",
                               "title": "Describe the location of the stopcock",
                               "type": "string",
                               "minLength": 1
                             },
                             "attachments": {
-                              "baspiRef": "4.6.1.2",
+                              "baspi4Ref": "4.6.1.2",
+                              "baspi5Ref": "4.6.1.2",
                               "title": "Photograph of stopcock location",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
@@ -17235,11 +18366,13 @@
                           "type": "object",
                           "ntsRef": "B3.2.1.1",
                           "ntslRef": "B3.2.1.1",
-                          "baspiRef": "A7.",
+                          "baspi4Ref": "A7.",
+                          "baspi5Ref": "A7.",
                           "ta6Ref": "13.3b",
                           "ntsRequired": ["isSupplyMetered"],
                           "ntslRequired": ["isSupplyMetered"],
-                          "baspiRequired": ["isSupplyMetered"],
+                          "baspi4Required": ["isSupplyMetered"],
+                          "baspi5Required": ["isSupplyMetered"],
                           "ta6Required": ["isSupplyMetered"],
                           "con29DWRequired": ["isSupplyMetered"],
                           "properties": {
@@ -17247,7 +18380,8 @@
                               "ntsRef": "3.2.3",
                               "ntslRef": "3.2.3",
                               "ta6Ref": "13.3b",
-                              "baspiRef": "B4.6.2",
+                              "baspi4Ref": "B4.6.2",
+                              "baspi5Ref": "B4.6.2",
                               "title": "Is the supply metered?",
                               "type": "string",
                               "enum": ["Yes", "No"]
@@ -17270,7 +18404,8 @@
                                   "enum": ["Yes"]
                                 },
                                 "location": {
-                                  "baspiRef": "4.6.2.1",
+                                  "baspi4Ref": "4.6.2.1",
+                                  "baspi5Ref": "4.6.2.1",
                                   "ta6Ref": "13.3b2",
                                   "con29DWRef": "3.6",
                                   "title": "Describe the location of the meter",
@@ -17278,13 +18413,15 @@
                                   "minLength": 1
                                 },
                                 "attachments": {
-                                  "baspiRef": "4.6.2.2",
+                                  "baspi4Ref": "4.6.2.2",
+                                  "baspi5Ref": "4.6.2.2",
                                   "title": "Photograph of meter location",
                                   "type": "string",
                                   "enum": ["Attached", "To follow"]
                                 }
                               },
-                              "baspiRequired": ["location"],
+                              "baspi4Required": ["location"],
+                              "baspi5Required": ["location"],
                               "ta6Required": ["location"],
                               "con29DWRequired": ["location"]
                             }
@@ -17293,7 +18430,8 @@
                       },
                       "ta6Required": ["supplier", "stopcock", "waterMeter"],
                       "con29DWRequired": ["details", "waterMeter"],
-                      "baspiRequired": ["stopcock", "waterMeter"],
+                      "baspi4Required": ["stopcock", "waterMeter"],
+                      "baspi5Required": ["stopcock", "waterMeter"],
                       "ntsRequired": ["waterMeter"],
                       "ntslRequired": ["waterMeter"]
                     },
@@ -17303,20 +18441,23 @@
                           "enum": ["To be connected"]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.10.3",
+                          "baspi4Ref": "A7.1.0.10.3",
+                          "baspi5Ref": "A7.1.0.10.3",
                           "title": "Date to be connected",
                           "type": "string",
                           "format": "date"
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.10.2",
+                          "baspi4Ref": "A7.1.0.10.2",
+                          "baspi5Ref": "A7.1.0.10.2",
                           "ta6Ref": "13.3.2",
                           "piqRef": "A7.1.8",
                           "title": "Supplier",
                           "type": "string"
                         }
                       },
-                      "baspiRequired": ["dateToBeConnected"]
+                      "baspi4Required": ["dateToBeConnected"],
+                      "baspi5Required": ["dateToBeConnected"]
                     }
                   ]
                 },
@@ -17451,11 +18592,16 @@
             "drainage": {
               "ntsRef": "B3.3",
               "ntslRef": "B3.3",
-              "baspiRef": "A7.1.0.12",
+              "baspi4Ref": "A7.1.0.12",
+              "baspi5Ref": "A7.1.0.12",
               "con29DWRef": "2",
               "title": "Drainage",
               "type": "object",
-              "baspiRequired": [
+              "baspi4Required": [
+                "mainsSurfaceWaterDrainage",
+                "mainsFoulDrainage"
+              ],
+              "baspi5Required": [
                 "mainsSurfaceWaterDrainage",
                 "mainsFoulDrainage"
               ],
@@ -17482,7 +18628,8 @@
                 "mainsSurfaceWaterDrainage": {
                   "ntsRef": "B3.3.1",
                   "ntslRef": "B3.3.1",
-                  "baspiRef": "A7.1.0.12.0",
+                  "baspi4Ref": "A7.1.0.12.0",
+                  "baspi5Ref": "A7.1.0.12.0",
                   "rdsRef": "Services/StormWaterDrainage",
                   "ta6Ref": "12.4b",
                   "con29DWRef": "2.2",
@@ -17490,7 +18637,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.1.0.12.1",
+                      "baspi4Ref": "A7.1.0.12.1",
+                      "baspi5Ref": "A7.1.0.12.1",
                       "ntsRef": "B3.3.1.1",
                       "ntslRef": "B3.3.1.1",
                       "ta6Ref": "12.4b1",
@@ -17504,7 +18652,8 @@
                       "ta6Enum": ["Yes", "No", "Not known"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "ntslRequired": ["yesNo"],
                   "ta6Required": ["yesNo"],
@@ -17539,26 +18688,30 @@
                           "enum": ["To be connected"]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.12.3",
+                          "baspi4Ref": "A7.1.0.12.3",
+                          "baspi5Ref": "A7.1.0.12.3",
                           "title": "Date to be connected",
                           "type": "string",
                           "format": "date"
                         }
                       },
-                      "baspiRequired": ["dateToBeConnected"]
+                      "baspi4Required": ["dateToBeConnected"],
+                      "baspi5Required": ["dateToBeConnected"]
                     }
                   ]
                 },
                 "mainsFoulDrainage": {
                   "ntsRef": "B3.3.2",
                   "ntslRef": "B3.3.2",
-                  "baspiRef": "A7.1.0.11",
+                  "baspi4Ref": "A7.1.0.11",
+                  "baspi5Ref": "A7.1.0.11",
                   "rdsRef": "Services/WasteWaterSewerageDisposal",
                   "ta6Ref": "12.4a",
                   "con29DWRef": "2.1",
                   "title": "Mains foul drainage / sewerage",
                   "type": "object",
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "ntslRequired": ["yesNo"],
@@ -17566,7 +18719,8 @@
                     "yesNo": {
                       "ntsRef": "B3.3.2.1",
                       "ntslRef": "B3.3.2.1",
-                      "baspiRef": "A7.1.0.11.1",
+                      "baspi4Ref": "A7.1.0.11.1",
+                      "baspi5Ref": "A7.1.0.11.1",
                       "ta6Ref": "12.4a1",
                       "type": "string",
                       "title": "",
@@ -17594,7 +18748,8 @@
                         },
                         "supplier": {
                           "ta6Ref": "13.4.2",
-                          "baspiRef": "A7.1.0.11.2",
+                          "baspi4Ref": "A7.1.0.11.2",
+                          "baspi5Ref": "A7.1.0.11.2",
                           "title": "Supplier",
                           "type": "string",
                           "minLength": 1
@@ -17609,19 +18764,22 @@
                           "enum": ["To be connected"]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.11.2",
+                          "baspi4Ref": "A7.1.0.11.2",
+                          "baspi5Ref": "A7.1.0.11.2",
                           "title": "Date to be connected",
                           "type": "string",
                           "format": "date"
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.11.3",
+                          "baspi4Ref": "A7.1.0.11.3",
+                          "baspi5Ref": "A7.1.0.11.3",
                           "ta6Ref": "13.4.2",
                           "title": "Supplier",
                           "type": "string"
                         }
                       },
-                      "baspiRequired": ["dateToBeConnected"]
+                      "baspi4Required": ["dateToBeConnected"],
+                      "baspi5Required": ["dateToBeConnected"]
                     },
                     {
                       "properties": {
@@ -17631,10 +18789,18 @@
                         "offMainsDrainageSystem": {
                           "ntsRef": "B3.3.3",
                           "ntslRef": "B3.3.3",
-                          "baspiRef": "A7.1.10.13",
+                          "baspi4Ref": "A7.1.10.13",
+                          "baspi5Ref": "A7.1.10.13",
                           "ta6Ref": "12.4a",
                           "type": "object",
-                          "baspiRequired": [
+                          "baspi4Required": [
+                            "offMainsDrainageSystemType",
+                            "otherConnectedProperties",
+                            "plantOnOtherLand",
+                            "plantRegistered",
+                            "plantDrainsIntoWaterway"
+                          ],
+                          "baspi5Required": [
                             "offMainsDrainageSystemType",
                             "otherConnectedProperties",
                             "plantOnOtherLand",
@@ -17652,7 +18818,8 @@
                             "offMainsDrainageSystemType": {
                               "ntsRef": "B3.3.3.1",
                               "ntslRef": "B3.3.3.1",
-                              "baspiRef": "A7.1",
+                              "baspi4Ref": "A7.1",
+                              "baspi5Ref": "A7.1",
                               "ta6Ref": "12.5",
                               "type": "string",
                               "enum": [
@@ -17665,7 +18832,8 @@
                               ]
                             },
                             "otherConnectedProperties": {
-                              "baspiRef": "A7.1.1",
+                              "baspi4Ref": "A7.1.1",
+                              "baspi5Ref": "A7.1.1",
                               "rdsRef": "Services/OtherServices/SharedWith",
                               "ta6Ref": "12.6",
                               "piqRef": "A7.1.29",
@@ -17673,14 +18841,16 @@
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.1.1",
+                                  "baspi4Ref": "A7.1.1.1",
+                                  "baspi5Ref": "A7.1.1.1",
                                   "ta6Ref": "12.6.1",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "ta6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
@@ -17699,19 +18869,25 @@
                                       "enum": ["Yes"]
                                     },
                                     "numberOfPropertiesSharing": {
-                                      "baspiRef": "A7.1.1.1",
+                                      "baspi4Ref": "A7.1.1.1",
+                                      "baspi5Ref": "A7.1.1.1",
                                       "ta6Ref": "12.6.2",
                                       "title": "How many other properties?",
                                       "type": "integer"
                                     },
                                     "details": {
-                                      "baspiRef": "A7.1.1.2",
+                                      "baspi4Ref": "A7.1.1.2",
+                                      "baspi5Ref": "A7.1.1.2",
                                       "title": "Provide details of the properties sharing the system and explain how maintenance of the system is arranged and paid for",
                                       "type": "string",
                                       "minLength": 1
                                     }
                                   },
-                                  "baspiRequired": [
+                                  "baspi4Required": [
+                                    "numberOfPropertiesSharing",
+                                    "details"
+                                  ],
+                                  "baspi5Required": [
                                     "numberOfPropertiesSharing",
                                     "details"
                                   ],
@@ -17720,7 +18896,8 @@
                               ]
                             },
                             "plantOnOtherLand": {
-                              "baspiRef": "A7.1.2",
+                              "baspi4Ref": "A7.1.2",
+                              "baspi5Ref": "A7.1.2",
                               "rdsRef": "Services/OtherServices/Located,Services/OtherServices/{access=?}",
                               "ta6Ref": "12.10",
                               "piqRef": "A7.1.30",
@@ -17729,14 +18906,16 @@
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "7.1.2.1",
+                                  "baspi4Ref": "7.1.2.1",
+                                  "baspi5Ref": "7.1.2.1",
                                   "ta6Ref": "12.10.1",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -17754,34 +18933,39 @@
                                       "enum": ["Yes"]
                                     },
                                     "attachments": {
-                                      "baspiRef": "7.1.2.2",
+                                      "baspi4Ref": "7.1.2.2",
+                                      "baspi5Ref": "7.1.2.2",
                                       "ta6Ref": "12.10.2",
                                       "title": "Please supply a plan showing the location of the system and how access is obtained.",
                                       "type": "string",
                                       "enum": ["Attached", "To follow"]
                                     }
                                   },
-                                  "baspiRequired": ["attachments"],
+                                  "baspi4Required": ["attachments"],
+                                  "baspi5Required": ["attachments"],
                                   "ta6Required": ["attachments"]
                                 }
                               ],
                               "ta6Required": ["yesNo"]
                             },
                             "plantRegistered": {
-                              "baspiRef": "A7.1.3",
+                              "baspi4Ref": "A7.1.3",
+                              "baspi5Ref": "A7.1.3",
                               "rdsRef": "Services/OtherServices/Certificates",
                               "piqRef": "A7.1.31",
                               "title": "Is the septic tank, cesspit or sewerage treatment plant registered with the Environment Agency or exempted?",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.3.1",
+                                  "baspi4Ref": "A7.1.3.1",
+                                  "baspi5Ref": "A7.1.3.1",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -17799,24 +18983,28 @@
                                       "enum": ["Yes"]
                                     },
                                     "attachments": {
-                                      "baspiRef": "A7.1.3.2",
+                                      "baspi4Ref": "A7.1.3.2",
+                                      "baspi5Ref": "A7.1.3.2",
                                       "title": "Please supply the appropriate permit to discharge or exemption certificate",
                                       "type": "string",
                                       "enum": ["Attached", "To follow"]
                                     }
                                   },
-                                  "baspiRequired": ["attachments"]
+                                  "baspi4Required": ["attachments"],
+                                  "baspi5Required": ["attachments"]
                                 }
                               ]
                             },
                             "plantDrainsIntoWaterway": {
-                              "baspiRef": "A7.1.4",
+                              "baspi4Ref": "A7.1.4",
+                              "baspi5Ref": "A7.1.4",
                               "rdsRef": "Services/OtherServices/{isExternallyConnected='yes?true'}",
                               "title": "Does the septic tank, cesspit or sewerage treatment plant drain into a waterway (lake, river, stream etc)",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.4.1",
+                                  "baspi4Ref": "A7.1.4.1",
+                                  "baspi5Ref": "A7.1.4.1",
                                   "type": "string",
                                   "title": "",
                                   "enum": [
@@ -17825,7 +19013,8 @@
                                   ]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -17845,14 +19034,18 @@
                                       "enum": ["Yes"]
                                     },
                                     "dischargeCompliesWithGBR": {
-                                      "baspiRef": "A7.1.4.1",
+                                      "baspi4Ref": "A7.1.4.1",
+                                      "baspi5Ref": "A7.1.4.1",
                                       "rdsRef": "Services/OtherServices/ExternalConnections/Flags",
                                       "title": "Does it comply with the General Binding Rules for discharge into a waterway?",
                                       "type": "string",
                                       "enum": ["Yes", "No"]
                                     }
                                   },
-                                  "baspiRequired": ["dischargeCompliesWithGBR"]
+                                  "baspi4Required": [
+                                    "dischargeCompliesWithGBR"
+                                  ],
+                                  "baspi5Required": ["dischargeCompliesWithGBR"]
                                 }
                               ]
                             }
@@ -17874,14 +19067,16 @@
                                   "enum": ["Septic tank"]
                                 },
                                 "dateReplaced": {
-                                  "baspiRef": "A7.1.0.14.2",
+                                  "baspi4Ref": "A7.1.0.14.2",
+                                  "baspi5Ref": "A7.1.0.14.2",
                                   "ta6Ref": "12.5.1",
                                   "title": "Date replaced or upgraded",
                                   "type": "string",
                                   "format": "date"
                                 },
                                 "dateLastEmptied": {
-                                  "baspiRef": "A7.1.0.14.3",
+                                  "baspi4Ref": "A7.1.0.14.3",
+                                  "baspi5Ref": "A7.1.0.14.3",
                                   "ta6Ref": "12.7",
                                   "piqRef": "A7.1.24",
                                   "title": "Date last emptied",
@@ -17889,7 +19084,11 @@
                                   "format": "date"
                                 }
                               },
-                              "baspiRequired": [
+                              "baspi4Required": [
+                                "dateReplaced",
+                                "dateLastEmptied"
+                              ],
+                              "baspi5Required": [
                                 "dateReplaced",
                                 "dateLastEmptied"
                               ],
@@ -17901,7 +19100,8 @@
                                   "enum": ["Cesspit"]
                                 },
                                 "dateLastEmptied": {
-                                  "baspiRef": "A7.1.0.15.2",
+                                  "baspi4Ref": "A7.1.0.15.2",
+                                  "baspi5Ref": "A7.1.0.15.2",
                                   "ta6Ref": "12.7",
                                   "piqRef": "A7.1.26",
                                   "title": "Date last emptied",
@@ -17909,7 +19109,8 @@
                                   "format": "date"
                                 }
                               },
-                              "baspiRequired": ["dateLastEmptied"],
+                              "baspi4Required": ["dateLastEmptied"],
+                              "baspi5Required": ["dateLastEmptied"],
                               "ta6Required": ["dateLastEmptied"]
                             },
                             {
@@ -17918,21 +19119,24 @@
                                   "enum": ["Sewerage treatment plant"]
                                 },
                                 "dateInstalled": {
-                                  "baspiRef": "A7.1.0.16.2",
+                                  "baspi4Ref": "A7.1.0.16.2",
+                                  "baspi5Ref": "A7.1.0.16.2",
                                   "ta6Ref": "12.9",
                                   "title": "Date installed",
                                   "type": "string",
                                   "format": "date"
                                 },
                                 "dateLastServiced": {
-                                  "baspiRef": "A7.1.0.16.3",
+                                  "baspi4Ref": "A7.1.0.16.3",
+                                  "baspi5Ref": "A7.1.0.16.3",
                                   "ta6Ref": "12.8",
                                   "title": "Date last serviced",
                                   "type": "string",
                                   "format": "date"
                                 },
                                 "attachments": {
-                                  "baspiRef": "A7.1.0.16.3",
+                                  "baspi4Ref": "A7.1.0.16.3",
+                                  "baspi5Ref": "A7.1.0.16.3",
                                   "title": "If installed after Jan 1991 supply the Building Regulations approval or equivalent",
                                   "type": "string",
                                   "enum": [
@@ -17942,7 +19146,12 @@
                                   ]
                                 }
                               },
-                              "baspiRequired": [
+                              "baspi4Required": [
+                                "dateInstalled",
+                                "dateLastServiced",
+                                "attachments"
+                              ],
+                              "baspi5Required": [
                                 "dateInstalled",
                                 "dateLastServiced",
                                 "attachments"
@@ -18302,21 +19511,24 @@
               }
             },
             "maintenanceAgreements": {
-              "baspiRef": "A7.2",
+              "baspi4Ref": "A7.2",
+              "baspi5Ref": "A7.2",
               "rdsRef": "Services/Certificates,Services/OtherServices/Certificates",
               "piqRef": "A7.2",
               "title": "Do you have any licences, maintenance agreements, contracts or service agreements in relation to these services?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.2.1",
+                  "baspi4Ref": "A7.2.1",
+                  "baspi5Ref": "A7.2.1",
                   "piqRef": "A7.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -18334,20 +19546,23 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A7.2.2",
+                      "baspi4Ref": "A7.2.2",
+                      "baspi5Ref": "A7.2.2",
                       "piqRef": "A7.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A7.2.3",
+                      "baspi4Ref": "A7.2.3",
+                      "baspi5Ref": "A7.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
@@ -18388,7 +19603,9 @@
                 },
                 "consequentialChargingBasis": {
                   "con29DWRef": "4.5",
-                  "title": "Will the basis for charging for sewerage and water services at the property change as a consequence of a change of occupation?"
+                  "title": "Will the basis for charging for sewerage and water services at the property change as a consequence of a change of occupation?",
+                  "type": "string",
+                  "minLength": 1
                 }
               },
               "con29DWRequired": [
@@ -18405,13 +19622,15 @@
         "heating": {
           "ntsRef": "B3.4",
           "ntslRef": "B3.4",
-          "baspiRef": "A7.4",
+          "baspi4Ref": "A7.4",
+          "baspi5Ref": "A7.4",
           "ta6Ref": "12.3",
           "rdsRef": "Buildings|BuildingSections/isUnheated=no|yes|true|false",
           "piqRef": "A7.3",
           "title": "Heating",
           "type": "object",
-          "baspiRequired": ["heatingSystem"],
+          "baspi4Required": ["heatingSystem"],
+          "baspi5Required": ["heatingSystem"],
           "ta6Required": ["heatingSystem"],
           "ntsRequired": ["heatingSystem"],
           "ntslRequired": ["heatingSystem"],
@@ -18419,12 +19638,14 @@
             "heatingSystem": {
               "ntsRef": "B3.4.1",
               "ntslRef": "B3.4.1",
-              "baspiRef": "A7.4.0",
+              "baspi4Ref": "A7.4.0",
+              "baspi5Ref": "A7.4.0",
               "ta6Ref": "12.3.1",
               "piqRef": "A7.3.1",
               "type": "object",
               "title": "Heating system",
-              "baspiRequired": ["heatingType"],
+              "baspi4Required": ["heatingType"],
+              "baspi5Required": ["heatingType"],
               "ta6Required": ["heatingType"],
               "ntsRequired": ["heatingType"],
               "ntslRequired": ["heatingType"],
@@ -18432,7 +19653,8 @@
                 "heatingType": {
                   "ntsRef": "B3.4.1",
                   "ntslRef": "B3.4.1",
-                  "baspiRef": "A7.4.0",
+                  "baspi4Ref": "A7.4.0",
+                  "baspi5Ref": "A7.4.0",
                   "ta6Ref": "12.3.1",
                   "piqRef": "A7.3.1",
                   "title": "What type of heating system does the property have?",
@@ -18464,12 +19686,21 @@
                     "centralHeatingDetails": {
                       "ntsRef": "B3.4.3",
                       "ntslRef": "B3.4.3",
-                      "baspiRef": "A7.4.0.0",
+                      "baspi4Ref": "A7.4.0.0",
+                      "baspi5Ref": "A7.4.0.0",
                       "ta6Ref": "12.3.2",
                       "piqRef": "A7.3.1.1",
                       "type": "object",
                       "title": "Central Heating Details",
-                      "baspiRequired": [
+                      "baspi4Required": [
+                        "centralHeatingFuel",
+                        "centralHeatingInstalled",
+                        "boilerInstallationCertificate",
+                        "heatingLastServicedDate",
+                        "heatingLastServicedReport",
+                        "heatingInGoodWorkingOrder"
+                      ],
+                      "baspi5Required": [
                         "centralHeatingFuel",
                         "centralHeatingInstalled",
                         "boilerInstallationCertificate",
@@ -18491,20 +19722,23 @@
                         "centralHeatingFuel": {
                           "ntsRef": "B3.4.3.1",
                           "ntslRef": "B3.4.3.1",
-                          "baspiRef": "A7.4.0.1",
+                          "baspi4Ref": "A7.4.0.1",
+                          "baspi5Ref": "A7.4.0.1",
                           "ta6Ref": "12.3.3",
                           "rdsRef": "Buildings|BuildingSections/Heating/isGas=no|yes|true|false",
                           "type": "object",
                           "title": "Central Heating Fuel",
                           "ntsRequired": ["centralHeatingFuelType"],
                           "ntslRequired": ["centralHeatingFuelType"],
-                          "baspiRequired": ["centralHeatingFuelType"],
+                          "baspi4Required": ["centralHeatingFuelType"],
+                          "baspi5Required": ["centralHeatingFuelType"],
                           "ta6Required": ["centralHeatingFuelType"],
                           "properties": {
                             "centralHeatingFuelType": {
                               "ntsRef": "B3.4.3.1.1",
                               "ntslRef": "B3.4.3.1.1",
-                              "baspiRef": "A7.4.0.2",
+                              "baspi4Ref": "A7.4.0.2",
+                              "baspi5Ref": "A7.4.0.2",
                               "ta6Ref": "12.3a1",
                               "title": "What type of fuel does the system run on?",
                               "type": "string",
@@ -18528,27 +19762,31 @@
                                   "enum": ["Mains gas"]
                                 },
                                 "supplier": {
-                                  "baspiRef": "A7.1.0",
+                                  "baspi4Ref": "A7.1.0",
+                                  "baspi5Ref": "A7.1.0",
                                   "ta6Ref": "13.2b",
                                   "title": "Supplier",
                                   "type": "string"
                                 },
                                 "gasMeter": {
-                                  "baspiRef": "B4.5",
+                                  "baspi4Ref": "B4.5",
+                                  "baspi5Ref": "B4.5",
                                   "ta6Ref": "13.2c",
                                   "rdsRef": "Objects/class='meters'&access=?&accessLocation=?",
                                   "title": "Location of gas meter",
                                   "type": "object",
                                   "properties": {
                                     "location": {
-                                      "baspiRef": "4.5.1",
+                                      "baspi4Ref": "4.5.1",
+                                      "baspi5Ref": "4.5.1",
                                       "ta6Ref": "13.2c1",
                                       "title": "Describe the location of the meter",
                                       "type": "string",
                                       "minLength": 1
                                     },
                                     "attachments": {
-                                      "baspiRef": "4.5.2",
+                                      "baspi4Ref": "4.5.2",
+                                      "baspi5Ref": "4.5.2",
                                       "title": "Photograph of meter location",
                                       "type": "string",
                                       "enum": ["Attached", "To follow"]
@@ -18559,11 +19797,13 @@
                                       "type": "integer"
                                     }
                                   },
-                                  "baspiRequired": ["location"],
+                                  "baspi4Required": ["location"],
+                                  "baspi5Required": ["location"],
                                   "ta6Required": ["location"]
                                 }
                               },
-                              "baspiRequired": ["supplier", "gasMeter"],
+                              "baspi4Required": ["supplier", "gasMeter"],
+                              "baspi5Required": ["supplier", "gasMeter"],
                               "ta6Required": ["supplier", "gasMeter"]
                             },
                             {
@@ -18579,7 +19819,8 @@
                                   "enum": ["Oil", "LPG", "Biomass"]
                                 },
                                 "supplier": {
-                                  "baspiRef": "A7.1.0",
+                                  "baspi4Ref": "A7.1.0",
+                                  "baspi5Ref": "A7.1.0",
                                   "title": "Supplier (if known)",
                                   "type": "string"
                                 }
@@ -18591,20 +19832,23 @@
                                   "enum": ["Other"]
                                 },
                                 "otherCentralHeatingFuelType": {
-                                  "baspiRef": "A7.4.0.3",
+                                  "baspi4Ref": "A7.4.0.3",
+                                  "baspi5Ref": "A7.4.0.3",
                                   "ta6Ref": "12.3a2",
                                   "title": "Please describe the other fuel type",
                                   "type": "string",
                                   "minLength": 1
                                 }
                               },
-                              "baspiRequired": ["otherCentralHeatingFuelType"],
+                              "baspi4Required": ["otherCentralHeatingFuelType"],
+                              "baspi5Required": ["otherCentralHeatingFuelType"],
                               "ta6Required": ["otherCentralHeatingFuelType"]
                             }
                           ]
                         },
                         "centralHeatingInstalled": {
-                          "baspiRef": "A7.4.1",
+                          "baspi4Ref": "A7.4.1",
+                          "baspi5Ref": "A7.4.1",
                           "rdsRef": "Objects/Installed",
                           "ta6Ref": "12.3b1",
                           "piqRef": "A7.4.1",
@@ -18613,21 +19857,24 @@
                           "format": "date"
                         },
                         "boilerInstallationCertificate": {
-                          "baspiRef": "A7.4.1.1",
+                          "baspi4Ref": "A7.4.1.1",
+                          "baspi5Ref": "A7.4.1.1",
                           "rdsRef": "Objects/Installation,Objects/Certificates",
                           "ta6Ref": "12.3b2",
                           "title": "Was a gas boiler installed after 1st April 2005, or a solid fuel or oil boiler installed after 1st October 2010?",
                           "type": "object",
                           "properties": {
                             "yesNo": {
-                              "baspiRef": "A10.1.1",
+                              "baspi4Ref": "A10.1.1",
+                              "baspi5Ref": "A10.1.1",
                               "ta6Ref": "12.3b3",
                               "type": "string",
                               "title": "",
                               "enum": ["Yes", "No"]
                             }
                           },
-                          "baspiRequired": ["yesNo"],
+                          "baspi4Required": ["yesNo"],
+                          "baspi5Required": ["yesNo"],
                           "ta6Required": ["yesNo"],
                           "discriminator": {
                             "propertyName": "yesNo"
@@ -18646,20 +19893,23 @@
                                   "enum": ["Yes"]
                                 },
                                 "attachments": {
-                                  "baspiRef": "A7.4.1.2",
+                                  "baspi4Ref": "A7.4.1.2",
+                                  "baspi5Ref": "A7.4.1.2",
                                   "ta6Ref": "12.3b4",
                                   "title": "Please supply a copy of the installation completion certificate from a competent person qualified under the relevant self-certification scheme e.g. HETAS etc",
                                   "type": "string",
                                   "enum": ["Attached", "To follow"]
                                 }
                               },
-                              "baspiRequired": ["attachments"],
+                              "baspi4Required": ["attachments"],
+                              "baspi5Required": ["attachments"],
                               "ta6Required": ["attachments"]
                             }
                           ]
                         },
                         "heatingLastServicedDate": {
-                          "baspiRef": "A7.4.2.1",
+                          "baspi4Ref": "A7.4.2.1",
+                          "baspi5Ref": "A7.4.2.1",
                           "rdsRef": "Objects/Maintenance",
                           "ta6Ref": "12.3d1",
                           "piqRef": "A7.5.1",
@@ -18668,14 +19918,16 @@
                           "format": "date"
                         },
                         "heatingLastServicedReport": {
-                          "baspiRef": "A7.4.2.2",
+                          "baspi4Ref": "A7.4.2.2",
+                          "baspi5Ref": "A7.4.2.2",
                           "ta6Ref": "12.3d2",
                           "title": "Please provide a copy of the service or maintenance works report.",
                           "type": "string",
                           "enum": ["Attached", "To follow", "Not available"]
                         },
                         "heatingInGoodWorkingOrder": {
-                          "baspiRef": "A7.4.3",
+                          "baspi4Ref": "A7.4.3",
+                          "baspi5Ref": "A7.4.3",
                           "rdsRef": "Objects/Condition=?",
                           "ta6Ref": "12.3c",
                           "piqRef": "A7.6",
@@ -18683,14 +19935,16 @@
                           "type": "object",
                           "properties": {
                             "yesNo": {
-                              "baspiRef": "A7.4.3.1",
+                              "baspi4Ref": "A7.4.3.1",
+                              "baspi5Ref": "A7.4.3.1",
                               "ta6Ref": "12.3c1",
                               "type": "string",
                               "title": "",
                               "enum": ["Yes", "No"]
                             }
                           },
-                          "baspiRequired": ["yesNo"],
+                          "baspi4Required": ["yesNo"],
+                          "baspi5Required": ["yesNo"],
                           "ta6Required": ["yesNo"],
                           "discriminator": {
                             "propertyName": "yesNo"
@@ -18709,20 +19963,23 @@
                                   "enum": ["No"]
                                 },
                                 "details": {
-                                  "baspiRef": "A7.4.3.2",
+                                  "baspi4Ref": "A7.4.3.2",
+                                  "baspi5Ref": "A7.4.3.2",
                                   "title": "Please provide details",
                                   "type": "string",
                                   "minLength": 1
                                 }
                               },
-                              "baspiRequired": ["details"]
+                              "baspi4Required": ["details"],
+                              "baspi5Required": ["details"]
                             }
                           ]
                         }
                       }
                     }
                   },
-                  "baspiRequired": ["centralHeatingDetails"],
+                  "baspi4Required": ["centralHeatingDetails"],
+                  "baspi5Required": ["centralHeatingDetails"],
                   "ntsRequired": ["centralHeatingDetails"],
                   "ntslRequired": ["centralHeatingDetails"],
                   "ta6Required": ["centralHeatingDetails"]
@@ -18730,12 +19987,12 @@
                 {
                   "properties": {
                     "heatingType": {
-                      "enum": ["Community heating system"]
+                      "enum": ["Communal heating system"]
                     },
                     "details": {
                       "ntsRef": "B3.4.4",
                       "ntslRef": "B3.4.4",
-                      "title": "Community heating system details",
+                      "title": "Communal heating system details",
                       "description": "Please describe how the cost of heating supply is charged, whether you have control over the energy supplier and whether you have any control over the heating.",
                       "type": "string",
                       "minLength": 1
@@ -18772,19 +20029,32 @@
           }
         },
         "connectivity": {
-          "baspiRef": "A7",
+          "baspi4Ref": "A7",
+          "baspi5Ref": "A7",
           "ntsRef": "B3",
           "ntslRef": "B3",
           "ta6Ref": "13",
           "title": "Connectivity",
           "type": "object",
-          "baspiRequired": ["telephone", "cableSatelliteTV", "broadband"],
+          "baspi4Required": [
+            "telephone",
+            "cableSatelliteTV",
+            "broadband",
+            "mobilePhone"
+          ],
+          "baspi5Required": [
+            "telephone",
+            "cableSatelliteTV",
+            "broadband",
+            "mobilePhone"
+          ],
           "ntsRequired": ["broadband"],
           "ntslRequired": ["broadband"],
           "ta6Required": ["telephone", "cableSatelliteTV"],
           "properties": {
             "telephone": {
-              "baspiRef": "A7.1.0.5",
+              "baspi4Ref": "A7.1.0.5",
+              "baspi5Ref": "A7.1.0.5",
               "ta6Ref": "13.5",
               "piqRef": "A7.1.11",
               "rdsRef": "Services/Telephone",
@@ -18792,7 +20062,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.5.1",
+                  "baspi4Ref": "A7.1.0.5.1",
+                  "baspi5Ref": "A7.1.0.5.1",
                   "ta6Ref": "13.5.1",
                   "type": "string",
                   "title": "",
@@ -18802,7 +20073,8 @@
                   "ta6Enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -18821,7 +20093,8 @@
                       "enum": ["Yes"]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.5.2",
+                      "baspi4Ref": "A7.1.0.5.2",
+                      "baspi5Ref": "A7.1.0.5.2",
                       "ta6Ref": "13.5.2",
                       "piqRef": "A7.1.12",
                       "title": "Supplier",
@@ -18836,25 +20109,29 @@
                       "enum": ["To be connected"]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.5.3",
+                      "baspi4Ref": "A7.1.0.5.3",
+                      "baspi5Ref": "A7.1.0.5.3",
                       "title": "Date to be connected",
                       "type": "string",
                       "format": "date"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.5.2",
+                      "baspi4Ref": "A7.1.0.5.2",
+                      "baspi5Ref": "A7.1.0.5.2",
                       "ta6Ref": "13.5.2",
                       "piqRef": "A7.1.12",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["dateToBeConnected"]
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
                 }
               ]
             },
             "cableSatelliteTV": {
-              "baspiRef": "A7.1.0.6",
+              "baspi4Ref": "A7.1.0.6",
+              "baspi5Ref": "A7.1.0.6",
               "ta6Ref": "13.6",
               "rdsRef": "Services/CableSatelliteTV",
               "piqRef": "A7.1.13",
@@ -18862,7 +20139,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.6.1",
+                  "baspi4Ref": "A7.1.0.6.1",
+                  "baspi5Ref": "A7.1.0.6.1",
                   "ta6Ref": "13.6.1",
                   "type": "string",
                   "title": "",
@@ -18872,7 +20150,8 @@
                   "ta6Enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -18891,7 +20170,8 @@
                       "enum": ["Yes"]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.6.2",
+                      "baspi4Ref": "A7.1.0.6.2",
+                      "baspi5Ref": "A7.1.0.6.2",
                       "ta6Ref": "13.6.2",
                       "piqRef": "A7.1.14",
                       "title": "Supplier",
@@ -18906,25 +20186,29 @@
                       "enum": ["To be connected"]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.6.3",
+                      "baspi4Ref": "A7.1.0.6.3",
+                      "baspi5Ref": "A7.1.0.6.3",
                       "title": "Date to be connected",
                       "type": "string",
                       "format": "date"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.6.2",
+                      "baspi4Ref": "A7.1.0.6.2",
+                      "baspi5Ref": "A7.1.0.6.2",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["dateToBeConnected"]
+                  "baspi4Required": ["dateToBeConnected"],
+                  "baspi5Required": ["dateToBeConnected"]
                 }
               ]
             },
             "broadband": {
               "ntsRef": "B3.5",
               "ntslRef": "B3.5",
-              "baspiRef": "A7.1.0.7",
+              "baspi4Ref": "A7.1.0.7",
+              "baspi5Ref": "A7.1.0.7",
               "title": "Broadband",
               "rdsRef": "Services/Internet",
               "piqRef": "A7.1.15",
@@ -18933,7 +20217,8 @@
                 "typeOfConnection": {
                   "ntsRef": "B3.5.2",
                   "ntslRef": "B3.5.2",
-                  "baspiRef": "A7.1.0.7.2",
+                  "baspi4Ref": "A7.1.0.7.2",
+                  "baspi5Ref": "A7.1.0.7.2",
                   "piqRef": "A7.1.16",
                   "title": "Type of connection",
                   "type": "string",
@@ -18980,21 +20265,29 @@
               "ntslRequired": ["typeOfConnection"]
             },
             "mobilePhone": {
+              "baspi4Ref": "A7.1.0.8",
+              "baspi5Ref": "A7.1.0.8",
               "ntsRef": "B3.6",
               "ntslRef": "B3.6",
               "title": "Mobile phone coverage",
               "type": "object",
               "properties": {
                 "knownSignalIssues": {
+                  "baspi4Ref": "A7.1.0.8.1",
+                  "baspi5Ref": "A7.1.0.8.1",
                   "ntsRef": "B3.6.1",
                   "ntslRef": "B3.6.1",
                   "title": "Are there any issues with mobile phone signal or coverage at the property?",
                   "description": "You should disclose any known issues with signal strength or dropped calls specific to the property.",
                   "type": "object",
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "ntslRequired": ["yesNo"],
                   "properties": {
                     "yesNo": {
+                      "baspi4Ref": "A7.1.0.8.2",
+                      "baspi5Ref": "A7.1.0.8.2",
                       "ntsRef": "B3.6.1.1",
                       "ntslRef": "B3.6.1.1",
                       "title": "",
@@ -19137,288 +20430,63 @@
           }
         },
         "insurance": {
-          "baspiRef": "A8",
+          "baspi4Ref": "A8",
+          "baspi5Ref": "A8",
           "ta6Ref": "6",
           "title": "Insurance",
           "type": "object",
-          "baspiRequired": ["isInsured"],
-          "ta6Required": ["isInsured"],
+          "baspi4Required": ["difficultiesObtainingInsurance", "isInsured"],
+          "baspi5Required": ["difficultiesObtainingInsurance", "isInsured"],
+          "ta6Required": ["difficultiesObtainingInsurance", "isInsured"],
           "properties": {
-            "isInsured": {
-              "baspiRef": "A8.1",
-              "rdsRef": "Insurance/isInsured=no|yes|true|false",
-              "ta6Ref": "6.1",
-              "piqRef": "A8.2",
-              "title": "Do you insure the property?",
-              "ta6Title": "Does the seller insure the property?",
-              "type": "string",
-              "enum": ["Yes", "No"]
-            }
-          },
-          "discriminator": {
-            "propertyName": "isInsured"
-          },
-          "oneOf": [
-            {
+            "difficultiesObtainingInsurance": {
+              "baspi4Ref": "A8.1.2.1",
+              "baspi5Ref": "A8.1.2.1",
+              "rdsRef": "Insurance/Flags,Insurance/refusalReason=?",
+              "ta6Ref": "6.4",
+              "piqRef": "A8.1",
+              "title": "Have you had any difficulty obtaining competitively priced building insurance due to the structure or location of the property or had insurance refused?",
+              "ta6Title": "Has any buildings insurance taken out by the seller ever been:",
+              "type": "object",
+              "baspi4Required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "baspi5Required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "ta6Required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
               "properties": {
-                "isInsured": {
-                  "enum": ["No"]
-                },
-                "details": {
-                  "baspiRef": "A8.1.1",
-                  "ta6Ref": "6.2",
-                  "title": "Why not?",
-                  "type": "string",
-                  "minLength": 1
-                },
-                "landlordInsuresIfFlat": {
-                  "baspiRef": "A8.1.2",
-                  "ta6Ref": "6.3",
-                  "title": "If the property is a flat, does the landlord insure the building?",
-                  "type": "string",
-                  "enum": ["Yes", "No", "Not applicable"]
-                }
-              },
-              "baspiRequired": ["details", "landlordInsuresIfFlat"],
-              "ta6Required": ["details", "landlordInsuresIfFlat"]
-            },
-            {
-              "properties": {
-                "isInsured": {
-                  "enum": ["Yes"]
-                },
-                "difficultiesObtainingInsurance": {
-                  "baspiRef": "A8.1.2.1",
-                  "rdsRef": "Insurance/Flags,Insurance/refusalReason=?",
-                  "ta6Ref": "6.4",
-                  "piqRef": "A8.1",
-                  "title": "Have you had any difficulty obtaining competitively priced building insurance due to the structure or location of the property or had insurance refused?",
-                  "ta6Title": "Has any buildings insurance taken out by the seller ever been:",
-                  "type": "object",
-                  "baspiRequired": [
-                    "abnormalRiseInPremiums",
-                    "subjectToHighExcesses",
-                    "subjectToUnusualConditions",
-                    "refused"
-                  ],
-                  "ta6Required": [
-                    "abnormalRiseInPremiums",
-                    "subjectToHighExcesses",
-                    "subjectToUnusualConditions",
-                    "refused"
-                  ],
-                  "properties": {
-                    "abnormalRiseInPremiums": {
-                      "baspiRef": "A8.1.2.1.1",
-                      "ta6Ref": "6.4a",
-                      "piqRef": "A8.1a",
-                      "title": "Subject to abnormal rise in premiums?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.1.1",
-                          "ta6Ref": "6.4a1",
-                          "piqRef": "A8.1a1",
-                          "type": "string",
-                          "title": "",
-                          "enum": ["Yes", "No"]
-                        }
-                      },
-                      "baspiRequired": ["yesNo"],
-                      "ta6Required": ["yesNo"],
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["No"]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["Yes"]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.1.2",
-                              "ta6Ref": "6.4.2",
-                              "piqRef": "A8.1a1.1",
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          },
-                          "baspiRequired": ["details"],
-                          "ta6Required": ["details"]
-                        }
-                      ]
-                    },
-                    "subjectToHighExcesses": {
-                      "baspiRef": "A8.1.2.1.2",
-                      "ta6Ref": "6.4b",
-                      "piqRef": "A8.1b",
-                      "title": "Subject to high excesses?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.2.1",
-                          "ta6Ref": "6.4b1",
-                          "piqRef": "A8.1b1",
-                          "type": "string",
-                          "title": "",
-                          "enum": ["Yes", "No"]
-                        }
-                      },
-                      "baspiRequired": ["yesNo"],
-                      "ta6Required": ["yesNo"],
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["No"]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["Yes"]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.2.2",
-                              "ta6Ref": "6.4.2",
-                              "piqRef": "A8.1b2",
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          },
-                          "baspiRequired": ["details"],
-                          "ta6Required": ["details"]
-                        }
-                      ]
-                    },
-                    "subjectToUnusualConditions": {
-                      "baspiRef": "A8.1.2.1.3",
-                      "ta6Ref": "6.4c",
-                      "piqRef": "A8.1c",
-                      "title": "Subject to unusual conditions?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.3.1",
-                          "ta6Ref": "6.4c1",
-                          "piqRef": "A8.1c1",
-                          "type": "string",
-                          "title": "",
-                          "enum": ["Yes", "No"]
-                        }
-                      },
-                      "baspiRequired": ["yesNo"],
-                      "ta6Required": ["yesNo"],
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["No"]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["Yes"]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.3.2",
-                              "ta6Ref": "6.4.2",
-                              "piqRef": "A8.1c2",
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          },
-                          "baspiRequired": ["details"],
-                          "ta6Required": ["details"]
-                        }
-                      ]
-                    },
-                    "refused": {
-                      "baspiRef": "A8.1.2.1.4",
-                      "ta6Ref": "6.4d",
-                      "piqRef": "A8.1d",
-                      "title": "Refused?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.4.1",
-                          "ta6Ref": "6.4d1",
-                          "piqRef": "A8.1d1",
-                          "type": "string",
-                          "title": "",
-                          "enum": ["Yes", "No"]
-                        }
-                      },
-                      "baspiRequired": ["yesNo"],
-                      "ta6Required": ["yesNo"],
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["No"]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": ["Yes"]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.4.2",
-                              "ta6Ref": "6.4.2",
-                              "piqRef": "A8.1d2",
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          },
-                          "baspiRequired": ["details"],
-                          "ta6Required": ["details"]
-                        }
-                      ]
-                    }
-                  }
-                },
-                "insuranceClaims": {
-                  "baspiRef": "A8.2",
-                  "rdsRef": "Insurance/Claims",
-                  "ta6Ref": "6.5",
-                  "title": "Have you ever made a claim against your building insurance in relation to the property?",
-                  "Title": "Has the seller made any buildings insurance claims?",
+                "abnormalRiseInPremiums": {
+                  "baspi4Ref": "A8.1.2.1.1",
+                  "baspi5Ref": "A8.1.2.1.1",
+                  "ta6Ref": "6.4a",
+                  "piqRef": "A8.1a",
+                  "title": "Subject to abnormal rise in premiums?",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A8.2.1",
-                      "ta6Ref": "6.5.1",
+                      "baspi4Ref": "A8.1.2.1.1.1",
+                      "baspi5Ref": "A8.1.2.1.1.1",
+                      "ta6Ref": "6.4a1",
+                      "piqRef": "A8.1a1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19437,38 +20505,304 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A8.2.1",
+                          "baspi4Ref": "A8.1.2.1.1.2",
+                          "baspi5Ref": "A8.1.2.1.1.2",
+                          "ta6Ref": "6.4.2",
+                          "piqRef": "A8.1a1.1",
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
+                      "ta6Required": ["details"]
+                    }
+                  ]
+                },
+                "subjectToHighExcesses": {
+                  "baspi4Ref": "A8.1.2.1.2",
+                  "baspi5Ref": "A8.1.2.1.2",
+                  "ta6Ref": "6.4b",
+                  "piqRef": "A8.1b",
+                  "title": "Subject to high excesses?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.2.1",
+                      "baspi5Ref": "A8.1.2.1.2.1",
+                      "ta6Ref": "6.4b1",
+                      "piqRef": "A8.1b1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
+                  "ta6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.2.2",
+                          "baspi5Ref": "A8.1.2.1.2.2",
+                          "ta6Ref": "6.4.2",
+                          "piqRef": "A8.1b2",
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
+                      "ta6Required": ["details"]
+                    }
+                  ]
+                },
+                "subjectToUnusualConditions": {
+                  "baspi4Ref": "A8.1.2.1.3",
+                  "baspi5Ref": "A8.1.2.1.3",
+                  "ta6Ref": "6.4c",
+                  "piqRef": "A8.1c",
+                  "title": "Subject to unusual conditions?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.3.1",
+                      "baspi5Ref": "A8.1.2.1.3.1",
+                      "ta6Ref": "6.4c1",
+                      "piqRef": "A8.1c1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
+                  "ta6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.3.2",
+                          "baspi5Ref": "A8.1.2.1.3.2",
+                          "ta6Ref": "6.4.2",
+                          "piqRef": "A8.1c2",
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
+                      "ta6Required": ["details"]
+                    }
+                  ]
+                },
+                "refused": {
+                  "baspi4Ref": "A8.1.2.1.4",
+                  "baspi5Ref": "A8.1.2.1.4",
+                  "ta6Ref": "6.4d",
+                  "piqRef": "A8.1d",
+                  "title": "Refused?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.4.1",
+                      "baspi5Ref": "A8.1.2.1.4.1",
+                      "ta6Ref": "6.4d1",
+                      "piqRef": "A8.1d1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
+                  "ta6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.4.2",
+                          "baspi5Ref": "A8.1.2.1.4.2",
+                          "ta6Ref": "6.4.2",
+                          "piqRef": "A8.1d2",
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
+                      "ta6Required": ["details"]
+                    }
+                  ]
+                }
+              }
+            },
+            "isInsured": {
+              "baspi4Ref": "A8.1",
+              "baspi5Ref": "A8.1",
+              "rdsRef": "Insurance/isInsured=no|yes|true|false",
+              "ta6Ref": "6.1",
+              "piqRef": "A8.2",
+              "title": "Do you currently insure the property?",
+              "ta6Title": "Does the seller insure the property?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            }
+          },
+          "discriminator": {
+            "propertyName": "isInsured"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": ["No"]
+                },
+                "details": {
+                  "baspi4Ref": "A8.1.1",
+                  "baspi5Ref": "A8.1.1",
+                  "ta6Ref": "6.2",
+                  "title": "Why not?",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "landlordInsuresIfFlat": {
+                  "baspi4Ref": "A8.1.2",
+                  "baspi5Ref": "A8.1.2",
+                  "ta6Ref": "6.3",
+                  "title": "If the property is a flat, does the landlord insure the building?",
+                  "type": "string",
+                  "enum": ["Yes", "No", "Not applicable"]
+                }
+              },
+              "baspi4Required": ["details", "landlordInsuresIfFlat"],
+              "baspi5Required": ["details", "landlordInsuresIfFlat"],
+              "ta6Required": ["details", "landlordInsuresIfFlat"]
+            },
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": ["Yes"]
+                },
+
+                "insuranceClaims": {
+                  "baspi4Ref": "A8.2",
+                  "baspi5Ref": "A8.2",
+                  "rdsRef": "Insurance/Claims",
+                  "ta6Ref": "6.5",
+                  "title": "Have you ever made a claim against your building insurance in relation to the property?",
+                  "Title": "Has the seller made any buildings insurance claims?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.2.1",
+                      "baspi5Ref": "A8.2.1",
+                      "ta6Ref": "6.5.1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
+                  "ta6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.2.1",
+                          "baspi5Ref": "A8.2.1",
                           "ta6Ref": "6.5.2",
                           "title": "Provide details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"],
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
                       "ta6Required": ["details"]
                     }
                   ]
                 }
               },
-              "baspiRequired": [
-                "difficultiesObtainingInsurance",
-                "insuranceClaims"
-              ],
-              "ta6Required": [
-                "difficultiesObtainingInsurance",
-                "insuranceClaims"
-              ]
+              "baspi4Required": ["insuranceClaims"],
+              "baspi5Required": ["insuranceClaims"],
+              "ta6Required": ["insuranceClaims"]
             }
           ]
         },
         "rightsAndInformalArrangements": {
           "ntsRef": "C2.2",
           "ntslRef": "C2.2",
-          "baspiRef": "A10",
+          "baspi4Ref": "A10",
+          "baspi5Ref": "A10",
           "ta6Ref": "8",
           "title": "Rights and Informal Arrangements",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "sharedContributions",
+            "neighbouringLandRights",
+            "accessRestrictionAttempts",
+            "rightsOrArrangements"
+          ],
+          "baspi5Required": [
             "sharedContributions",
             "neighbouringLandRights",
             "accessRestrictionAttempts",
@@ -19484,7 +20818,8 @@
           ],
           "properties": {
             "sharedContributions": {
-              "baspiRef": "A10.1",
+              "baspi4Ref": "A10.1",
+              "baspi5Ref": "A10.1",
               "rdsRef": "Services/SharedCosts",
               "ta6Ref": "8.1",
               "piqRef": "A10.1",
@@ -19492,7 +20827,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.1.1",
+                  "baspi4Ref": "A10.1.1",
+                  "baspi5Ref": "A10.1.1",
                   "ta6Ref": "8.1.1",
                   "piqRef": "A10.1.1",
                   "type": "string",
@@ -19500,7 +20836,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -19519,7 +20856,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A10.1.2",
+                      "baspi4Ref": "A10.1.2",
+                      "baspi5Ref": "A10.1.2",
                       "ta6Ref": "8.1.2",
                       "piqRef": "A10.1.2",
                       "title": "Please give details including who collects payments and organises the work, the amount of the payments in the last year and whether they are regular payments or only when maintenance work is required",
@@ -19527,13 +20865,15 @@
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "neighbouringLandRights": {
-              "baspiRef": "A10.2",
+              "baspi4Ref": "A10.2",
+              "baspi5Ref": "A10.2",
               "rdsRef": "Tenure/Rights,Tenure *with different property entity and references etc*",
               "ta6Ref": "8.2",
               "piqRef": "A10.2",
@@ -19541,7 +20881,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.2.1",
+                  "baspi4Ref": "A10.2.1",
+                  "baspi5Ref": "A10.2.1",
                   "ta6Ref": "8.2.1",
                   "piqRef": "A10.2.1",
                   "type": "string",
@@ -19549,7 +20890,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -19568,7 +20910,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A10.2.2",
+                      "baspi4Ref": "A10.2.2",
+                      "baspi5Ref": "A10.2.2",
                       "ta6Ref": "8.2.2",
                       "piqRef": "A10.2.2",
                       "title": "Please give details and provide a plan showing the route of the access, parking etc",
@@ -19576,19 +20919,22 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A10.2.3",
+                      "baspi4Ref": "A10.2.3",
+                      "baspi5Ref": "A10.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "accessRestrictionAttempts": {
-              "baspiRef": "A10.3",
+              "baspi4Ref": "A10.3",
+              "baspi5Ref": "A10.3",
               "rdsRef": "Tenure/Restrictions",
               "ta6Ref": "8.3",
               "piqRef": "A10.3",
@@ -19596,7 +20942,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.3.1",
+                  "baspi4Ref": "A10.3.1",
+                  "baspi5Ref": "A10.3.1",
                   "ta6Ref": "8.3.1",
                   "piqRef": "A10.3.1",
                   "type": "string",
@@ -19604,7 +20951,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -19623,7 +20971,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A10.3.2",
+                      "baspi4Ref": "A10.3.2",
+                      "baspi5Ref": "A10.3.2",
                       "ta6Ref": "8.3.2",
                       "piqRef": "A10.3.2",
                       "title": "Details",
@@ -19631,7 +20980,8 @@
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -19639,13 +20989,24 @@
             "rightsOrArrangements": {
               "ntsRef": "C2.2.1",
               "ntslRef": "C2.2.1",
-              "baspiRef": "A10.4",
+              "baspi4Ref": "A10.4",
+              "baspi5Ref": "A10.4",
               "ta6Ref": "8.4",
               "title": "Do you know if any of the following rights or arrangements affect the property?",
               "type": "object",
               "ntsRequired": ["publicRightOfWay"],
               "ntslRequired": ["publicRightOfWay"],
-              "baspiRequired": [
+              "baspi4Required": [
+                "publicRightOfWay",
+                "rightsOfLight",
+                "rightsOfSupport",
+                "rightsCreatedThroughCustom",
+                "minesAndMinerals",
+                "churchChancel",
+                "rightsToTakeFromLand",
+                "otherRights"
+              ],
+              "baspi5Required": [
                 "publicRightOfWay",
                 "rightsOfLight",
                 "rightsOfSupport",
@@ -19668,7 +21029,8 @@
                 "publicRightOfWay": {
                   "ntsRef": "C2.2.1",
                   "ntslRef": "C2.2.1",
-                  "baspiRef": "A10.4.1",
+                  "baspi4Ref": "A10.4.1",
+                  "baspi5Ref": "A10.4.1",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities,Tenure/CadastralMapOfParcels",
                   "ta6Ref": "8.6",
                   "piqRef": "A10.4",
@@ -19679,7 +21041,8 @@
                     "yesNo": {
                       "ntsRef": "C2.2.1.1",
                       "ntslRef": "C2.2.1.1",
-                      "baspiRef": "A10.4.1.1",
+                      "baspi4Ref": "A10.4.1.1",
+                      "baspi5Ref": "A10.4.1.1",
                       "ta6Ref": "8.6.1",
                       "piqRef": "A10.4.1",
                       "type": "string",
@@ -19687,7 +21050,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "ntslRequired": ["yesNo"],
                   "ta6Required": ["yesNo"],
@@ -19710,7 +21074,8 @@
                         "details": {
                           "ntsRef": "C2.2.1.2",
                           "ntslRef": "C2.2.1.2",
-                          "baspiRef": "A10.4.1.2",
+                          "baspi4Ref": "A10.4.1.2",
+                          "baspi5Ref": "A10.4.1.2",
                           "ta6Ref": "8.6.2",
                           "piqRef": "A10.4.2",
                           "title": "Please provide details",
@@ -19718,13 +21083,15 @@
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "A10.4.1.3",
+                          "baspi4Ref": "A10.4.1.3",
+                          "baspi5Ref": "A10.4.1.3",
                           "title": "Please mark the route on a plan of the property",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details", "attachments"],
+                      "baspi4Required": ["details", "attachments"],
+                      "baspi5Required": ["details", "attachments"],
                       "ta6Required": ["details"],
                       "ntsRequired": ["details"],
                       "ntslRequired": ["details"]
@@ -19732,7 +21099,8 @@
                   ]
                 },
                 "rightsOfLight": {
-                  "baspiRef": "A10.4.2a",
+                  "baspi4Ref": "A10.4.2a",
+                  "baspi5Ref": "A10.4.2a",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4a",
                   "piqRef": "A10.5a",
@@ -19740,7 +21108,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.2a.1",
+                      "baspi4Ref": "A10.4.2a.1",
+                      "baspi5Ref": "A10.4.2a.1",
                       "ta6Ref": "8.4a1",
                       "piqRef": "A10.5a1",
                       "type": "string",
@@ -19748,7 +21117,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19767,18 +21137,21 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.2a.2",
+                          "baspi4Ref": "A10.4.2a.2",
+                          "baspi5Ref": "A10.4.2a.2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "rightsOfSupport": {
-                  "baspiRef": "A10.4.2b",
+                  "baspi4Ref": "A10.4.2b",
+                  "baspi5Ref": "A10.4.2b",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4a",
                   "piqRef": "A10.5b",
@@ -19786,7 +21159,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.2b.1",
+                      "baspi4Ref": "A10.4.2b.1",
+                      "baspi5Ref": "A10.4.2b.1",
                       "ta6Ref": "8.4b1",
                       "piqRef": "A10.5b1",
                       "type": "string",
@@ -19794,7 +21168,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19813,18 +21188,21 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.2b.2",
+                          "baspi4Ref": "A10.4.2b.2",
+                          "baspi5Ref": "A10.4.2b.2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "rightsCreatedThroughCustom": {
-                  "baspiRef": "A10.4.3a",
+                  "baspi4Ref": "A10.4.3a",
+                  "baspi5Ref": "A10.4.3a",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4c",
                   "piqRef": "A10.5c",
@@ -19832,7 +21210,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.3a1",
+                      "baspi4Ref": "A10.4.3a1",
+                      "baspi5Ref": "A10.4.3a1",
                       "ta6Ref": "8.4c1",
                       "piqRef": "A10.5c1",
                       "type": "string",
@@ -19840,7 +21219,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19859,18 +21239,21 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.3a2",
+                          "baspi4Ref": "A10.4.3a2",
+                          "baspi5Ref": "A10.4.3a2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "rightsToTakeFromLand": {
-                  "baspiRef": "A10.4.3b",
+                  "baspi4Ref": "A10.4.3b",
+                  "baspi5Ref": "A10.4.3b",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5b",
                   "piqRef": "A10.5f",
@@ -19878,7 +21261,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.3b1",
+                      "baspi4Ref": "A10.4.3b1",
+                      "baspi5Ref": "A10.4.3b1",
                       "ta6Ref": "8.5c1",
                       "piqRef": "A10.5f1",
                       "type": "string",
@@ -19886,7 +21270,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19905,20 +21290,23 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.3b2",
+                          "baspi4Ref": "A10.4.3b2",
+                          "baspi5Ref": "A10.4.3b2",
                           "ta6Ref": "8.5c2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"],
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
                       "ta6Required": ["details"]
                     }
                   ]
                 },
                 "minesAndMinerals": {
-                  "baspiRef": "A10.4.4",
+                  "baspi4Ref": "A10.4.4",
+                  "baspi5Ref": "A10.4.4",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5a",
                   "piqRef": "A10.5d",
@@ -19926,7 +21314,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.4.1",
+                      "baspi4Ref": "A10.4.4.1",
+                      "baspi5Ref": "A10.4.4.1",
                       "ta6Ref": "8.5a1",
                       "piqRef": "A10.5d1",
                       "type": "string",
@@ -19934,7 +21323,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19953,18 +21343,21 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.4.2",
+                          "baspi4Ref": "A10.4.4.2",
+                          "baspi5Ref": "A10.4.4.2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "churchChancel": {
-                  "baspiRef": "A10.4.5",
+                  "baspi4Ref": "A10.4.5",
+                  "baspi5Ref": "A10.4.5",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5b",
                   "piqRef": "A10.5e",
@@ -19972,7 +21365,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.5.1",
+                      "baspi4Ref": "A10.4.5.1",
+                      "baspi5Ref": "A10.4.5.1",
                       "ta6Ref": "8.5b1",
                       "piqRef": "A10.5e1",
                       "type": "string",
@@ -19980,7 +21374,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19999,18 +21394,21 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.5.2",
+                          "baspi4Ref": "A10.4.5.2",
+                          "baspi5Ref": "A10.4.5.2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "otherRights": {
-                  "baspiRef": "A10.4.6",
+                  "baspi4Ref": "A10.4.6",
+                  "baspi5Ref": "A10.4.6",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.6",
                   "piqRef": "A10.5g",
@@ -20018,7 +21416,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.6.1",
+                      "baspi4Ref": "A10.4.6.1",
+                      "baspi5Ref": "A10.4.6.1",
                       "ta6Ref": "8.6.1",
                       "piqRef": "A10.5g1",
                       "type": "string",
@@ -20026,7 +21425,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -20045,14 +21445,16 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A10.4.6.2",
+                          "baspi4Ref": "A10.4.6.2",
+                          "baspi5Ref": "A10.4.6.2",
                           "ta6Ref": "8.6.2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"],
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
                       "ta6Required": ["details"]
                     }
                   ]
@@ -20064,12 +21466,19 @@
         "environmentalIssues": {
           "ntsRef": "C3.1",
           "ntslRef": "C3.1",
-          "baspiRef": "A11.1",
+          "baspi4Ref": "A11.1",
+          "baspi5Ref": "A11.1",
           "ta6Ref": "7",
           "piqRef": "A11.1",
           "title": "Environmental Issues Affecting the Property",
           "type": "object",
-          "baspiRequired": ["flooding", "radon", "otherEnvironmental"],
+          "baspi4Required": ["flooding", "radon", "otherEnvironmental"],
+          "baspi5Required": [
+            "flooding",
+            "radon",
+            "coastalErosion",
+            "otherEnvironmental"
+          ],
           "ntsRequired": [
             "flooding",
             "coalMining",
@@ -20087,12 +21496,14 @@
             "flooding": {
               "ntsRef": "C3.1.1",
               "ntslRef": "C3.1.1",
-              "baspiRef": "A11.1.1",
+              "baspi4Ref": "A11.1.1",
+              "baspi5Ref": "A11.1.1",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
               "ta6Ref": "7.1.0",
               "title": "Flooding",
               "type": "object",
-              "baspiRequired": ["historicalFlooding"],
+              "baspi4Required": ["historicalFlooding"],
+              "baspi5Required": ["historicalFlooding"],
               "ntsRequired": ["floodRisk", "historicalFlooding"],
               "ntslRequired": ["floodRisk", "historicalFlooding"],
               "ta6Required": ["historicalFlooding"],
@@ -20106,7 +21517,8 @@
                   "type": "object",
                   "ntsRequired": ["riskIndicator"],
                   "ntslRequired": ["riskIndicator"],
-                  "baspiRequired": ["riskIndicator"],
+                  "baspi4Required": ["riskIndicator"],
+                  "baspi5Required": ["riskIndicator"],
                   "properties": {
                     "riskIndicator": {
                       "ntsRef": "C3.1.1.1",
@@ -20114,7 +21526,8 @@
                       "type": "string",
                       "title": "Is the property impacted?",
                       "ntsTitle": "To your knowledge, is the property at risk of flooding of any type?",
-                      "baspiTitle": "To your knowledge, is the property at risk of flooding of any type?",
+                      "baspi4Title": "To your knowledge,, is the property at risk of flooding of any type?",
+                      "baspi5Title": "To your knowledge, is the property at risk of flooding of any type?",
                       "enum": ["Yes", "No"]
                     }
                   },
@@ -20216,11 +21629,13 @@
                 "historicalFlooding": {
                   "ntsRef": "C3.1.1.2",
                   "ntslRef": "C3.1.1.2",
-                  "baspiRef": "A11.1.2",
+                  "baspi4Ref": "A11.1.2",
+                  "baspi5Ref": "A11.1.2",
                   "ta6Ref": "7.1",
                   "title": "Historical flooding",
                   "type": "object",
-                  "baspiRequired": ["hasBeenFlooded"],
+                  "baspi4Required": ["hasBeenFlooded"],
+                  "baspi5Required": ["hasBeenFlooded"],
                   "ntsRequired": ["hasBeenFlooded"],
                   "ntslRequired": ["hasBeenFlooded"],
                   "ta6Required": ["hasBeenFlooded"],
@@ -20228,7 +21643,8 @@
                     "hasBeenFlooded": {
                       "ntsRef": "C3.1.1.2.1",
                       "ntslRef": "C3.1.1.2.1",
-                      "baspiRef": "A11.1.2.1",
+                      "baspi4Ref": "A11.1.2.1",
+                      "baspi5Ref": "A11.1.2.1",
                       "ta6Ref": "7.1.1",
                       "title": "Has any part of the property (whether buildings or surrounding garden or land) ever been flooded?",
                       "type": "string",
@@ -20254,7 +21670,8 @@
                         "typeOfFlooding": {
                           "ntsRef": "C3.1.1.3",
                           "ntslRef": "C3.1.1.3",
-                          "baspiRef": "A11.1.2.2",
+                          "baspi4Ref": "A11.1.2.2",
+                          "baspi5Ref": "A11.1.2.2",
                           "rdsRef": "Sustainability/Environmental|Natural|Situational",
                           "ta6Ref": "7.2",
                           "title": "What type of flooding occurred?",
@@ -20274,14 +21691,16 @@
                         "details": {
                           "ntsRef": "C3.1.1.4",
                           "ntslRef": "C3.1.1.4",
-                          "baspiRef": "A11.1.2.1",
+                          "baspi4Ref": "A11.1.2.1",
+                          "baspi5Ref": "A11.1.2.1",
                           "ta6Ref": "7.1.2",
                           "title": "Please state when the flooding occurred and identify the parts that flooded",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["typeOfFlooding", "details"],
+                      "baspi4Required": ["typeOfFlooding", "details"],
+                      "baspi5Required": ["typeOfFlooding", "details"],
                       "ntsRequired": ["typeOfFlooding", "details"],
                       "ntslRequired": ["typeOfFlooding", "details"],
                       "ta6Required": ["typeOfFlooding", "details"]
@@ -20291,12 +21710,14 @@
               }
             },
             "radon": {
-              "baspiRef": "A11.1.3",
+              "baspi4Ref": "A11.1.3",
+              "baspi5Ref": "A11.1.3",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
               "ta6Ref": "7.4",
               "title": "Radon",
               "type": "object",
-              "baspiRequired": ["remedialMeasuresOnConstruction", "radonTest"],
+              "baspi4Required": ["remedialMeasuresOnConstruction", "radonTest"],
+              "baspi5Required": ["remedialMeasuresOnConstruction", "radonTest"],
               "properties": {
                 "radonRisk": {
                   "type": "object",
@@ -20380,20 +21801,23 @@
                   }
                 },
                 "radonTest": {
-                  "baspiRef": "A11.1.3",
+                  "baspi4Ref": "A11.1.3",
+                  "baspi5Ref": "A11.1.3",
                   "ta6Ref": "7.4",
                   "title": "Has a Radon test been carried out on the property?",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A11.1.3.1",
+                      "baspi4Ref": "A11.1.3.1",
+                      "baspi5Ref": "A11.1.3.1",
                       "ta6Ref": "7.4.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -20411,42 +21835,48 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "A11.1.3.2",
+                          "baspi4Ref": "A11.1.3.2",
+                          "baspi5Ref": "A11.1.3.2",
                           "ta6Ref": "7.4b",
                           "title": "Was the test result was below the recommended action level?",
                           "type": "string",
                           "enum": ["Yes", "No"]
                         },
                         "attachments": {
-                          "baspiRef": "A11.1.3.3",
+                          "baspi4Ref": "A11.1.3.3",
+                          "baspi5Ref": "A11.1.3.3",
                           "ta6Ref": "7.4a",
                           "title": "Please supply a copy of the report",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details", "attachments"],
+                      "baspi4Required": ["details", "attachments"],
+                      "baspi5Required": ["details", "attachments"],
                       "ta6Required": ["details", "attachments"]
                     }
                   ],
                   "ta6Required": ["yesNo"]
                 },
                 "remedialMeasuresOnConstruction": {
-                  "baspiRef": "A11.1.3.4",
+                  "baspi4Ref": "A11.1.3.4",
+                  "baspi5Ref": "A11.1.3.4",
                   "rdsRef": "Sustainability/Environmental|Natural|Situational",
                   "ta6Ref": "7.5",
                   "title": "Were any remedial measures undertaken on construction to reduce Radon gas levels on the property?",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A11.1.3.4.1",
+                      "baspi4Ref": "A11.1.3.4.1",
+                      "baspi5Ref": "A11.1.3.4.1",
                       "ta6Ref": "7.5.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No", "Not known"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"]
                 }
               },
@@ -21296,6 +22726,7 @@
             "coastalErosion": {
               "ntsRef": "C3.2",
               "ntslRef": "C3.2",
+              "baspi5Ref": "A11.1.2",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
               "title": "Coastal erosion",
               "type": "object",
@@ -21407,7 +22838,8 @@
               ]
             },
             "otherEnvironmental": {
-              "baspiRef": "A11.1.4",
+              "baspi4Ref": "A11.1.4",
+              "baspi5Ref": "A11.1.4",
               "piqRef": "A11.5",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
               "title": "To your knowledge, have there been any other environmental issues that affect the property or garden (for example, these could include air pollution, mining, sink holes, quarrying or fracking etc)?",
@@ -21415,13 +22847,15 @@
               "properties": {
                 "riskIndicator": {
                   "piqRef": "A11.5.1",
-                  "baspiRef": "A11.1.4.1",
+                  "baspi4Ref": "A11.1.4.1",
+                  "baspi5Ref": "A11.1.4.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["riskIndicator"],
+              "baspi4Required": ["riskIndicator"],
+              "baspi5Required": ["riskIndicator"],
               "discriminator": {
                 "propertyName": "riskIndicator"
               },
@@ -21439,45 +22873,56 @@
                       "enum": ["Yes"]
                     },
                     "summary": {
-                      "baspiRef": "A11.1.4.2",
+                      "baspi4Ref": "A11.1.4.2",
+                      "baspi5Ref": "A11.1.4.2",
                       "title": "Please provide details. For example the level of air pollution, location of fracking etc, and whether any action has been taken to prevent harm.",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["summary"]
+                  "baspi4Required": ["summary"],
+                  "baspi5Required": ["summary"]
                 }
               ]
             }
           }
         },
         "otherIssues": {
-          "baspiRef": "A11",
+          "baspi4Ref": "A11",
+          "baspi5Ref": "A11",
           "title": "Other Issues Affecting the Property",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
             "excessiveNoise",
             "crime",
             "cautionOrConviction",
             "failedTransactionsInLast12Months"
           ],
+          "baspi5Required": [
+            "excessiveNoise",
+            "crime",
+            "failedTransactionsInLast12Months"
+          ],
           "properties": {
             "excessiveNoise": {
-              "baspiRef": "A11.2",
+              "baspi4Ref": "A11.2",
+              "baspi5Ref": "A11.3",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "piqRef": "A11.2",
               "title": "To your knowledge, has anyone occupying the property been disturbed by excessive noise which is likely to reoccur at the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.2.1",
+                  "baspi4Ref": "A11.2.1",
+                  "baspi5Ref": "A11.3.1",
                   "type": "string",
                   "piqRef": "A11.2.1",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21495,38 +22940,44 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A11.2.2",
+                      "baspi4Ref": "A11.2.2",
+                      "baspi5Ref": "A11.3.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A11.2.3",
+                      "baspi4Ref": "A11.2.3",
+                      "baspi5Ref": "A11.3.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "crime": {
-              "baspiRef": "A11.3",
+              "baspi4Ref": "A11.3",
+              "baspi5Ref": "A11.4",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "piqRef": "A11.3",
               "title": "To your knowledge, has the property been subject to any crime, burglary or violent death?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.3.1",
+                  "baspi4Ref": "A11.3.1",
+                  "baspi5Ref": "A11.4.1",
                   "type": "string",
                   "title": "",
                   "piqRef": "A11.3.1",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21544,36 +22995,40 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A11.3.2",
+                      "baspi4Ref": "A11.3.2",
+                      "baspi5Ref": "A11.4.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A11.3.3",
+                      "baspi4Ref": "A11.3.3",
+                      "baspi5Ref": "A11.4.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "cautionOrConviction": {
-              "baspiRef": "A11.4",
+              "baspi4Ref": "A11.4",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "title": "To your knowledge, has the property been occupied by someone who has been cautioned or convicted of a serious crime?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.4.1",
+                  "baspi4Ref": "A11.4.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21591,38 +23046,42 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A11.4.2",
+                      "baspi4Ref": "A11.4.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A11.4.3",
+                      "baspi4Ref": "A11.4.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "failedTransactionsInLast12Months": {
-              "baspiRef": "A11.5",
+              "baspi4Ref": "A11.5",
+              "baspi5Ref": "A11.5",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "piqRef": "A11.6",
               "title": "Have there been any failed purchase transactions on the property within the last 12 months?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.5.1",
+                  "baspi4Ref": "A11.5.1",
+                  "baspi5Ref": "A11.5.1",
                   "piqRef": "A11.6.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21640,30 +23099,39 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A11.5.2",
+                      "baspi4Ref": "A11.5.2",
+                      "baspi5Ref": "A11.5.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A11.5.3",
+                      "baspi4Ref": "A11.5.3",
+                      "baspi5Ref": "A11.5.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             }
           }
         },
         "additionalInformation": {
-          "baspiRef": "A12",
+          "baspi4Ref": "A12",
+          "baspi5Ref": "A12",
           "ta6Ref": "10",
           "title": "Additional Information",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "restrictionsOnUseNotCompliedWith",
+            "otherMaterialIssue",
+            "otherCharges"
+          ],
+          "baspi5Required": [
             "restrictionsOnUseNotCompliedWith",
             "otherMaterialIssue",
             "otherCharges"
@@ -21671,21 +23139,24 @@
           "ta6Required": ["otherCharges"],
           "properties": {
             "restrictionsOnUseNotCompliedWith": {
-              "baspiRef": "A12.1",
+              "baspi4Ref": "A12.1",
+              "baspi5Ref": "A12.1",
               "rdsRef": "Use/NonCompliance",
               "piqRef": "A12.1",
               "title": "Are you aware of any restrictions on the use or alteration of the property which have not been complied with?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.1.1",
+                  "baspi4Ref": "A12.1.1",
+                  "baspi5Ref": "A12.1.1",
                   "piqRef": "A12.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21703,25 +23174,29 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A12.1.2",
+                      "baspi4Ref": "A12.1.2",
+                      "baspi5Ref": "A12.1.2",
                       "piqRef": "A12.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A12.1.3",
+                      "baspi4Ref": "A12.1.3",
+                      "baspi5Ref": "A12.1.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "otherMaterialIssue": {
-              "baspiRef": "A12.2",
+              "baspi4Ref": "A12.2",
+              "baspi5Ref": "A12.2",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "piqRef": "A12.2",
               "title": "Are you aware of any other material issue or information which relates to the property or has anything occurred which may affect the average person’s decision to proceed?",
@@ -21729,14 +23204,16 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.2.1",
+                  "baspi4Ref": "A12.2.1",
+                  "baspi5Ref": "A12.2.1",
                   "piqRef": "A12.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21754,38 +23231,44 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A12.2.2",
+                      "baspi4Ref": "A12.2.2",
+                      "baspi5Ref": "A12.2.2",
                       "piqRef": "A12.2.2",
                       "title": "Please describe this issue and any action that has been taken, if applicable.",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A12.2.3",
+                      "baspi4Ref": "A12.2.3",
+                      "baspi5Ref": "A12.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "otherCharges": {
-              "baspiRef": "A12.3",
+              "baspi4Ref": "A12.3",
+              "baspi5Ref": "A12.3",
               "ta6Ref": "10.1",
               "title": "Does the seller have to pay any charges relating to the property (excluding any payments such as council tax, utility charges, etc.), for example payments to a management company?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.3.1",
+                  "baspi4Ref": "A12.3.1",
+                  "baspi5Ref": "A12.3.1",
                   "ta6Ref": "10.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -21804,14 +23287,16 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A12.3.2",
+                      "baspi4Ref": "A12.3.2",
+                      "baspi5Ref": "A12.3.2",
                       "ta6Ref": "10.1.2",
                       "title": "Please give details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -21830,13 +23315,16 @@
           }
         },
         "consumerProtectionRegulationsDeclaration": {
-          "baspiRef": "A13",
+          "baspi4Ref": "A13",
+          "baspi5Ref": "A13",
           "title": "Consumer Protection Regulations Declaration",
           "type": "object",
-          "baspiRequired": ["consumerProtectionRegulationsResponse"],
+          "baspi4Required": ["consumerProtectionRegulationsResponse"],
+          "baspi5Required": ["consumerProtectionRegulationsResponse"],
           "properties": {
             "consumerProtectionRegulationsResponse": {
-              "baspiRef": "A13.1",
+              "baspi4Ref": "A13.1",
+              "baspi5Ref": "A13.1",
               "title": "Seller’s declaration",
               "description": "I/we confirm the answers to be truthful and accurate and to the best of my/our knowledge. The questions have been designed to assist with the disclosure of material information and any misleading or incorrect answers are likely to be exposed later in the legal process which may hinder my/our sale. I/we will provide my property lawyer with the additional documentation in support of the information supplied on this form. If there are any changes which alter the information provided, I/we will immediately notify the person marketing the property as well as my/our property lawyer.",
               "type": "boolean"
@@ -21845,26 +23333,32 @@
         },
 
         "legalOwners": {
-          "baspiRef": "B1",
+          "baspi4Ref": "B1",
+          "baspi5Ref": "B1",
           "title": "Legal Owners",
           "type": "object",
-          "baspiRequired": ["namesOfLegalOwners"],
+          "baspi4Required": ["namesOfLegalOwners"],
+          "baspi5Required": ["namesOfLegalOwners"],
           "properties": {
             "namesOfLegalOwners": {
-              "baspiRef": "B1.1",
+              "baspi4Ref": "B1.1",
+              "baspi5Ref": "B1.1",
               "rdsRef": "RightsHolders",
               "piqRef": "B1.1",
               "title": "Names of all legal owners",
               "type": "array",
               "minItems": 1,
               "items": {
-                "baspiRef": "B1.1",
+                "baspi4Ref": "B1.1",
+                "baspi5Ref": "B1.1",
                 "title": "Legal owner",
                 "type": "object",
-                "baspiRequired": ["ownerType"],
+                "baspi4Required": ["ownerType"],
+                "baspi5Required": ["ownerType"],
                 "properties": {
                   "ownerType": {
-                    "baspiRef": "B1.1.1",
+                    "baspi4Ref": "B1.1.1",
+                    "baspi5Ref": "B1.1.1",
                     "type": "string",
                     "title": "Type of owner",
                     "enum": ["Private individual", "Organisation"]
@@ -21880,24 +23374,28 @@
                         "enum": ["Private individual"]
                       },
                       "firstName": {
-                        "baspiRef": "B1.1.2",
+                        "baspi4Ref": "B1.1.2",
+                        "baspi5Ref": "B1.1.2",
                         "title": "First name",
                         "type": "string",
                         "minLength": 1
                       },
                       "middleNames": {
-                        "baspiRef": "B1.1.3",
+                        "baspi4Ref": "B1.1.3",
+                        "baspi5Ref": "B1.1.3",
                         "title": "Middle names",
                         "type": "string"
                       },
                       "lastName": {
-                        "baspiRef": "B1.1.4",
+                        "baspi4Ref": "B1.1.4",
+                        "baspi5Ref": "B1.1.4",
                         "title": "Last name",
                         "type": "string",
                         "minLength": 1
                       }
                     },
-                    "baspiRequired": ["firstName", "lastName"]
+                    "baspi4Required": ["firstName", "lastName"],
+                    "baspi5Required": ["firstName", "lastName"]
                   },
                   {
                     "properties": {
@@ -21905,13 +23403,15 @@
                         "enum": ["Organisation"]
                       },
                       "organisationName": {
-                        "baspiRef": "B1.1.5",
+                        "baspi4Ref": "B1.1.5",
+                        "baspi5Ref": "B1.1.5",
                         "title": "Organisation name",
                         "type": "string",
                         "minLength": 1
                       }
                     },
-                    "baspiRequired": ["organisationName"]
+                    "baspi4Required": ["organisationName"],
+                    "baspi5Required": ["organisationName"]
                   }
                 ]
               }
@@ -21919,13 +23419,24 @@
           }
         },
         "legalBoundaries": {
-          "baspiRef": "B2.1",
+          "baspi4Ref": "B2.1",
+          "baspi5Ref": "B2.1",
           "ta6Ref": "1",
           "piqRef": "B3.1",
           "title": "Legal Boundaries",
           "description": "",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "partOutsideLegalOwnership",
+            "partOnSeparateSiteOrDeed",
+            "boundariesDifferFromTitlePlan",
+            "boundaryAlterationProposal",
+            "ownership",
+            "haveBoundaryFeaturesMoved",
+            "adjacentLandIncluded",
+            "flyingFreehold"
+          ],
+          "baspi5Required": [
             "partOutsideLegalOwnership",
             "partOnSeparateSiteOrDeed",
             "boundariesDifferFromTitlePlan",
@@ -21943,21 +23454,24 @@
           ],
           "properties": {
             "partOutsideLegalOwnership": {
-              "baspiRef": "A9.1",
+              "baspi4Ref": "A9.1",
+              "baspi5Ref": "A9.1",
               "rdsRef": "Tenure/Interests",
               "piqRef": "A9.1",
               "title": "Is any part of the property outside the seller’s legal ownership?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.1.1",
+                  "baspi4Ref": "A9.1.1",
+                  "baspi5Ref": "A9.1.1",
                   "piqRef": "A9.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21975,31 +23489,36 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A9.1.2",
+                      "baspi4Ref": "A9.1.2",
+                      "baspi5Ref": "A9.1.2",
                       "piqRef": "A9.1.2",
                       "title": "Please provide details. E.g. parking, garden, outbuilding, accessway, etc",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "partOnSeparateSiteOrDeed": {
-              "baspiRef": "A9.2",
+              "baspi4Ref": "A9.2",
+              "baspi5Ref": "A9.2",
               "rdsRef": "Tenure *with different property entity and references etc*",
               "title": "Is any part of the property on a separate site or separate title number e.g. garden, outbuilding, parking, garage?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.2.1",
+                  "baspi4Ref": "A9.2.1",
+                  "baspi5Ref": "A9.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -22017,30 +23536,35 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A9.2.2",
+                      "baspi4Ref": "A9.2.2",
+                      "baspi5Ref": "A9.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "boundariesDifferFromTitlePlan": {
-              "baspiRef": "A9.3",
+              "baspi4Ref": "A9.3",
+              "baspi5Ref": "A9.3",
               "rdsRef": "Tenure/Boundaries,Tenure/BoundaryDifferences,Tenure/CadastralMapOfParcels",
               "title": "Do the boundaries differ from those shown on the title plan?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.3.1",
+                  "baspi4Ref": "A9.3.1",
+                  "baspi5Ref": "A9.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -22058,38 +23582,44 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A9.3.2",
+                      "baspi4Ref": "A9.3.2",
+                      "baspi5Ref": "A9.3.2",
                       "title": "Please provide details of how they differ and why they changed and provide a plan showing where you believe the boundaries are",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "A9.3.3",
+                      "baspi4Ref": "A9.3.3",
+                      "baspi5Ref": "A9.3.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"]
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"]
                 }
               ]
             },
             "boundaryAlterationProposal": {
-              "baspiRef": "A9.4",
+              "baspi4Ref": "A9.4",
+              "baspi5Ref": "A9.4",
               "rdsRef": "Tenure/Boundaries/proposedAlterations=?",
               "piqRef": "A9.2",
               "title": "Is there a current proposal with anyone to alter the boundaries of your property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.4.1",
+                  "baspi4Ref": "A9.4.1",
+                  "baspi5Ref": "A9.4.1",
                   "piqRef": "A9.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -22107,29 +23637,34 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "A9.4.2",
+                      "baspi4Ref": "A9.4.2",
+                      "baspi5Ref": "A9.4.2",
                       "piqRef": "A9.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"]
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"]
                 }
               ]
             },
             "ownership": {
-              "baspiRef": "B2.1.0",
+              "baspi4Ref": "B2.1.0",
+              "baspi5Ref": "B2.1.0",
               "ta6Ref": "1",
               "rdsRef": "Tenure/Boundaries",
               "title": "Boundary ownership",
               "description": "If the property is leasehold this section, or parts of it, may not apply.",
               "type": "object",
-              "baspiRequired": ["areBoundariesUniform"],
+              "baspi4Required": ["areBoundariesUniform"],
+              "baspi5Required": ["areBoundariesUniform"],
               "ta6Required": ["areBoundariesUniform"],
               "properties": {
                 "areBoundariesUniform": {
-                  "baspiRef": "B2.1.0.1",
+                  "baspi4Ref": "B2.1.0.1",
+                  "baspi5Ref": "B2.1.0.1",
                   "ta6Ref": "1.2",
                   "title": "Are the boundaries uniform?",
                   "type": "string",
@@ -22146,14 +23681,16 @@
                       "enum": ["Yes"]
                     },
                     "uniformBoundaries": {
-                      "baspiRef": "B2.1.0.2",
+                      "baspi4Ref": "B2.1.0.2",
+                      "baspi5Ref": "B2.1.0.2",
                       "ta6Ref": "1.1",
                       "title": "Please indicate who has repaired, or treated as belonging to them, each of the boundaries. Identify each boundary as if you were looking at the property from the road.",
                       "ta6title": "Looking towards the property from the road, who owns or accepts responsibility to maintain or repair the boundary features:",
                       "type": "object",
                       "properties": {
                         "left": {
-                          "baspiRef": "B2.1.1",
+                          "baspi4Ref": "B2.1.1",
+                          "baspi5Ref": "B2.1.1",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1a",
                           "piqRef": "B3.1.1",
@@ -22162,7 +23699,8 @@
                           "enum": ["Seller", "Shared", "Neighbour", "Not known"]
                         },
                         "right": {
-                          "baspiRef": "B2.1.2",
+                          "baspi4Ref": "B2.1.2",
+                          "baspi5Ref": "B2.1.2",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1b",
                           "piqRef": "B3.1.2",
@@ -22171,7 +23709,8 @@
                           "enum": ["Seller", "Shared", "Neighbour", "Not known"]
                         },
                         "rear": {
-                          "baspiRef": "B2.1.3",
+                          "baspi4Ref": "B2.1.3",
+                          "baspi5Ref": "B2.1.3",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1c",
                           "piqRef": "B3.1.3",
@@ -22180,7 +23719,8 @@
                           "enum": ["Seller", "Shared", "Neighbour", "Not known"]
                         },
                         "front": {
-                          "baspiRef": "B2.1.4",
+                          "baspi4Ref": "B2.1.4",
+                          "baspi5Ref": "B2.1.4",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1d",
                           "piqRef": "B3.1.4",
@@ -22189,7 +23729,8 @@
                           "enum": ["Seller", "Shared", "Neighbour", "Not known"]
                         }
                       },
-                      "baspiRequired": ["left", "right", "rear", "front"],
+                      "baspi4Required": ["left", "right", "rear", "front"],
+                      "baspi5Required": ["left", "right", "rear", "front"],
                       "ta6Required": ["left", "right", "rear", "front"]
                     }
                   }
@@ -22200,21 +23741,24 @@
                       "enum": ["No"]
                     },
                     "details": {
-                      "baspiRef": "B2.1.5",
+                      "baspi4Ref": "B2.1.5",
+                      "baspi5Ref": "B2.1.5",
                       "ta6Ref": "1.2.1",
                       "title": "Please indicate ownership or those you have repaired by written description or marking them on a plan of the property",
                       "type": "string",
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "B2.1.6",
+                      "baspi4Ref": "B2.1.6",
+                      "baspi5Ref": "B2.1.6",
                       "ta6Ref": "1.2.2",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details", "attachments"],
+                  "baspi4Required": ["details", "attachments"],
+                  "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details", "attachments"]
                 },
                 {
@@ -22227,7 +23771,8 @@
               ]
             },
             "haveBoundaryFeaturesMoved": {
-              "baspiRef": "B2.2",
+              "baspi4Ref": "B2.2",
+              "baspi5Ref": "B2.2",
               "rdsRef": "Tenure/Boundaries",
               "ta6Ref": "1.3",
               "piqRef": "B3.3",
@@ -22236,7 +23781,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.2.1",
+                  "baspi4Ref": "B2.2.1",
+                  "baspi5Ref": "B2.2.1",
                   "piqRef": "B3.3.1",
                   "ta6Ref": "1.3.1",
                   "type": "string",
@@ -22244,7 +23790,8 @@
                   "enum": ["Yes", "No", "Not applicable"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22263,7 +23810,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B2.2.2",
+                      "baspi4Ref": "B2.2.2",
+                      "baspi5Ref": "B2.2.2",
                       "ta6Ref": "1.3.2",
                       "piqRef": "B3.3.2",
                       "title": "Details",
@@ -22271,13 +23819,15 @@
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "adjacentLandIncluded": {
-              "baspiRef": "B2.3",
+              "baspi4Ref": "B2.3",
+              "baspi5Ref": "B2.3",
               "rdsRef": "Property/Flags,Property/GUID/name='UPRN'&id=?",
               "ta6Ref": "1.4",
               "title": "Has any adjacent land or property been purchased by you that will be included in the sale?",
@@ -22285,7 +23835,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.3.1",
+                  "baspi4Ref": "B2.3.1",
+                  "baspi5Ref": "B2.3.1",
                   "ta6Ref": "1.4.1",
                   "piqRef": "B3.4",
                   "type": "string",
@@ -22293,7 +23844,8 @@
                   "enum": ["Yes", "No", "Not applicable"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22312,20 +23864,23 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B2.3.2",
+                      "baspi4Ref": "B2.3.2",
+                      "baspi5Ref": "B2.3.2",
                       "ta6Ref": "1.4.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "flyingFreehold": {
-              "baspiRef": "B2.5",
+              "baspi4Ref": "B2.5",
+              "baspi5Ref": "B2.5",
               "rdsRef": "Tenure/tenure=?",
               "ta6Ref": "1.5",
               "title": "Is there a flying freehold?",
@@ -22335,14 +23890,16 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.5.1",
+                  "baspi4Ref": "B2.5.1",
+                  "baspi5Ref": "B2.5.1",
                   "ta6Ref": "1.5.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not applicable"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22361,14 +23918,16 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B2.5.2",
+                      "baspi4Ref": "B2.5.2",
+                      "baspi5Ref": "B2.5.2",
                       "ta6Ref": "1.5.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -22376,11 +23935,17 @@
           }
         },
         "servicesCrossing": {
-          "baspiRef": "B3",
+          "baspi4Ref": "B3",
+          "baspi5Ref": "B3",
           "ta6Ref": "8",
           "title": "Services Crossing Other Property",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "pipesWiresCablesDrainsToProperty",
+            "pipesWiresCablesDrainsFromProperty",
+            "formalOrInformalAgreements"
+          ],
+          "baspi5Required": [
             "pipesWiresCablesDrainsToProperty",
             "pipesWiresCablesDrainsFromProperty",
             "formalOrInformalAgreements"
@@ -22392,7 +23957,8 @@
           ],
           "properties": {
             "pipesWiresCablesDrainsToProperty": {
-              "baspiRef": "B3.1",
+              "baspi4Ref": "B3.1",
+              "baspi5Ref": "B3.1",
               "rdsRef": "Services/.../Located",
               "ta6Ref": "8.7",
               "piqRef": "B4.1",
@@ -22401,7 +23967,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.1.1",
+                  "baspi4Ref": "B3.1.1",
+                  "baspi5Ref": "B3.1.1",
                   "ta6Ref": "8.7.1",
                   "piqRef": "B4.1.1",
                   "type": "string",
@@ -22409,7 +23976,8 @@
                   "enum": ["Yes", "No", "Not known"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22428,7 +23996,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B3.1.2",
+                      "baspi4Ref": "B3.1.2",
+                      "baspi5Ref": "B3.1.2",
                       "piqRef": "B4.1.2",
                       "ta6Ref": "8.7.2",
                       "title": "Please provide details",
@@ -22436,19 +24005,22 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "B3.1.3",
+                      "baspi4Ref": "B3.1.3",
+                      "baspi5Ref": "B3.1.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "pipesWiresCablesDrainsFromProperty": {
-              "baspiRef": "B3.2",
+              "baspi4Ref": "B3.2",
+              "baspi5Ref": "B3.2",
               "rdsRef": "Services/.../Located *with Property entities and references for the related properties etc",
               "ta6Ref": "8.8",
               "piqRef": "B4.2",
@@ -22457,7 +24029,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.2.1",
+                  "baspi4Ref": "B3.2.1",
+                  "baspi5Ref": "B3.2.1",
                   "ta6Ref": "8.8.1",
                   "piqRef": "B4.2.1",
                   "type": "string",
@@ -22465,7 +24038,8 @@
                   "enum": ["Yes", "No", "Not known"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22484,7 +24058,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B3.2.2",
+                      "baspi4Ref": "B3.2.2",
+                      "baspi5Ref": "B3.2.2",
                       "ta6Ref": "8.8.2",
                       "piqRef": "B4.2.2",
                       "title": "Please provide details",
@@ -22492,19 +24067,22 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "B3.2.3",
+                      "baspi4Ref": "B3.2.3",
+                      "baspi5Ref": "B3.2.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "formalOrInformalAgreements": {
-              "baspiRef": "B3.3",
+              "baspi4Ref": "B3.3",
+              "baspi5Ref": "B3.3",
               "rdsRef": "Services/.../Consent",
               "ta6Ref": "8.9",
               "piqRef": "B4.3",
@@ -22513,7 +24091,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.3.1",
+                  "baspi4Ref": "B3.3.1",
+                  "baspi5Ref": "B3.3.1",
                   "ta6Ref": "8.9.1",
                   "piqRef": "B4.3.1",
                   "type": "string",
@@ -22521,7 +24100,8 @@
                   "enum": ["Yes", "No", "Not known"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22540,7 +24120,8 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B3.3.2",
+                      "baspi4Ref": "B3.3.2",
+                      "baspi5Ref": "B3.3.2",
                       "ta6Ref": "8.9.2",
                       "piqRef": "B4.3.2",
                       "title": "Please provide details",
@@ -22548,14 +24129,16 @@
                       "minLength": 1
                     },
                     "attachments": {
-                      "baspiRef": "B3.3.3",
+                      "baspi4Ref": "B3.3.3",
+                      "baspi5Ref": "B3.3.3",
                       "ta6Ref": "8.9.3",
                       "title": "Please supply a copy",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
@@ -22563,11 +24146,16 @@
           }
         },
         "electricalWorks": {
-          "baspiRef": "B4",
+          "baspi4Ref": "B4",
+          "baspi5Ref": "B4",
           "ta6Ref": "12",
           "title": "Electrical Works",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "testedByQualifiedElectrician",
+            "electricalWorkSince2005"
+          ],
+          "baspi5Required": [
             "testedByQualifiedElectrician",
             "electricalWorkSince2005"
           ],
@@ -22577,7 +24165,8 @@
           ],
           "properties": {
             "testedByQualifiedElectrician": {
-              "baspiRef": "B4.1",
+              "baspi4Ref": "B4.1",
+              "baspi5Ref": "B4.1",
               "rdsRef": "Objects/Servicing",
               "ta6Ref": "12.1",
               "piqRef": "B7.1",
@@ -22585,7 +24174,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B4.1.1",
+                  "baspi4Ref": "B4.1.1",
+                  "baspi5Ref": "B4.1.1",
                   "ta6Ref": "12.1.1",
                   "piqRef": "B7.1.1",
                   "type": "string",
@@ -22593,7 +24183,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22612,27 +24203,31 @@
                       "enum": ["Yes"]
                     },
                     "yearTested": {
-                      "baspiRef": "B4.1.2",
+                      "baspi4Ref": "B4.1.2",
+                      "baspi5Ref": "B4.1.2",
                       "ta6Ref": "12.1.2",
                       "piqRef": "B7.1.2",
                       "title": "State the year they were last tested",
                       "type": "integer"
                     },
                     "attachments": {
-                      "baspiRef": "B4.1.3",
+                      "baspi4Ref": "B4.1.3",
+                      "baspi5Ref": "B4.1.3",
                       "ta6Ref": "12.1.3",
                       "title": "Please upload the test certificate.",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
                   },
-                  "baspiRequired": ["yearTested", "attachments"],
+                  "baspi4Required": ["yearTested", "attachments"],
+                  "baspi5Required": ["yearTested", "attachments"],
                   "ta6Required": ["yearTested", "attachments"]
                 }
               ]
             },
             "electricalWorkSince2005": {
-              "baspiRef": "B4.2",
+              "baspi4Ref": "B4.2",
+              "baspi5Ref": "B4.2",
               "rdsRef": "WorksAlterationsChanges/Consent,WorksAlterationsChanges/Consent/Certificates",
               "ta6Ref": "12.2",
               "piqRef": "B7.2",
@@ -22640,16 +24235,19 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B4.2.1",
+                  "baspi4Ref": "B4.2.1",
+                  "baspi5Ref": "B4.2.1",
                   "ta6Ref": "12.2.1",
                   "piqRef": "B7.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not known"],
-                  "baspiEnum": ["Yes", "No"]
+                  "baspi4Enum": ["Yes", "No"],
+                  "baspi5Enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -22668,13 +24266,15 @@
                       "enum": ["Yes"]
                     },
                     "yearWorkCarriedOut": {
-                      "baspiRef": "B4.2.2",
+                      "baspi4Ref": "B4.2.2",
+                      "baspi5Ref": "B4.2.2",
                       "piqRef": "B7.2.2",
                       "title": "State the year the work was carried out",
                       "type": "integer"
                     },
                     "details": {
-                      "baspiRef": "B4.2.3",
+                      "baspi4Ref": "B4.2.3",
+                      "baspi5Ref": "B4.2.3",
                       "title": "Provide details",
                       "type": "string",
                       "minLength": 1
@@ -22682,13 +24282,16 @@
                     "suppliedCertificate": {
                       "title": "Please supply one of the following:",
                       "type": "object",
-                      "baspiRef": "B4.2.4.1",
+                      "baspi4Ref": "B4.2.4.1",
+                      "baspi5Ref": "B4.2.4.1",
                       "ta6Ref": "12.2.2a",
-                      "baspiRequired": ["certificateType", "attachments"],
+                      "baspi4Required": ["certificateType", "attachments"],
+                      "baspi5Required": ["certificateType", "attachments"],
                       "ta6Required": ["certificateType", "attachments"],
                       "properties": {
                         "certificateType": {
-                          "baspiRef": "B4.2.3.1",
+                          "baspi4Ref": "B4.2.3.1",
+                          "baspi5Ref": "B4.2.3.1",
                           "ta6Ref": "12.2.2a.1",
                           "type": "string",
                           "enum": [
@@ -22698,7 +24301,8 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B4.2.3.2",
+                          "baspi4Ref": "B4.2.3.2",
+                          "baspi5Ref": "B4.2.3.2",
                           "ta6Ref": "12.2.2a.2",
                           "title": "Attachments",
                           "type": "string",
@@ -22707,7 +24311,12 @@
                       }
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "yearWorkCarriedOut",
+                    "details",
+                    "suppliedCertificate"
+                  ],
+                  "baspi5Required": [
                     "yearWorkCarriedOut",
                     "details",
                     "suppliedCertificate"
@@ -22719,13 +24328,16 @@
           }
         },
         "smartHomeSystems": {
-          "baspiRef": "B7.4",
+          "baspi4Ref": "B7.4",
+          "baspi5Ref": "B7.4",
           "title": "Smart Home Systems",
           "type": "object",
-          "baspiRequired": ["hasSmartHomeSystems"],
+          "baspi4Required": ["hasSmartHomeSystems"],
+          "baspi5Required": ["hasSmartHomeSystems"],
           "properties": {
             "hasSmartHomeSystems": {
-              "baspiRef": "B7.4.1",
+              "baspi4Ref": "B7.4.1",
+              "baspi5Ref": "B7.4.1",
               "title": "Are there Smart Home Systems at the property?",
               "description": "If so please indicate which are included in the sale",
               "type": "string",
@@ -22749,19 +24361,22 @@
                   "enum": ["Yes"]
                 },
                 "heatingAndPower": {
-                  "baspiRef": "B7.4.2",
+                  "baspi4Ref": "B7.4.2",
+                  "baspi5Ref": "B7.4.2",
                   "title": "Heating and Power",
                   "description": "E.g. remote boiler control, solar panels, EV charging point, power storage, indoor or outdoor lighting systems",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.2.1",
+                      "baspi4Ref": "B7.4.2.1",
+                      "baspi5Ref": "B7.4.2.1",
                       "type": "string",
                       "title": "Included",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22779,30 +24394,35 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B7.4.2.2",
+                          "baspi4Ref": "B7.4.2.2",
+                          "baspi5Ref": "B7.4.2.2",
                           "title": "Please provide the name of the service/system",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "security": {
                   "title": "Security",
-                  "baspiRef": "B7.4.3",
+                  "baspi4Ref": "B7.4.3",
+                  "baspi5Ref": "B7.4.3",
                   "description": "E.g. CCTV, alarms, barriers, doors or gates",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.3.1",
+                      "baspi4Ref": "B7.4.3.1",
+                      "baspi5Ref": "B7.4.3.1",
                       "type": "string",
                       "title": "Included",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22820,30 +24440,35 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B7.4.3.2",
+                          "baspi4Ref": "B7.4.3.2",
+                          "baspi5Ref": "B7.4.3.2",
                           "title": "Please provide the name of the service/system",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "entertainment": {
-                  "baspiRef": "B7.4.4",
+                  "baspi4Ref": "B7.4.4",
+                  "baspi5Ref": "B7.4.4",
                   "title": "Entertainment",
                   "description": "E.g. integrated audio system",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.4.1",
+                      "baspi4Ref": "B7.4.4.1",
+                      "baspi5Ref": "B7.4.4.1",
                       "type": "string",
                       "title": "Included",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22861,24 +24486,33 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B7.4.4.2",
+                          "baspi4Ref": "B7.4.4.2",
+                          "baspi5Ref": "B7.4.4.2",
                           "title": "Please provide the name of the service/system",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["details"]
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"]
                     }
                   ]
                 },
                 "handoverOnCompletion": {
-                  "baspiRef": "B7.4.2",
+                  "baspi4Ref": "B7.4.2",
+                  "baspi5Ref": "B7.4.2",
                   "title": "Confirm that you will handover details on day of completion",
                   "description": "Confirm that you will provide the buyer with the login, password and link to user instructions for the relevant system(s). [NOTE: It is recommended that you reset the password before handing it over to avoid security issues by passing on your own password]",
                   "type": "boolean"
                 }
               },
-              "baspiRequired": [
+              "baspi4Required": [
+                "heatingAndPower",
+                "security",
+                "entertainment",
+                "handoverOnCompletion"
+              ],
+              "baspi5Required": [
                 "heatingAndPower",
                 "security",
                 "entertainment",
@@ -22888,15 +24522,18 @@
           ]
         },
         "guaranteesWarrantiesAndIndemnityInsurances": {
-          "baspiRef": "B5",
+          "baspi4Ref": "B5",
+          "baspi5Ref": "B5",
           "ta6Ref": "5",
           "title": "Guarantees, Warranties and Indemnity Insurances",
           "type": "object",
-          "baspiRequired": ["hasValidGuaranteesOrWarranties"],
+          "baspi4Required": ["hasValidGuaranteesOrWarranties"],
+          "baspi5Required": ["hasValidGuaranteesOrWarranties"],
           "ta6Required": ["hasValidGuaranteesOrWarranties"],
           "properties": {
             "hasValidGuaranteesOrWarranties": {
-              "baspiRef": "B5.1",
+              "baspi4Ref": "B5.1",
+              "baspi5Ref": "B5.1",
               "ta6Ref": "5.1",
               "rdsRef": "Certificates",
               "piqRef": "B5.1",
@@ -22922,7 +24559,8 @@
                   "enum": ["Yes"]
                 },
                 "newHomeWarranty": {
-                  "baspiRef": "B5.1.1",
+                  "baspi4Ref": "B5.1.1",
+                  "baspi5Ref": "B5.1.1",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1a",
                   "piqRef": "B5.1.1",
@@ -22930,14 +24568,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.1.1",
+                      "baspi4Ref": "B5.1.1.1",
+                      "baspi5Ref": "B5.1.1.1",
                       "ta6Ref": "5.1a1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -22956,34 +24596,39 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1a2",
                           "title": "Please confirm the name of the warranty provider and the date of the warranty",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.3",
+                          "baspi4Ref": "B5.1.1.3",
+                          "baspi5Ref": "B5.1.1.3",
                           "ta6Ref": "5.1a3",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details", "attachments"],
+                      "baspi4Required": ["details", "attachments"],
+                      "baspi5Required": ["details", "attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "roofingWork": {
-                  "baspiRef": "B5.1.2",
+                  "baspi4Ref": "B5.1.2",
+                  "baspi5Ref": "B5.1.2",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1f",
                   "title": "Roofing work",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.2.1",
+                      "baspi4Ref": "B5.1.2.1",
+                      "baspi5Ref": "B5.1.2.1",
                       "ta6Ref": "5.1f1",
                       "piqRef": "B5.1.2",
                       "type": "string",
@@ -22991,7 +24636,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23010,20 +24656,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1f2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "dampProofingTreatment": {
-                  "baspiRef": "B5.1.3",
+                  "baspi4Ref": "B5.1.3",
+                  "baspi5Ref": "B5.1.3",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1b",
                   "piqRef": "B5.1.3",
@@ -23031,14 +24680,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.3.1",
+                      "baspi4Ref": "B5.1.3.1",
+                      "baspi5Ref": "B5.1.3.1",
                       "ta6Ref": "5.1b1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23057,20 +24708,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1b2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "timberRotOrInfestationTreatment": {
-                  "baspiRef": "B5.1.4",
+                  "baspi4Ref": "B5.1.4",
+                  "baspi5Ref": "B5.1.4",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1c",
                   "piqRef": "B5.1.4",
@@ -23078,14 +24732,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.4.1",
+                      "baspi4Ref": "B5.1.4.1",
+                      "baspi5Ref": "B5.1.4.1",
                       "ta6Ref": "5.1c1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23104,20 +24760,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1c2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "centralHeatingAndorPlumbing": {
-                  "baspiRef": "B5.1.5",
+                  "baspi4Ref": "B5.1.5",
+                  "baspi5Ref": "B5.1.5",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1g",
                   "piqRef": "B5.1.5",
@@ -23125,14 +24784,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.5.1",
+                      "baspi4Ref": "B5.1.5.1",
+                      "baspi5Ref": "B5.1.5.1",
                       "ta6Ref": "5.1g1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23151,20 +24812,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1g2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "doubleGlazing": {
-                  "baspiRef": "B5.1.6",
+                  "baspi4Ref": "B5.1.6",
+                  "baspi5Ref": "B5.1.6",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1d",
                   "piqRef": "B5.1.6",
@@ -23172,14 +24836,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.6.1",
+                      "baspi4Ref": "B5.1.6.1",
+                      "baspi5Ref": "B5.1.6.1",
                       "ta6Ref": "5.1d1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23198,20 +24864,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1d2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "electricalRepairOrInstallation": {
-                  "baspiRef": "B5.1.7",
+                  "baspi4Ref": "B5.1.7",
+                  "baspi5Ref": "B5.1.7",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1e",
                   "piqRef": "B5.1.7",
@@ -23219,14 +24888,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.7.1",
+                      "baspi4Ref": "B5.1.7.1",
+                      "baspi5Ref": "B5.1.7.1",
                       "ta6Ref": "5.1e1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23245,20 +24916,23 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1e2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "subsidenceWork": {
-                  "baspiRef": "B5.1.8",
+                  "baspi4Ref": "B5.1.8",
+                  "baspi5Ref": "B5.1.8",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1h",
                   "piqRef": "B5.1.8",
@@ -23266,14 +24940,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.8.1",
+                      "baspi4Ref": "B5.1.8.1",
+                      "baspi5Ref": "B5.1.8.1",
                       "ta6Ref": "5.1h1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23292,33 +24968,38 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "ta6Ref": "5.1h2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"],
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"],
                       "ta6Required": ["attachments"]
                     }
                   ]
                 },
                 "solarPanels": {
-                  "baspiRef": "B5.1.9",
+                  "baspi4Ref": "B5.1.9",
+                  "baspi5Ref": "B5.1.9",
                   "rdsRef": "Certificates",
                   "piqRef": "B5.1.9",
                   "title": "Solar panels",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.9.1",
+                      "baspi4Ref": "B5.1.9.1",
+                      "baspi5Ref": "B5.1.9.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -23336,18 +25017,21 @@
                           "enum": ["Yes"]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2",
+                          "baspi4Ref": "B5.1.1.2",
+                          "baspi5Ref": "B5.1.1.2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["attachments"]
+                      "baspi4Required": ["attachments"],
+                      "baspi5Required": ["attachments"]
                     }
                   ]
                 },
                 "otherGuarantees": {
-                  "baspiRef": "B5.1.10",
+                  "baspi4Ref": "B5.1.10",
+                  "baspi5Ref": "B5.1.10",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1i",
                   "piqRef": "B5.1.10",
@@ -23355,14 +25039,16 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.10.1",
+                      "baspi4Ref": "B5.1.10.1",
+                      "baspi5Ref": "B5.1.10.1",
                       "ta6Ref": "5.1i1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23381,7 +25067,8 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B5.1.10.2",
+                          "baspi4Ref": "B5.1.10.2",
+                          "baspi5Ref": "B5.1.10.2",
                           "ta6Ref": "5.1i2",
                           "title": "Please provide details",
                           "type": "string",
@@ -23394,13 +25081,15 @@
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details"],
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
                       "ta6Required": ["details", "attachments"]
                     }
                   ]
                 },
                 "outstandingClaimsOrApplications": {
-                  "baspiRef": "B5.2",
+                  "baspi4Ref": "B5.2",
+                  "baspi5Ref": "B5.2",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.2",
                   "piqRef": "B5.2",
@@ -23409,7 +25098,8 @@
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.2.1",
+                      "baspi4Ref": "B5.2.1",
+                      "baspi5Ref": "B5.2.1",
                       "ta6Ref": "5.2.1",
                       "piqRef": "B5.2.1",
                       "type": "string",
@@ -23417,7 +25107,8 @@
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -23436,40 +25127,46 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B5.2.2",
+                          "baspi4Ref": "B5.2.2",
+                          "baspi5Ref": "B5.2.2",
                           "ta6Ref": "5.2.2",
                           "title": "Please provide details",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "B5.2.3",
+                          "baspi4Ref": "B5.2.3",
+                          "baspi5Ref": "B5.2.3",
                           "ta6Ref": "5.2.3",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details"],
+                      "baspi4Required": ["details"],
+                      "baspi5Required": ["details"],
                       "ta6Required": ["details"]
                     }
                   ]
                 },
                 "titleDefectInsurance": {
-                  "baspiRef": "B5.3",
+                  "baspi4Ref": "B5.3",
+                  "baspi5Ref": "B5.3",
                   "rdsRef": "Certificates",
                   "title": "Do you have any title defect insurance policies?",
                   "description": "e.g. for breach of planning permission, buildings regulations, restrictions, chancel repair etc",
                   "type": "object",
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.3.1",
+                      "baspi4Ref": "B5.3.1",
+                      "baspi5Ref": "B5.3.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
                     }
                   },
-                  "baspiRequired": ["yesNo"],
+                  "baspi4Required": ["yesNo"],
+                  "baspi5Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -23487,24 +25184,41 @@
                           "enum": ["Yes"]
                         },
                         "details": {
-                          "baspiRef": "B5.3.2",
+                          "baspi4Ref": "B5.3.2",
+                          "baspi5Ref": "B5.3.2",
                           "title": "Please provide details",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
-                          "baspiRef": "B5.3.3",
+                          "baspi4Ref": "B5.3.3",
+                          "baspi5Ref": "B5.3.3",
                           "title": "Policy",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
                         }
                       },
-                      "baspiRequired": ["details", "attachments"]
+                      "baspi4Required": ["details", "attachments"],
+                      "baspi5Required": ["details", "attachments"]
                     }
                   ]
                 }
               },
-              "baspiRequired": [
+              "baspi4Required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "timberRotOrInfestationTreatment",
+                "centralHeatingAndorPlumbing",
+                "doubleGlazing",
+                "electricalRepairOrInstallation",
+                "subsidenceWork",
+                "solarPanels",
+                "otherGuarantees",
+                "outstandingClaimsOrApplications",
+                "titleDefectInsurance"
+              ],
+              "baspi5Required": [
                 "newHomeWarranty",
                 "roofingWork",
                 "dampProofingTreatment",
@@ -23534,39 +25248,47 @@
           ]
         },
         "occupiers": {
-          "baspiRef": "B6",
+          "baspi4Ref": "B6",
+          "baspi5Ref": "B6",
           "ta6Ref": "11",
           "title": "Occupiers",
           "type": "object",
-          "baspiRequired": ["sellerLivesAtProperty", "othersAged17OrOver"],
+          "baspi4Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
+          "baspi5Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
           "properties": {
             "sellerLivesAtProperty": {
-              "baspiRef": "B6.1",
+              "baspi4Ref": "B6.1",
+              "baspi5Ref": "B6.1",
               "rdsRef": "Property/Flags",
               "ta6Ref": "11.1",
               "title": "Does the seller live at the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B6.1.1",
+                  "baspi4Ref": "B6.1.1",
+                  "baspi5Ref": "B6.1.1",
                   "ta6Ref": "11.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"]
             },
             "othersAged17OrOver": {
-              "baspiRef": "B6.2",
+              "baspi4Ref": "B6.2",
+              "baspi5Ref": "B6.2",
               "rdsRef": "Participants",
               "ta6Ref": "11.2",
               "type": "object",
-              "baspiRequired": ["hasOthersAged17OrOver"],
+              "baspi4Required": ["hasOthersAged17OrOver"],
+              "baspi5Required": ["hasOthersAged17OrOver"],
               "properties": {
                 "hasOthersAged17OrOver": {
-                  "baspiRef": "B6.2.1",
+                  "baspi4Ref": "B6.2.1",
+                  "baspi5Ref": "B6.2.1",
                   "rdsRef": "Participants",
                   "ta6Ref": "11.2.1",
                   "piqRef": "B8.1",
@@ -23592,7 +25314,8 @@
                       "enum": ["Yes"]
                     },
                     "aged17OrOverNames": {
-                      "baspiRef": "B6.2.2",
+                      "baspi4Ref": "B6.2.2",
+                      "baspi5Ref": "B6.2.2",
                       "ta6Ref": "11.3",
                       "piqRef": "B8.1.1",
                       "title": "Please provide their full names and ages.",
@@ -23600,32 +25323,38 @@
                       "minLength": 1
                     },
                     "aged17OrOverTenantsOrLodgers": {
-                      "baspiRef": "B6.2.3",
+                      "baspi4Ref": "B6.2.3",
+                      "baspi5Ref": "B6.2.3",
                       "rdsRef": "Property/Flags",
                       "ta6Ref": "11.4",
                       "title": "Are any of them tenants or lodgers?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B6.2.2.1",
+                          "baspi4Ref": "B6.2.2.1",
+                          "baspi5Ref": "B6.2.2.1",
                           "ta6Ref": "11.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
                         }
                       },
-                      "baspiRequired": ["yesNo"],
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"]
                     },
                     "vacantPossession": {
-                      "baspiRef": "B6.2.4",
+                      "baspi4Ref": "B6.2.4",
+                      "baspi5Ref": "B6.2.4",
                       "ta6Ref": "11.5",
                       "type": "object",
-                      "baspiRequired": ["soldWithVacantPossession"],
+                      "baspi4Required": ["soldWithVacantPossession"],
+                      "baspi5Required": ["soldWithVacantPossession"],
                       "ta6Required": ["soldWithVacantPossession"],
                       "properties": {
                         "soldWithVacantPossession": {
-                          "baspiRef": "B6.2.4.1",
+                          "baspi4Ref": "B6.2.4.1",
+                          "baspi5Ref": "B6.2.4.1",
                           "ta6Ref": "11.5.1",
                           "type": "string",
                           "title": "Is the property being sold with vacant possession?",
@@ -23642,19 +25371,22 @@
                               "enum": ["No"]
                             },
                             "details": {
-                              "baspiRef": "B6.2.4.2",
+                              "baspi4Ref": "B6.2.4.2",
+                              "baspi5Ref": "B6.2.4.2",
                               "title": "Please provide details (e.g. the property is sold let to tenants)",
                               "type": "string",
                               "minLength": 1
                             },
                             "attachments": {
-                              "baspiRef": "B6.2.4.3",
+                              "baspi4Ref": "B6.2.4.3",
+                              "baspi5Ref": "B6.2.4.3",
                               "title": "If applicable please supply a copy of the tenancy agreement together with a copy of any notice to quit which has been served upon them.",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
                           },
-                          "baspiRequired": ["details"]
+                          "baspi4Required": ["details"],
+                          "baspi5Required": ["details"]
                         },
                         {
                           "properties": {
@@ -23662,25 +25394,29 @@
                               "enum": ["Yes"]
                             },
                             "aged17OrOverAgreedToLeave": {
-                              "baspiRef": "B6.3.1",
+                              "baspi4Ref": "B6.3.1",
+                              "baspi5Ref": "B6.3.1",
                               "rdsRef": "RightsHolders,TenureAgreements,Notifications",
                               "ta6Ref": "11.5a",
                               "title": "Have all occupiers aged 17 or over agreed to leave prior to completion?",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "B6.3.1.1",
+                                  "baspi4Ref": "B6.3.1.1",
+                                  "baspi5Ref": "B6.3.1.1",
                                   "ta6Ref": "11.5a1",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "ta6Required": ["yesNo"]
                             },
                             "aged17OrOverWillSignToConfirmWillVacate": {
-                              "baspiRef": "B6.3.2",
+                              "baspi4Ref": "B6.3.2",
+                              "baspi5Ref": "B6.3.2",
                               "rdsRef": "RightsHolders,TenureAgreements,Notifications",
                               "ta6Ref": "11.5b",
                               "piqRef": "B8.2",
@@ -23688,7 +25424,8 @@
                               "type": "object",
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "B6.3.2.1",
+                                  "baspi4Ref": "B6.3.2.1",
+                                  "baspi5Ref": "B6.3.2.1",
                                   "ta6Ref": "11.5b1",
                                   "piqRef": "B8.2.1",
                                   "type": "string",
@@ -23696,7 +25433,8 @@
                                   "enum": ["Yes", "No"]
                                 }
                               },
-                              "baspiRequired": ["yesNo"],
+                              "baspi4Required": ["yesNo"],
+                              "baspi5Required": ["yesNo"],
                               "ta6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
@@ -23715,26 +25453,33 @@
                                       "enum": ["No"]
                                     },
                                     "details": {
-                                      "baspiRef": "B6.3.2.2",
+                                      "baspi4Ref": "B6.3.2.2",
+                                      "baspi5Ref": "B6.3.2.2",
                                       "title": "Please provide details (eg the property is sold let to tenants)",
                                       "type": "string",
                                       "minLength": 1
                                     },
                                     "attachments": {
-                                      "baspiRef": "B6.3.2.3",
+                                      "baspi4Ref": "B6.3.2.3",
+                                      "baspi5Ref": "B6.3.2.3",
                                       "ta6Ref": "11.5b2",
                                       "title": "Please supply other evidence that the property will be vacant on completion (a copy of the tenancy agreement together with a copy of any notice to quit which has been served upon them).",
                                       "type": "string",
                                       "enum": ["Attached", "To follow"]
                                     }
                                   },
-                                  "baspiRequired": ["details", "attachments"],
+                                  "baspi4Required": ["details", "attachments"],
+                                  "baspi5Required": ["details", "attachments"],
                                   "ta6Required": ["attachments"]
                                 }
                               ]
                             }
                           },
-                          "baspiRequired": [
+                          "baspi4Required": [
+                            "aged17OrOverAgreedToLeave",
+                            "aged17OrOverWillSignToConfirmWillVacate"
+                          ],
+                          "baspi5Required": [
                             "aged17OrOverAgreedToLeave",
                             "aged17OrOverWillSignToConfirmWillVacate"
                           ],
@@ -23746,7 +25491,12 @@
                       ]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "aged17OrOverNames",
+                    "aged17OrOverTenantsOrLodgers",
+                    "vacantPossession"
+                  ],
+                  "baspi5Required": [
                     "aged17OrOverNames",
                     "aged17OrOverTenantsOrLodgers",
                     "vacantPossession"
@@ -23764,11 +25514,19 @@
           "ta6Required": ["sellerLivesAtProperty", "othersAged17OrOver"]
         },
         "completionAndMoving": {
-          "baspiRef": "B7",
+          "baspi4Ref": "B7",
+          "baspi5Ref": "B7",
           "ta6Ref": "14",
           "title": "Completion and Moving",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "sellerWillEnsure",
+            "otherPropertyInChain",
+            "moveRestrictionDates",
+            "digitalPropertyLogbook",
+            "sufficientToRepayAllMortgages"
+          ],
+          "baspi5Required": [
             "sellerWillEnsure",
             "otherPropertyInChain",
             "moveRestrictionDates",
@@ -23783,7 +25541,8 @@
           ],
           "properties": {
             "sellerWillEnsure": {
-              "baspiRef": "B7.1",
+              "baspi4Ref": "B7.1",
+              "baspi5Ref": "B7.1",
               "rdsRef": "RightsHolders/Flags",
               "ta6Ref": "14.4",
               "title": "Please confirm that on completion you will:",
@@ -23796,28 +25555,32 @@
               ],
               "properties": {
                 "removeRubbish": {
-                  "baspiRef": "B7.1.1",
+                  "baspi4Ref": "B7.1.1",
+                  "baspi5Ref": "B7.1.1",
                   "ta6Ref": "14.4a",
                   "piqRef": "B9.3",
                   "title": "Remove all rubbish and items not included in the sale from the property (including its garden, loft and any sheds or outbuildings) and leave the property in a clean and tidy condition.",
                   "type": "boolean"
                 },
                 "replaceLightFittings": {
-                  "baspiRef": "B7.1.2",
+                  "baspi4Ref": "B7.1.2",
+                  "baspi5Ref": "B7.1.2",
                   "ta6Ref": "14.4b",
                   "piqRef": "B9.4",
                   "title": "If light fittings are removed, the fittings will be replaced with ceiling rose, flex, bulb holder and bulb.",
                   "type": "boolean"
                 },
                 "takeReasonableCare": {
-                  "baspiRef": "B7.1.3",
+                  "baspi4Ref": "B7.1.3",
+                  "baspi5Ref": "B7.1.3",
                   "ta6Ref": "14.4c",
                   "piqRef": "B9.6",
                   "title": "Take reasonable care when removing any other fittings or contents.",
                   "type": "boolean"
                 },
                 "leaveKeys": {
-                  "baspiRef": "B7.1.4",
+                  "baspi4Ref": "B7.1.4",
+                  "baspi5Ref": "B7.1.4",
                   "ta6Ref": "14.4d",
                   "piqRef": "B9.5",
                   "title": "Leave keys for all door and window locks, along with any alarm codes, for the buyer on the day of completion.",
@@ -23826,7 +25589,8 @@
               }
             },
             "otherPropertyInChain": {
-              "baspiRef": "B7.2",
+              "baspi4Ref": "B7.2",
+              "baspi5Ref": "B7.2",
               "rdsRef": "RightsHolders/Flags",
               "ta6Ref": "14.1",
               "piqRef": "B9.1",
@@ -23834,7 +25598,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.2.1",
+                  "baspi4Ref": "B7.2.1",
+                  "baspi5Ref": "B7.2.1",
                   "ta6Ref": "14.1.1",
                   "piqRef": "B9.1.1",
                   "type": "string",
@@ -23842,7 +25607,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -23861,47 +25627,59 @@
                       "enum": ["Yes"]
                     },
                     "propertyDependencyType": {
-                      "baspiRef": "B7.2.2",
+                      "baspi4Ref": "B7.2.2",
+                      "baspi5Ref": "B7.2.2",
                       "type": "string",
                       "enum": ["Sale", "Purchase", "Remortgage"]
                     },
                     "dependentPropertyAddress": {
-                      "baspiRef": "B7.2.3",
+                      "baspi4Ref": "B7.2.3",
+                      "baspi5Ref": "B7.2.3",
                       "title": "Address",
                       "type": "object",
                       "properties": {
                         "line1": {
-                          "baspiRef": "B7.2.3.1",
+                          "baspi4Ref": "B7.2.3.1",
+                          "baspi5Ref": "B7.2.3.1",
                           "title": "Address line 1",
                           "type": "string",
                           "minLength": 1
                         },
                         "line2": {
-                          "baspiRef": "B7.2.3.2",
+                          "baspi4Ref": "B7.2.3.2",
+                          "baspi5Ref": "B7.2.3.2",
                           "title": "Address line 2",
                           "type": "string"
                         },
                         "line3": {
-                          "baspiRef": "B7.2.3.3",
+                          "baspi4Ref": "B7.2.3.3",
+                          "baspi5Ref": "B7.2.3.3",
                           "title": "Address line 3",
                           "type": "string"
                         },
                         "town": {
-                          "baspiRef": "B7.2.3.4",
+                          "baspi4Ref": "B7.2.3.4",
+                          "baspi5Ref": "B7.2.3.4",
                           "title": "Town",
                           "type": "string"
                         },
                         "postcode": {
-                          "baspiRef": "B7.2.3.5",
+                          "baspi4Ref": "B7.2.3.5",
+                          "baspi5Ref": "B7.2.3.5",
                           "title": "Postcode",
                           "type": "string",
                           "minLength": 1
                         }
                       },
-                      "baspiRequired": ["line1", "postcode"]
+                      "baspi4Required": ["line1", "postcode"],
+                      "baspi5Required": ["line1", "postcode"]
                     }
                   },
-                  "baspiRequired": [
+                  "baspi4Required": [
+                    "propertyDependencyType",
+                    "dependentPropertyAddress"
+                  ],
+                  "baspi5Required": [
                     "propertyDependencyType",
                     "dependentPropertyAddress"
                   ]
@@ -23909,7 +25687,8 @@
               ]
             },
             "moveRestrictionDates": {
-              "baspiRef": "B7.3",
+              "baspi4Ref": "B7.3",
+              "baspi5Ref": "B7.3",
               "rdsRef": "RightsHolders/Text",
               "ta6Ref": "14.2",
               "piqRef": "B9.2",
@@ -23918,7 +25697,8 @@
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.3.1",
+                  "baspi4Ref": "B7.3.1",
+                  "baspi5Ref": "B7.3.1",
                   "ta6Ref": "14.2.1",
                   "piqRef": "B9.1.2",
                   "type": "string",
@@ -23926,7 +25706,8 @@
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -23945,30 +25726,35 @@
                       "enum": ["Yes"]
                     },
                     "details": {
-                      "baspiRef": "B7.3.2",
+                      "baspi4Ref": "B7.3.2",
+                      "baspi5Ref": "B7.3.2",
                       "ta6Ref": "14.2.2",
                       "type": "string"
                     }
                   },
-                  "baspiRequired": ["details"],
+                  "baspi4Required": ["details"],
+                  "baspi5Required": ["details"],
                   "ta6Required": ["details"]
                 }
               ]
             },
             "digitalPropertyLogbook": {
-              "baspiRef": "B7.5",
+              "baspi4Ref": "B7.5",
+              "baspi5Ref": "B7.5",
               "title": "Do you have a Digital Property Logbook?",
               "description": "See https://www.rlba.org.uk/what-is-a-property-logbook?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.5.1",
+                  "baspi4Ref": "B7.5.1",
+                  "baspi5Ref": "B7.5.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -23986,60 +25772,94 @@
                       "enum": ["Yes"]
                     },
                     "logbookProvider": {
-                      "baspiRef": "B7.5.2",
+                      "baspi4Ref": "B7.5.2",
+                      "baspi5Ref": "B7.5.2",
                       "title": "Please confirm the name of the existing logbook provider",
                       "type": "string",
                       "minLength": 1
                     },
                     "willHandoverLogbook": {
-                      "baspiRef": "B7.5.2",
+                      "baspi4Ref": "B7.5.2",
+                      "baspi5Ref": "B7.5.2",
                       "title": "Please confirm that on completion you will transfer it to the new owner",
                       "type": "boolean"
                     }
                   },
-                  "baspiRequired": ["logbookProvider", "willHandoverLogbook"]
+                  "baspi4Required": ["logbookProvider", "willHandoverLogbook"],
+                  "baspi5Required": ["logbookProvider", "willHandoverLogbook"]
                 }
               ]
             },
             "sufficientToRepayAllMortgages": {
-              "baspiRef": "B7.6",
+              "baspi4Ref": "B7.6",
+              "baspi5Ref": "B7.6",
               "ta6Ref": "14.3",
               "title": "Will the sale price be sufficient to repay all mortgages and charges secured on the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.6.1",
+                  "baspi4Ref": "A7.6.1",
+                  "baspi5Ref": "A7.6.1",
                   "ta6Ref": "14.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "No mortgage"]
                 }
               },
-              "baspiRequired": ["yesNo"],
+              "baspi4Required": ["yesNo"],
+              "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"]
             }
           }
         },
         "confirmationOfAccuracyByOwners": {
-          "baspiRef": "B8",
+          "baspi4Ref": "B8",
+          "baspi5Ref": "B8",
           "ta6Ref": "14.5",
           "title": "Confirmation to be supplied by all owners or their representative",
           "type": "object",
-          "baspiRequired": [
+          "baspi4Required": [
+            "confirmWillProvideAdditionalDocumentation",
+            "confirmInformationIsAccurate"
+          ],
+          "baspi5Required": [
             "confirmWillProvideAdditionalDocumentation",
             "confirmInformationIsAccurate"
           ],
           "ta6Required": ["confirmInformationIsAccurate"],
           "properties": {
             "confirmWillProvideAdditionalDocumentation": {
-              "baspiRef": "B8.1",
+              "baspi4Ref": "B8.1",
+              "baspi5Ref": "B8.1",
               "title": "I/we will provide my property lawyer with the additional documentation in support of the information supplied.",
               "type": "boolean"
             },
             "confirmInformationIsAccurate": {
-              "baspiRef": "B8.2",
+              "baspi4Ref": "B8.2",
+              "baspi5Ref": "B8.2",
               "ta6Ref": "14.5.1",
               "title": "I/we confirm that all information provided is accurate to the best of our knowledge and if we become aware of any change to/changes which alter the information supplied/provided prior to exchange of contracts for the sale of the property, I/we will update immediately notify the person marketing the property as well as my/our property lawyer",
+              "type": "boolean"
+            }
+          }
+        },
+        "saleReadyDeclarations": {
+          "sr24Ref": "1",
+          "title": "Confirmations to be supplied to confirm Sale Ready status",
+          "type": "object",
+          "sr24Required": [
+            "authorisedToActOnBehalfOfAllSellers",
+            "authorisationToShare"
+          ],
+          "properties": {
+            "authorisedToActOnBehalfOfAllSellers": {
+              "sr24Ref": "1.1",
+              "title": "I/we confirm that I am/we are authorised to supply data and documents in relation to this property on behalf of all the owners of the property",
+              "type": "boolean"
+            },
+            "authorisationToShare": {
+              "sr24Ref": "1.2",
+              "title": "I/we consent to the sharing of the information contained in the Sale Ready pack with the my/our legal representative and the buyer(s) and their legal representatives",
               "type": "boolean"
             }
           }
@@ -28415,31 +30235,66 @@
                         }
                       },
                       "propertyAddress": {
-                        "type": "object",
-                        "oc1Required": ["addressLine"],
-                        "properties": {
-                          "postcodeZone": {
-                            "type": "object",
-                            "oc1Required": ["postcode"],
-                            "properties": {
-                              "postcode": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "addressLine": {
-                            "type": "object",
-                            "properties": {
-                              "line": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "oc1Required": ["addressLine"],
+                              "properties": {
+                                "postcodeZone": {
+                                  "type": "object",
+                                  "oc1Required": ["postcode"],
+                                  "properties": {
+                                    "postcode": {
+                                      "type": "string"
+                                    }
+                                  }
                                 },
-                                "minItems": 0
+                                "addressLine": {
+                                  "type": "object",
+                                  "properties": {
+                                    "line": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minItems": 0
+                          },
+                          {
+                            "type": "object",
+                            "oc1Required": ["addressLine"],
+                            "properties": {
+                              "postcodeZone": {
+                                "type": "object",
+                                "oc1Required": ["postcode"],
+                                "properties": {
+                                  "postcode": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "addressLine": {
+                                "type": "object",
+                                "properties": {
+                                  "line": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 0
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "type": "object",
@@ -36469,6 +38324,39 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              },
+              "additionalDocuments": {
+                "title": "Additional documents referred to in title register",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "documentType": {
+                      "title": "Human-readable document type",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentTypeCode": {
+                      "title": "HMLR document type code",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentDate": {
+                      "title": "Date of original document",
+                      "type": "string",
+                      "fornat": "date"
+                    },
+                    "retrievedOn": {
+                      "title": "Datetime retrieved from HMLR",
+                      "type": "string",
+                      "fornat": "date-time"
+                    },
+                    "filedUnder": {
+                      "title": "Related title number",
+                      "type": "string"
                     }
                   }
                 }

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -179,7 +179,9 @@
               "Mortgage Broker",
               "Lender",
               "Landlord",
-              "Tenant"
+              "Tenant",
+              "Assistant",
+              "Giftor"
             ]
           },
           "externalIds": {
@@ -204,7 +206,9 @@
                   "Mortgage Broker",
                   "Lender",
                   "Landlord",
-                  "Tenant"
+                  "Tenant",
+                  "Assistant",
+                  "Giftor"
                 ]
               }
             }
@@ -231,9 +235,13 @@
                     "title": "",
                     "enum": [
                       "Legal Owner",
+                      "Deceased Owner",
                       "Personal Representative for a Deceased Owner",
                       "Under Power of Attorney",
                       "Mortgagee in Possession",
+                      "Company Director",
+		                  "Company Representative",
+		                  "Trustee",
                       "Other"
                     ]
                   }

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -196,7 +196,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -253,6 +252,13 @@
                   {
                     "properties": {
                       "capacity": {
+                        "enum": ["Deceased Owner", "Company Director", "Company Representative", "Trustee"]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
                         "enum": ["Legal Owner", "Mortgagee in Possession"]
                       },
                       "sellersCapacityDetails": {
@@ -304,6 +310,64 @@
             },
             "baspi4Required": ["sellersCapacity"],
             "baspi5Required": ["sellersCapacity"]
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": ["Buyer"]
+              },
+              "buyersCapacity": {
+                "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+                "title": "Capacity in which the Buyer buys",
+                "type": "object",
+                "properties": {
+                  "capacity": {
+                    "type": "string",
+                    "title": "",
+                    "enum": [
+                      "Legal Buyer",
+                      "Under Power of Attorney",
+                      "Company Director",
+		                  "Company Representative",
+		                  "Trustee",
+                      "Other"
+                    ]
+                  }
+                },
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": ["Legal Buyer", "Company Director", "Company Representative", "Trustee"]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "buyersCapacityDetails": {
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details and provide any grant of representation or power of attorney",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
           }
         ]
       }

--- a/src/schemas/v3/overlays/baspi4.json
+++ b/src/schemas/v3/overlays/baspi4.json
@@ -1,0 +1,7872 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/baspi4.json",
+  "required": [
+    "participants",
+    "propertyPack"
+  ],
+  "properties": {
+    "participants": {
+      "baspi4Ref": "B1",
+      "items": {
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer",
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller"
+                ]
+              },
+              "sellersCapacity": {
+                "baspi4Ref": "B1.3",
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3"
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3"
+                      }
+                    },
+                    "required": [
+                      "sellersCapacityDetails",
+                      "attachments"
+                    ]
+                  }
+                ],
+                "required": [
+                  "capacity"
+                ],
+                "properties": {
+                  "capacity": {
+                    "baspi4Ref": "B1.3.1"
+                  }
+                }
+              }
+            },
+            "required": [
+              "sellersCapacity"
+            ]
+          }
+        ],
+        "required": [
+          "name",
+          "email",
+          "role"
+        ],
+        "properties": {
+          "name": {
+            "required": [
+              "firstName",
+              "lastName"
+            ]
+          },
+          "address": {
+            "required": [
+              "line1",
+              "postcode"
+            ]
+          }
+        }
+      }
+    },
+    "propertyPack": {
+      "baspi4Ref": "0",
+      "required": [
+        "uprn",
+        "address",
+        "delayFactors",
+        "ownership",
+        "parking",
+        "listingAndConservation",
+        "typeOfConstruction",
+        "energyEfficiency",
+        "councilTax",
+        "disputesAndComplaints",
+        "alterationsAndChanges",
+        "notices",
+        "specialistIssues",
+        "fixturesAndFittings",
+        "waterAndDrainage",
+        "electricity",
+        "connectivity",
+        "heating",
+        "insurance",
+        "rightsAndInformalArrangements",
+        "environmentalIssues",
+        "otherIssues",
+        "additionalInformation",
+        "consumerProtectionRegulationsDeclaration",
+        "legalOwners",
+        "legalBoundaries",
+        "servicesCrossing",
+        "electricalWorks",
+        "smartHomeSystems",
+        "guaranteesWarrantiesAndIndemnityInsurances",
+        "occupiers",
+        "completionAndMoving",
+        "confirmationOfAccuracyByOwners"
+      ],
+      "properties": {
+        "address": {
+          "baspi4Ref": "A1.1",
+          "required": [
+            "line1",
+            "postcode"
+          ],
+          "properties": {
+            "line1": {
+              "baspi4Ref": "A1.1.1"
+            },
+            "line2": {
+              "baspi4Ref": "A1.1.2"
+            },
+            "line3": {
+              "baspi4Ref": "A1.1.3"
+            },
+            "town": {
+              "baspi4Ref": "A1.1.4"
+            },
+            "postcode": {
+              "baspi4Ref": "A1.1.5"
+            }
+          }
+        },
+        "uprn": {
+          "baspi4Ref": "A1.1.5"
+        },
+        "media": {
+          "items": {
+            "required": [
+              "mediaUrl"
+            ]
+          }
+        },
+        "delayFactors": {
+          "baspi4Ref": "A1.2",
+          "required": [
+            "hasDelayFactors"
+          ],
+          "properties": {
+            "hasDelayFactors": {
+              "baspi4Ref": "A1.2.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A10.1.1"
+                }
+              }
+            }
+          }
+        },
+        "ownership": {
+          "baspi4Ref": "A1.3",
+          "required": [
+            "ownershipsToBeTransferred"
+          ],
+          "properties": {
+            "ownershipsToBeTransferred": {
+              "baspi4Ref": "A1.3",
+              "items": {
+                "discriminator": {
+                  "propertyName": "ownershipType"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Freehold"
+                        ]
+                      },
+                      "wholeFreeholdForSale": {
+                        "baspi4Ref": "A1.3.0.2.1",
+                        "discriminator": {
+                          "propertyName": "yesNo"
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "Yes"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "No"
+                                ]
+                              },
+                              "details": {
+                                "baspi4Ref": "A1.3.0.2.2"
+                              }
+                            },
+                            "required": [
+                              "details"
+                            ]
+                          }
+                        ],
+                        "required": [
+                          "yesNo"
+                        ],
+                        "properties": {
+                          "yesNo": {
+                            "baspi4Ref": "A1.3.0.2.1"
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "wholeFreeholdForSale"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Managed Freehold",
+                          "Commonhold"
+                        ]
+                      },
+                      "managedFreeholdOrCommonholdInformation": {
+                        "baspi4Ref": "A1.5",
+                        "required": [
+                          "contactDetails",
+                          "serviceCharge"
+                        ],
+                        "properties": {
+                          "contactDetails": {
+                            "baspi4Ref": "A1.5.1",
+                            "required": [
+                              "rentchargeOwner",
+                              "managingAgent"
+                            ],
+                            "properties": {
+                              "rentchargeOwner": {
+                                "baspi4Ref": "A1.5.4",
+                                "required": [
+                                  "contact"
+                                ],
+                                "properties": {
+                                  "contact": {
+                                    "baspi4Ref": "A1.5.4.1",
+                                    "required": [
+                                      "nameOrOrganisation",
+                                      "address",
+                                      "emailAddress"
+                                    ],
+                                    "properties": {
+                                      "nameOrOrganisation": {
+                                        "baspi4Ref": "A1.5.4.1.1"
+                                      },
+                                      "address": {
+                                        "baspi4Ref": "A1.5.4.1.2",
+                                        "required": [
+                                          "line1",
+                                          "postcode"
+                                        ],
+                                        "properties": {
+                                          "line1": {
+                                            "baspi4Ref": "A1.5.4.1.2.1"
+                                          },
+                                          "line2": {
+                                            "baspi4Ref": "A1.5.4.1.2.2"
+                                          },
+                                          "line3": {
+                                            "baspi4Ref": "A1.5.4.1.2.3"
+                                          },
+                                          "town": {
+                                            "baspi4Ref": "A1.5.4.1.2.4"
+                                          },
+                                          "postcode": {
+                                            "baspi4Ref": "A1.5.4.1.2.5"
+                                          }
+                                        }
+                                      },
+                                      "emailAddress": {
+                                        "baspi4Ref": "A1.5.5.1.3"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "managingAgent": {
+                                "baspi4Ref": "A1.5.5",
+                                "required": [
+                                  "contact"
+                                ],
+                                "properties": {
+                                  "contact": {
+                                    "baspi4Ref": "A1.5.5.1",
+                                    "required": [
+                                      "nameOrOrganisation",
+                                      "telephone",
+                                      "emailAddress"
+                                    ],
+                                    "properties": {
+                                      "nameOrOrganisation": {
+                                        "baspi4Ref": "A1.5.5.1.1"
+                                      },
+                                      "address": {
+                                        "baspi4Ref": "A1.5.5.1.2",
+                                        "required": [
+                                          "line1",
+                                          "postcode"
+                                        ],
+                                        "properties": {
+                                          "line1": {
+                                            "baspi4Ref": "A1.5.5.1.2.1"
+                                          },
+                                          "line2": {
+                                            "baspi4Ref": "A1.5.5.1.2.2"
+                                          },
+                                          "line3": {
+                                            "baspi4Ref": "A1.5.5.1.2.3"
+                                          },
+                                          "town": {
+                                            "baspi4Ref": "A1.5.5.1.2.4"
+                                          },
+                                          "postcode": {
+                                            "baspi4Ref": "A1.5.5.1.2.5"
+                                          }
+                                        }
+                                      },
+                                      "emailAddress": {
+                                        "baspi4Ref": "A1.5.5.1.3"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "transferAndRegistration": {
+                            "properties": {
+                              "requirementsToBeMemberOfManagementCompany": {
+                                "baspi4Ref": "A1.5.6",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "properties": {
+                                  "yesNo": {
+                                    "baspi4Ref": "A1.5.6.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "serviceCharge": {
+                            "baspi4Ref": "A1.5.1",
+                            "required": [
+                              "annualServiceCharge",
+                              "largeAdditionalExpense",
+                              "reserveFund"
+                            ],
+                            "properties": {
+                              "annualServiceCharge": {
+                                "baspi4Ref": "A1.5.1.1.2"
+                              },
+                              "largeAdditionalExpense": {
+                                "baspi4Ref": "A1.5.2.1",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "baspi4Ref": "A1.5.2.3"
+                                      }
+                                    },
+                                    "required": [
+                                      "details"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "properties": {
+                                  "yesNo": {
+                                    "baspi4Ref": "A1.5.2.2"
+                                  }
+                                }
+                              },
+                              "transferFees": {
+                                "baspi4Ref": "A1.5.3",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "baspi4Ref": "A1.5.3.2"
+                                      }
+                                    }
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Additional fees payable on sale or letting, if known",
+                                "properties": {
+                                  "yesNo": {
+                                    "baspi4Ref": "A1.5.3.1"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "managedFreeholdOrCommonholdInformation"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Leasehold"
+                        ]
+                      },
+                      "leaseholdInformation": {
+                        "baspi4Ref": "A1.5",
+                        "required": [
+                          "sharedOwnership",
+                          "leaseTerm",
+                          "contactDetails",
+                          "groundRent",
+                          "transferAndRegistration",
+                          "serviceCharge"
+                        ],
+                        "properties": {
+                          "sharedOwnership": {
+                            "baspi4Ref": "A1.3.1",
+                            "discriminator": {
+                              "propertyName": "isSharedOwnership"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "isSharedOwnership": {
+                                    "enum": [
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "isSharedOwnership": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "sharedOwnershipPercentage": {
+                                    "baspi4Ref": "A1.3.1.1"
+                                  },
+                                  "sharedOwnershipRent": {
+                                    "baspi4Ref": "A1.3.1.2"
+                                  },
+                                  "sharedOwnershipRentFrequency": {
+                                    "baspi4Ref": "A1.3.1.3"
+                                  }
+                                },
+                                "required": [
+                                  "sharedOwnershipPercentage",
+                                  "sharedOwnershipRent",
+                                  "sharedOwnershipRentFrequency"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "isSharedOwnership"
+                            ],
+                            "properties": {
+                              "isSharedOwnership": {
+                                "baspi4Ref": "A1.3.1"
+                              }
+                            }
+                          },
+                          "leaseTerm": {
+                            "baspi4Ref": "A1.4.1",
+                            "required": [
+                              "startYearOfLease",
+                              "lengthOfLeaseInYears"
+                            ],
+                            "properties": {
+                              "startYearOfLease": {
+                                "baspi4Ref": "A1.4.1.1"
+                              },
+                              "lengthOfLeaseInYears": {
+                                "baspi4Ref": "A1.4.1.2"
+                              }
+                            }
+                          },
+                          "contactDetails": {
+                            "baspi4Ref": "A1.5.4",
+                            "required": [
+                              "contacts"
+                            ],
+                            "properties": {
+                              "contacts": {
+                                "baspi4Ref": "A1.5.4",
+                                "required": [
+                                  "landlord",
+                                  "managingAgent"
+                                ],
+                                "properties": {
+                                  "landlord": {
+                                    "baspi4Ref": "A1.5.4",
+                                    "required": [
+                                      "contact"
+                                    ],
+                                    "properties": {
+                                      "contact": {
+                                        "baspi4Ref": "A1.5.4.1",
+                                        "required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "baspi4Ref": "A1.5.4.1.1"
+                                          },
+                                          "address": {
+                                            "baspi4Ref": "A1.5.4.1.2",
+                                            "required": [
+                                              "line1",
+                                              "postcode"
+                                            ],
+                                            "properties": {
+                                              "line1": {
+                                                "baspi4Ref": "A1.5.4.1.2.1"
+                                              },
+                                              "line2": {
+                                                "baspi4Ref": "A1.5.4.1.2.2"
+                                              },
+                                              "line3": {
+                                                "baspi4Ref": "A1.5.4.1.2.3"
+                                              },
+                                              "town": {
+                                                "baspi4Ref": "A1.5.4.1.2.4"
+                                              },
+                                              "postcode": {
+                                                "baspi4Ref": "A1.5.4.1.2.5"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "baspi4Ref": "A1.5.4.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "managingAgent": {
+                                    "baspi4Ref": "A1.5.5",
+                                    "required": [
+                                      "contact"
+                                    ],
+                                    "properties": {
+                                      "contact": {
+                                        "baspi4Ref": "A1.5.5.1",
+                                        "required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "baspi4Ref": "A1.5.5.1.1"
+                                          },
+                                          "address": {
+                                            "baspi4Ref": "A1.5.5.1.2",
+                                            "required": [
+                                              "line1",
+                                              "postcode"
+                                            ],
+                                            "properties": {
+                                              "line1": {
+                                                "baspi4Ref": "A1.5.5.1.2.1"
+                                              },
+                                              "line2": {
+                                                "baspi4Ref": "A1.5.5.1.2.2"
+                                              },
+                                              "line3": {
+                                                "baspi4Ref": "A1.5.5.1.2.3"
+                                              },
+                                              "town": {
+                                                "baspi4Ref": "A1.5.5.1.2.4"
+                                              },
+                                              "postcode": {
+                                                "baspi4Ref": "A1.5.5.1.2.5"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "baspi4Ref": "A1.5.5.1.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "residentTenantsAssociation": {
+                                    "properties": {
+                                      "contact": {
+                                        "required": [
+                                          "nameOrOrganisation",
+                                          "line1",
+                                          "postcode"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "transferAndRegistration": {
+                            "baspi4Ref": "A1.5.6",
+                            "required": [
+                              "requirementsToBeMemberOfManagementCompany"
+                            ],
+                            "properties": {
+                              "requirementsToBeMemberOfManagementCompany": {
+                                "baspi4Ref": "A1.5.6",
+                                "discriminator": {
+                                  "propertyName": "yesNoNotApplicable"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "No",
+                                          "Not applicable"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ],
+                                "required": [
+                                  "yesNoNotApplicable"
+                                ],
+                                "title": "Is the owner of the Property required to become a director in a management company for the maintenance of shared amenities?",
+                                "properties": {
+                                  "yesNoNotApplicable": {
+                                    "baspi4Ref": "A1.5.6.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "groundRent": {
+                            "baspi4Ref": "A1.4.2",
+                            "discriminator": {
+                              "propertyName": "isGroundRentPayable"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "isGroundRentPayable": {
+                                    "enum": [
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "isGroundRentPayable": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "annualGroundRent": {
+                                    "baspi4Ref": "A1.4.2.2"
+                                  },
+                                  "rentSubjectToIncrease": {
+                                    "baspi4Ref": "A1.4.2.3",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "rentReviewFrequency": {
+                                            "baspi4Ref": "A1.4.2.3.2"
+                                          },
+                                          "rentIncreaseCalculated": {
+                                            "baspi4Ref": "A1.4.2.3.3"
+                                          }
+                                        },
+                                        "required": [
+                                          "rentReviewFrequency",
+                                          "rentIncreaseCalculated"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "baspi4Ref": "A1.4.2.3.1"
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "annualGroundRent",
+                                  "rentSubjectToIncrease"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "isGroundRentPayable"
+                            ],
+                            "properties": {
+                              "isGroundRentPayable": {
+                                "baspi4Ref": "A1.4.2.1"
+                              }
+                            }
+                          },
+                          "serviceCharge": {
+                            "baspi4Ref": "A1.5.1",
+                            "discriminator": {
+                              "propertyName": "sellerContributesToServiceCharge"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "sellerContributesToServiceCharge": {
+                                    "enum": [
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "sellerContributesToServiceCharge": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "annualServiceCharge": {
+                                    "baspi4Ref": "A1.5.1.1.2"
+                                  },
+                                  "largeAdditionalExpense": {
+                                    "baspi4Ref": "A1.5.2.1",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "baspi4Ref": "A1.5.2.3"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "baspi4Ref": "A1.5.2.2"
+                                      }
+                                    }
+                                  },
+                                  "reserveFund": {
+                                    "baspi4Ref": "1.5.2.1",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "title": "Is there a reserve fund (also known as sinking fund or replacement fund)?",
+                                    "properties": {
+                                      "yesNo": {
+                                        "baspi4Ref": "1.5.2.1.1"
+                                      }
+                                    }
+                                  },
+                                  "transferFees": {
+                                    "baspi4Ref": "A1.5.3",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "baspi4Ref": "A1.5.3.2"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "baspi4Ref": "A1.5.3.1"
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "annualServiceCharge",
+                                  "largeAdditionalExpense",
+                                  "reserveFund"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "sellerContributesToServiceCharge"
+                            ],
+                            "properties": {
+                              "sellerContributesToServiceCharge": {
+                                "baspi4Ref": "A1.5.1.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "leaseholdInformation"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Other"
+                        ]
+                      },
+                      "otherOwnershipDetails": {
+                        "baspi4Ref": "A1.3.2"
+                      }
+                    },
+                    "required": [
+                      "otherOwnershipDetails"
+                    ]
+                  }
+                ],
+                "baspi4Ref": "A1.3.0",
+                "required": [
+                  "ownershipType"
+                ],
+                "properties": {
+                  "titleNumber": {
+                    "baspi4Ref": "A1.3.0.1"
+                  },
+                  "ownershipType": {
+                    "baspi4Ref": "A1.3.0.2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parking": {
+          "baspi4Ref": "A1.6",
+          "required": [
+            "parkingArrangements",
+            "controlledParking",
+            "electricVehicleChargingPoint"
+          ],
+          "properties": {
+            "parkingArrangements": {
+              "baspi4Ref": "A1.6.0"
+            },
+            "controlledParking": {
+              "baspi4Ref": "A1.6.0.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.6.0.2.1"
+                }
+              }
+            },
+            "electricVehicleChargingPoint": {
+              "baspi4Ref": "A1.6.1",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.6.1.1"
+                }
+              }
+            },
+            "locatedInUlez": {
+              "baspi4Ref": "A1.6.2",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.6.2.1"
+                }
+              }
+            }
+          }
+        },
+        "listingAndConservation": {
+          "baspi4Ref": "A1.7",
+          "required": [
+            "isListed",
+            "isConservationArea",
+            "hasTreePreservationOrder"
+          ],
+          "properties": {
+            "isListed": {
+              "baspi4Ref": "A1.7.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.7.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.7.1.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.7.1.1"
+                }
+              }
+            },
+            "isConservationArea": {
+              "baspi4Ref": "A1.7.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.7.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.7.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.7.2.1"
+                }
+              }
+            },
+            "hasTreePreservationOrder": {
+              "baspi4Ref": "A1.7.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "workCarriedOut": {
+                      "baspi4Ref": "A1.7.3.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "consentsObtained": {
+                              "baspi4Ref": "A1.7.3.3"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A1.7.3.4"
+                            }
+                          },
+                          "required": [
+                            "consentsObtained"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A1.7.3.2.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "workCarriedOut"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.7.3.1"
+                }
+              }
+            }
+          }
+        },
+        "typeOfConstruction": {
+          "baspi4Ref": "A1.8",
+          "required": [
+            "isStandardForm",
+            "buildingSafety",
+            "sprayFoamInsulation"
+          ],
+          "properties": {
+            "isStandardForm": {
+              "baspi4Ref": "A1.8.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.8.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.8.1.1"
+                }
+              }
+            },
+            "buildingSafety": {
+              "baspi4Ref": "A1.8.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.8.2.2"
+                    },
+                    "workAlreadyDone": {
+                      "baspi4Ref": "A1.8.2.2"
+                    },
+                    "workToBeDone": {
+                      "baspi4Ref": "A1.8.2.2"
+                    },
+                    "potentialCost": {
+                      "baspi4Ref": "A1.8.2.2"
+                    },
+                    "abilityToResideAtProperty": {
+                      "baspi4Ref": "A1.8.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.8.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of any remediation required to the property due to building safety?",
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.8.2.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "sprayFoamInsulation": {
+              "baspi4Ref": "A1.8.4",
+              "discriminator": {
+                "propertyName": "hasSprayFoamInstalled"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "hasSprayFoamInstalled": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "hasSprayFoamInstalled": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.8.4.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.8.4.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "hasSprayFoamInstalled"
+              ],
+              "properties": {
+                "hasSprayFoamInstalled": {
+                  "baspi4Ref": "A1.8.4.1"
+                }
+              }
+            }
+          }
+        },
+        "energyEfficiency": {
+          "baspi4Ref": "A1.8.3",
+          "required": [
+            "certificate",
+            "greenDealLoan"
+          ],
+          "properties": {
+            "certificate": {
+              "baspi4Ref": "A1.8.3.1",
+              "required": [
+                "currentEnergyRating"
+              ],
+              "properties": {
+                "currentEnergyRating": {
+                  "baspi4Ref": "A1.8.3.1.1"
+                }
+              }
+            },
+            "greenDealLoan": {
+              "baspi4Ref": "A7.3",
+              "required": [
+                "hasGreenDealLoan"
+              ],
+              "properties": {
+                "hasGreenDealLoan": {
+                  "baspi4Ref": "A7.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A7.3.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "A7.3.3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A7.3.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "councilTax": {
+          "baspi4Ref": "A1.9",
+          "required": [
+            "councilTaxBand",
+            "councilTaxAffectingAlterations"
+          ],
+          "properties": {
+            "councilTaxBand": {
+              "baspi4Ref": "A1.9.1"
+            },
+            "councilTaxAffectingAlterations": {
+              "baspi4Ref": "A1.9.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A1.9.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A1.9.2.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A1.9.2.1"
+                }
+              }
+            }
+          }
+        },
+        "disputesAndComplaints": {
+          "baspi4Ref": "A2",
+          "required": [
+            "hasDisputesAndComplaints",
+            "leadingToDisputesAndComplaints"
+          ],
+          "properties": {
+            "hasDisputesAndComplaints": {
+              "baspi4Ref": "A2.1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A2.1.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A2.1.1.1"
+                }
+              }
+            },
+            "leadingToDisputesAndComplaints": {
+              "baspi4Ref": "A2.1.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A2.1.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A2.1.2.1"
+                }
+              }
+            }
+          }
+        },
+        "alterationsAndChanges": {
+          "baspi4Ref": "A3",
+          "required": [
+            "hasStructuralAlterations",
+            "changeOfUse",
+            "windowReplacementsSince2002",
+            "hasAddedConservatory",
+            "worksUnfinished",
+            "planningPermissionBreaches",
+            "unresolvedPlanningIssues"
+          ],
+          "properties": {
+            "hasStructuralAlterations": {
+              "baspi4Ref": "A3.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.1.2"
+                    },
+                    "buildingRegApproval": {
+                      "baspi4Ref": "A3.5.1",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.1.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.1.1"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "baspi4Ref": "A3.5.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.2.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.2.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.2.1"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "baspi4Ref": "A3.5.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.3.1"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "baspi4Ref": "A3.5.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.4.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.1.1"
+                }
+              }
+            },
+            "changeOfUse": {
+              "baspi4Ref": "A3.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.2.2"
+                    },
+                    "yearCompleted": {
+                      "baspi4Ref": "A3.2.3"
+                    },
+                    "buildingRegApproval": {
+                      "baspi4Ref": "A3.5.1",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.1.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.1.1"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "baspi4Ref": "A3.5.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.2.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.2.1"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "baspi4Ref": "A3.5.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.3.1"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "baspi4Ref": "A3.5.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.4.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.2.1"
+                }
+              }
+            },
+            "windowReplacementsSince2002": {
+              "baspi4Ref": "A3.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.3.2"
+                    },
+                    "yearCompleted": {
+                      "baspi4Ref": "A3.3.3"
+                    },
+                    "buildingRegApproval": {
+                      "baspi4Ref": "A3.5.1",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.1.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.1.1"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "baspi4Ref": "A3.5.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.2.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.2.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.2.1"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "baspi4Ref": "A3.5.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.3.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.3.1"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "baspi4Ref": "A3.5.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.4.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.4.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.3.1"
+                }
+              }
+            },
+            "hasAddedConservatory": {
+              "baspi4Ref": "A3.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.4.2"
+                    },
+                    "yearCompleted": {
+                      "baspi4Ref": "A3.4.3"
+                    },
+                    "buildingRegApproval": {
+                      "baspi4Ref": "A3.5.1",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.1.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.1.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.1.1"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "baspi4Ref": "A3.5.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.2.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.2.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.2.1"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "baspi4Ref": "A3.5.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.3.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.3.1"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "baspi4Ref": "A3.5.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "baspi4Ref": "A3.5.4.3"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "A3.5.4.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "A3.5.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "yearCompleted",
+                    "buildingRegApproval",
+                    "planningPermission",
+                    "listedBuildingConsent",
+                    "deedRestrictionConsent"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.4.1"
+                }
+              }
+            },
+            "worksUnfinished": {
+              "baspi4Ref": "A3.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.6.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A3.6.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.6.1"
+                }
+              }
+            },
+            "planningPermissionBreaches": {
+              "baspi4Ref": "A3.7",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.7.2"
+                    },
+                    "willingToInsure": {
+                      "baspi4Ref": "A3.9"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A3.7.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments",
+                    "willingToInsure"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.7.1"
+                }
+              }
+            },
+            "unresolvedPlanningIssues": {
+              "baspi4Ref": "A3.8",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A3.8.2"
+                    },
+                    "willingToInsure": {
+                      "baspi4Ref": "A3.9"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A3.8.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments",
+                    "willingToInsure"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A3.8.1"
+                }
+              }
+            }
+          }
+        },
+        "notices": {
+          "baspi4Ref": "A4",
+          "required": [
+            "neighbourDevelopment",
+            "planningApplication",
+            "requiredMaintenance",
+            "listedBuildingApplication",
+            "infrastructureProject",
+            "partyWallAct",
+            "otherNotices"
+          ],
+          "properties": {
+            "neighbourDevelopment": {
+              "baspi4Ref": "A4.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.1.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.1.1"
+                }
+              }
+            },
+            "planningApplication": {
+              "baspi4Ref": "A4.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.2.1"
+                }
+              }
+            },
+            "requiredMaintenance": {
+              "baspi4Ref": "A4.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.3.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.3.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.3.1"
+                }
+              }
+            },
+            "listedBuildingApplication": {
+              "baspi4Ref": "A4.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.4.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.4.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.4.1"
+                }
+              }
+            },
+            "infrastructureProject": {
+              "baspi4Ref": "A4.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.5.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.5.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.5.1"
+                }
+              }
+            },
+            "partyWallAct": {
+              "baspi4Ref": "A4.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.6.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.6.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.6.1"
+                }
+              }
+            },
+            "otherNotices": {
+              "baspi4Ref": "A4.7",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A4.7.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A4.7.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A4.7.1"
+                }
+              }
+            }
+          }
+        },
+        "specialistIssues": {
+          "baspi4Ref": "A5",
+          "required": [
+            "dryRotEtcTreatment",
+            "containsAsbestos",
+            "japaneseKnotweed",
+            "subsidenceOrStructuralFault",
+            "ongoingHealthOrSafetyIssue"
+          ],
+          "properties": {
+            "dryRotEtcTreatment": {
+              "baspi4Ref": "A5.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A5.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A5.1.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A5.1.1"
+                }
+              }
+            },
+            "containsAsbestos": {
+              "baspi4Ref": "A5.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A5.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A5.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A5.2.1"
+                }
+              }
+            },
+            "japaneseKnotweed": {
+              "baspi4Ref": "A5.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "managementPlanInPlace": {
+                      "baspi4Ref": "A5.3.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A5.3.3"
+                    }
+                  },
+                  "required": [
+                    "managementPlanInPlace"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A5.3.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "subsidenceOrStructuralFault": {
+              "baspi4Ref": "A5.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A5.4.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A5.4.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A5.4.1"
+                }
+              }
+            },
+            "ongoingHealthOrSafetyIssue": {
+              "baspi4Ref": "A5.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A5.5.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A5.5.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A5.5.1"
+                }
+              }
+            }
+          }
+        },
+        "fixturesAndFittings": {
+          "baspi4Ref": "A6",
+          "required": [
+            "itemsToRemove",
+            "itemsToInclude"
+          ],
+          "properties": {
+            "itemsToRemove": {
+              "baspi4Ref": "A6.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A6.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A6.1.1"
+                }
+              }
+            },
+            "itemsToInclude": {
+              "baspi4Ref": "A6.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A6.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A6.2.1"
+                }
+              }
+            }
+          }
+        },
+        "electricity": {
+          "baspi4Ref": "A7.1.0.1",
+          "required": [
+            "mainsElectricity",
+            "solarPanels",
+            "otherSources"
+          ],
+          "properties": {
+            "mainsElectricity": {
+              "baspi4Ref": "A7.1.0.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.1.2"
+                    },
+                    "electricityMeter": {
+                      "baspi4Ref": "B4.4",
+                      "required": [
+                        "location"
+                      ],
+                      "properties": {
+                        "location": {
+                          "baspi4Ref": "4.4.1"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "4.4.2"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "electricityMeter"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.1.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.1.2"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.1.1"
+                }
+              }
+            },
+            "solarPanels": {
+              "baspi4Ref": "A7.1.0.8",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.8.2"
+                    },
+                    "yearInstalled": {
+                      "baspi4Ref": "B4.3.1"
+                    },
+                    "panelsOwnedOutright": {
+                      "baspi4Ref": "B4.3.2",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "B4.3.2.2"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "B4.3.2.3"
+                            }
+                          },
+                          "required": [
+                            "details",
+                            "attachments"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "B4.3.2.1"
+                        }
+                      }
+                    },
+                    "panelProviderLease": {
+                      "baspi4Ref": "B4.3.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "4.3.3.2"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "4.3.3.3"
+                            }
+                          },
+                          "required": [
+                            "details",
+                            "attachments"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "4.3.3.1"
+                        }
+                      }
+                    },
+                    "lastMaintained": {
+                      "baspi4Ref": "B4.3.4"
+                    },
+                    "inGoodWorkingOrder": {
+                      "baspi4Ref": "B4.3.5",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "B4.3.5.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "B4.3.5.1"
+                        }
+                      }
+                    },
+                    "isConnectedToNationalGrid": {
+                      "baspi4Ref": "B4.3.6"
+                    },
+                    "photovoltaicMeterPanelLocation": {
+                      "baspi4Ref": "B4.7",
+                      "properties": {
+                        "description": {
+                          "baspi4Ref": "4.7.1"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "4.7.2"
+                        }
+                      }
+                    },
+                    "photovoltaicBatteriesLocation": {
+                      "baspi4Ref": "B4.8",
+                      "properties": {
+                        "description": {
+                          "baspi4Ref": "4.8.1"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "4.8.2"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "yearInstalled",
+                    "panelsOwnedOutright",
+                    "panelProviderLease",
+                    "lastMaintained",
+                    "inGoodWorkingOrder",
+                    "isConnectedToNationalGrid"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.8.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.8.2"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.8.1"
+                }
+              }
+            },
+            "heatPump": {
+              "baspi4Ref": "A7.1.0.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.10.2"
+                    },
+                    "dateInstalled": {
+                      "baspi4Ref": "A7.1.0.10.3"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A7.1.0.10.4"
+                    }
+                  },
+                  "required": [
+                    "dateInstalled",
+                    "attachments"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A7.1.0.10.2"
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.10.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.10.4"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.10.1"
+                }
+              }
+            },
+            "otherSources": {
+              "baspi4Ref": "A7.1.0.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.9.2"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A7.1.0.9.2"
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.9.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.9.4"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.9.1"
+                }
+              }
+            }
+          }
+        },
+        "waterAndDrainage": {
+          "baspi4Ref": "A7.1.0",
+          "required": [
+            "water",
+            "drainage",
+            "maintenanceAgreements"
+          ],
+          "properties": {
+            "water": {
+              "baspi4Ref": "A7.1.0.10",
+              "required": [
+                "mainsWater"
+              ],
+              "properties": {
+                "mainsWater": {
+                  "baspi4Ref": "A7.1.0.10.0",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "supplier": {
+                          "baspi4Ref": "A7.1.0.10.2"
+                        },
+                        "stopcock": {
+                          "baspi4Ref": "B4.6.1",
+                          "properties": {
+                            "location": {
+                              "baspi4Ref": "4.6.1.1"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "4.6.1.2"
+                            }
+                          }
+                        },
+                        "waterMeter": {
+                          "baspi4Ref": "A7.",
+                          "discriminator": {
+                            "propertyName": "isSupplyMetered"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "isSupplyMetered": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "isSupplyMetered": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "location": {
+                                  "baspi4Ref": "4.6.2.1"
+                                },
+                                "attachments": {
+                                  "baspi4Ref": "4.6.2.2"
+                                }
+                              },
+                              "required": [
+                                "location"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "isSupplyMetered"
+                          ],
+                          "properties": {
+                            "isSupplyMetered": {
+                              "baspi4Ref": "B4.6.2"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "stopcock",
+                        "waterMeter"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        },
+                        "dateToBeConnected": {
+                          "baspi4Ref": "A7.1.0.10.3"
+                        },
+                        "supplier": {
+                          "baspi4Ref": "A7.1.0.10.2"
+                        }
+                      },
+                      "required": [
+                        "dateToBeConnected"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A7.1.0.10.1"
+                    }
+                  }
+                }
+              }
+            },
+            "drainage": {
+              "baspi4Ref": "A7.1.0.12",
+              "required": [
+                "mainsSurfaceWaterDrainage",
+                "mainsFoulDrainage"
+              ],
+              "properties": {
+                "mainsSurfaceWaterDrainage": {
+                  "baspi4Ref": "A7.1.0.12.0",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        },
+                        "dateToBeConnected": {
+                          "baspi4Ref": "A7.1.0.12.3"
+                        }
+                      },
+                      "required": [
+                        "dateToBeConnected"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A7.1.0.12.1"
+                    }
+                  }
+                },
+                "mainsFoulDrainage": {
+                  "baspi4Ref": "A7.1.0.11",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "supplier": {
+                          "baspi4Ref": "A7.1.0.11.2"
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        },
+                        "dateToBeConnected": {
+                          "baspi4Ref": "A7.1.0.11.2"
+                        },
+                        "supplier": {
+                          "baspi4Ref": "A7.1.0.11.3"
+                        }
+                      },
+                      "required": [
+                        "dateToBeConnected"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        },
+                        "offMainsDrainageSystem": {
+                          "baspi4Ref": "A7.1.10.13",
+                          "discriminator": {
+                            "propertyName": "offMainsDrainageSystemType"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Sustainable Drainage System"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Septic tank"
+                                  ]
+                                },
+                                "dateReplaced": {
+                                  "baspi4Ref": "A7.1.0.14.2"
+                                },
+                                "dateLastEmptied": {
+                                  "baspi4Ref": "A7.1.0.14.3"
+                                }
+                              },
+                              "required": [
+                                "dateReplaced",
+                                "dateLastEmptied"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Cesspit"
+                                  ]
+                                },
+                                "dateLastEmptied": {
+                                  "baspi4Ref": "A7.1.0.15.2"
+                                }
+                              },
+                              "required": [
+                                "dateLastEmptied"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Sewerage treatment plant"
+                                  ]
+                                },
+                                "dateInstalled": {
+                                  "baspi4Ref": "A7.1.0.16.2"
+                                },
+                                "dateLastServiced": {
+                                  "baspi4Ref": "A7.1.0.16.3"
+                                },
+                                "attachments": {
+                                  "baspi4Ref": "A7.1.0.16.3"
+                                }
+                              },
+                              "required": [
+                                "dateInstalled",
+                                "dateLastServiced",
+                                "attachments"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Other",
+                                    "Not known"
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "required": [
+                            "offMainsDrainageSystemType",
+                            "otherConnectedProperties",
+                            "plantOnOtherLand",
+                            "plantRegistered",
+                            "plantDrainsIntoWaterway"
+                          ],
+                          "properties": {
+                            "offMainsDrainageSystemType": {
+                              "baspi4Ref": "A7.1"
+                            },
+                            "otherConnectedProperties": {
+                              "baspi4Ref": "A7.1.1",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "numberOfPropertiesSharing": {
+                                      "baspi4Ref": "A7.1.1.1"
+                                    },
+                                    "details": {
+                                      "baspi4Ref": "A7.1.1.2"
+                                    }
+                                  },
+                                  "required": [
+                                    "numberOfPropertiesSharing",
+                                    "details"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "A7.1.1.1"
+                                }
+                              }
+                            },
+                            "plantOnOtherLand": {
+                              "baspi4Ref": "A7.1.2",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "attachments": {
+                                      "baspi4Ref": "7.1.2.2"
+                                    }
+                                  },
+                                  "required": [
+                                    "attachments"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "7.1.2.1"
+                                }
+                              }
+                            },
+                            "plantRegistered": {
+                              "baspi4Ref": "A7.1.3",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "attachments": {
+                                      "baspi4Ref": "A7.1.3.2"
+                                    }
+                                  },
+                                  "required": [
+                                    "attachments"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "A7.1.3.1"
+                                }
+                              }
+                            },
+                            "plantDrainsIntoWaterway": {
+                              "baspi4Ref": "A7.1.4",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No, the effluent is discharged through a soakaway system."
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "dischargeCompliesWithGBR": {
+                                      "baspi4Ref": "A7.1.4.1"
+                                    }
+                                  },
+                                  "required": [
+                                    "dischargeCompliesWithGBR"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "A7.1.4.1"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A7.1.0.11.1"
+                    }
+                  }
+                }
+              }
+            },
+            "maintenanceAgreements": {
+              "baspi4Ref": "A7.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A7.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A7.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.2.1"
+                }
+              }
+            }
+          }
+        },
+        "heating": {
+          "baspi4Ref": "A7.4",
+          "required": [
+            "heatingSystem"
+          ],
+          "properties": {
+            "heatingSystem": {
+              "baspi4Ref": "A7.4.0",
+              "discriminator": {
+                "propertyName": "heatingType"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "None",
+                        "Room heaters only"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "Central heating"
+                      ]
+                    },
+                    "centralHeatingDetails": {
+                      "baspi4Ref": "A7.4.0.0",
+                      "required": [
+                        "centralHeatingFuel",
+                        "centralHeatingInstalled",
+                        "boilerInstallationCertificate",
+                        "heatingLastServicedDate",
+                        "heatingLastServicedReport",
+                        "heatingInGoodWorkingOrder"
+                      ],
+                      "properties": {
+                        "centralHeatingFuel": {
+                          "baspi4Ref": "A7.4.0.1",
+                          "discriminator": {
+                            "propertyName": "centralHeatingFuelType"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Mains gas"
+                                  ]
+                                },
+                                "supplier": {
+                                  "baspi4Ref": "A7.1.0"
+                                },
+                                "gasMeter": {
+                                  "baspi4Ref": "B4.5",
+                                  "required": [
+                                    "location"
+                                  ],
+                                  "properties": {
+                                    "location": {
+                                      "baspi4Ref": "4.5.1"
+                                    },
+                                    "attachments": {
+                                      "baspi4Ref": "4.5.2"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "supplier",
+                                "gasMeter"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Electricity"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Oil",
+                                    "LPG",
+                                    "Biomass"
+                                  ]
+                                },
+                                "supplier": {
+                                  "baspi4Ref": "A7.1.0"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Other"
+                                  ]
+                                },
+                                "otherCentralHeatingFuelType": {
+                                  "baspi4Ref": "A7.4.0.3"
+                                }
+                              },
+                              "required": [
+                                "otherCentralHeatingFuelType"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "centralHeatingFuelType"
+                          ],
+                          "properties": {
+                            "centralHeatingFuelType": {
+                              "baspi4Ref": "A7.4.0.2"
+                            }
+                          }
+                        },
+                        "centralHeatingInstalled": {
+                          "baspi4Ref": "A7.4.1"
+                        },
+                        "boilerInstallationCertificate": {
+                          "baspi4Ref": "A7.4.1.1",
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "attachments": {
+                                  "baspi4Ref": "A7.4.1.2"
+                                }
+                              },
+                              "required": [
+                                "attachments"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "yesNo"
+                          ],
+                          "properties": {
+                            "yesNo": {
+                              "baspi4Ref": "A10.1.1"
+                            }
+                          }
+                        },
+                        "heatingLastServicedDate": {
+                          "baspi4Ref": "A7.4.2.1"
+                        },
+                        "heatingLastServicedReport": {
+                          "baspi4Ref": "A7.4.2.2"
+                        },
+                        "heatingInGoodWorkingOrder": {
+                          "baspi4Ref": "A7.4.3",
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                },
+                                "details": {
+                                  "baspi4Ref": "A7.4.3.2"
+                                }
+                              },
+                              "required": [
+                                "details"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "yesNo"
+                          ],
+                          "properties": {
+                            "yesNo": {
+                              "baspi4Ref": "A7.4.3.1"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "centralHeatingDetails"
+                  ]
+                },
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "Communal heating system"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "heatingType"
+              ],
+              "properties": {
+                "heatingType": {
+                  "baspi4Ref": "A7.4.0"
+                }
+              }
+            }
+          }
+        },
+        "connectivity": {
+          "baspi4Ref": "A7",
+          "required": [
+            "telephone",
+            "cableSatelliteTV",
+            "broadband",
+            "mobilePhone"
+          ],
+          "properties": {
+            "telephone": {
+              "baspi4Ref": "A7.1.0.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.5.2"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.5.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.5.2"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.5.1"
+                }
+              }
+            },
+            "cableSatelliteTV": {
+              "baspi4Ref": "A7.1.0.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.6.2"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "dateToBeConnected": {
+                      "baspi4Ref": "A7.1.0.6.3"
+                    },
+                    "supplier": {
+                      "baspi4Ref": "A7.1.0.6.2"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.1.0.6.1"
+                }
+              }
+            },
+            "broadband": {
+              "baspi4Ref": "A7.1.0.7",
+              "properties": {
+                "typeOfConnection": {
+                  "baspi4Ref": "A7.1.0.7.2"
+                }
+              }
+            },
+            "mobilePhone": {
+              "baspi4Ref": "A7.1.0.8",
+              "properties": {
+                "knownSignalIssues": {
+                  "baspi4Ref": "A7.1.0.8.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A7.1.0.8.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "insurance": {
+          "baspi4Ref": "A8",
+          "discriminator": {
+            "propertyName": "isInsured"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "No"
+                  ]
+                },
+                "details": {
+                  "baspi4Ref": "A8.1.1"
+                },
+                "landlordInsuresIfFlat": {
+                  "baspi4Ref": "A8.1.2"
+                }
+              },
+              "required": [
+                "details",
+                "landlordInsuresIfFlat"
+              ]
+            },
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "insuranceClaims": {
+                  "baspi4Ref": "A8.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.2.1"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.2.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "insuranceClaims"
+              ]
+            }
+          ],
+          "required": [
+            "difficultiesObtainingInsurance",
+            "isInsured"
+          ],
+          "properties": {
+            "difficultiesObtainingInsurance": {
+              "baspi4Ref": "A8.1.2.1",
+              "required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "properties": {
+                "abnormalRiseInPremiums": {
+                  "baspi4Ref": "A8.1.2.1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.1.1"
+                    }
+                  }
+                },
+                "subjectToHighExcesses": {
+                  "baspi4Ref": "A8.1.2.1.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.2.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.2.1"
+                    }
+                  }
+                },
+                "subjectToUnusualConditions": {
+                  "baspi4Ref": "A8.1.2.1.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.3.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.3.1"
+                    }
+                  }
+                },
+                "refused": {
+                  "baspi4Ref": "A8.1.2.1.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A8.1.2.1.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A8.1.2.1.4.1"
+                    }
+                  }
+                }
+              }
+            },
+            "isInsured": {
+              "baspi4Ref": "A8.1"
+            }
+          }
+        },
+        "rightsAndInformalArrangements": {
+          "baspi4Ref": "A10",
+          "required": [
+            "sharedContributions",
+            "neighbouringLandRights",
+            "accessRestrictionAttempts",
+            "rightsOrArrangements"
+          ],
+          "properties": {
+            "sharedContributions": {
+              "baspi4Ref": "A10.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A10.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A10.1.1"
+                }
+              }
+            },
+            "neighbouringLandRights": {
+              "baspi4Ref": "A10.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A10.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A10.2.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A10.2.1"
+                }
+              }
+            },
+            "accessRestrictionAttempts": {
+              "baspi4Ref": "A10.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A10.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A10.3.1"
+                }
+              }
+            },
+            "rightsOrArrangements": {
+              "baspi4Ref": "A10.4",
+              "required": [
+                "publicRightOfWay",
+                "rightsOfLight",
+                "rightsOfSupport",
+                "rightsCreatedThroughCustom",
+                "minesAndMinerals",
+                "churchChancel",
+                "rightsToTakeFromLand",
+                "otherRights"
+              ],
+              "properties": {
+                "publicRightOfWay": {
+                  "baspi4Ref": "A10.4.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.1.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "A10.4.1.3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.1.1"
+                    }
+                  }
+                },
+                "rightsOfLight": {
+                  "baspi4Ref": "A10.4.2a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.2a.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.2a.1"
+                    }
+                  }
+                },
+                "rightsOfSupport": {
+                  "baspi4Ref": "A10.4.2b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.2b.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.2b.1"
+                    }
+                  }
+                },
+                "rightsCreatedThroughCustom": {
+                  "baspi4Ref": "A10.4.3a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.3a2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.3a1"
+                    }
+                  }
+                },
+                "rightsToTakeFromLand": {
+                  "baspi4Ref": "A10.4.3b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.3b2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.3b1"
+                    }
+                  }
+                },
+                "minesAndMinerals": {
+                  "baspi4Ref": "A10.4.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.4.1"
+                    }
+                  }
+                },
+                "churchChancel": {
+                  "baspi4Ref": "A10.4.5",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.5.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.5.1"
+                    }
+                  }
+                },
+                "otherRights": {
+                  "baspi4Ref": "A10.4.6",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A10.4.6.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A10.4.6.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "environmentalIssues": {
+          "baspi4Ref": "A11.1",
+          "required": [
+            "flooding",
+            "radon",
+            "otherEnvironmental"
+          ],
+          "properties": {
+            "flooding": {
+              "baspi4Ref": "A11.1.1",
+              "required": [
+                "historicalFlooding"
+              ],
+              "properties": {
+                "floodRisk": {
+                  "required": [
+                    "riskIndicator"
+                  ],
+                  "properties": {
+                    "riskIndicator": {
+                      "title": "To your knowledge,, is the property at risk of flooding of any type?"
+                    }
+                  }
+                },
+                "historicalFlooding": {
+                  "baspi4Ref": "A11.1.2",
+                  "discriminator": {
+                    "propertyName": "hasBeenFlooded"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasBeenFlooded": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasBeenFlooded": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "typeOfFlooding": {
+                          "baspi4Ref": "A11.1.2.2"
+                        },
+                        "details": {
+                          "baspi4Ref": "A11.1.2.1"
+                        }
+                      },
+                      "required": [
+                        "typeOfFlooding",
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "hasBeenFlooded"
+                  ],
+                  "properties": {
+                    "hasBeenFlooded": {
+                      "baspi4Ref": "A11.1.2.1"
+                    }
+                  }
+                }
+              }
+            },
+            "radon": {
+              "baspi4Ref": "A11.1.3",
+              "required": [
+                "remedialMeasuresOnConstruction",
+                "radonTest"
+              ],
+              "properties": {
+                "radonTest": {
+                  "baspi4Ref": "A11.1.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "A11.1.3.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "A11.1.3.3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A11.1.3.1"
+                    }
+                  }
+                },
+                "remedialMeasuresOnConstruction": {
+                  "baspi4Ref": "A11.1.3.4",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "A11.1.3.4.1"
+                    }
+                  }
+                }
+              }
+            },
+            "otherEnvironmental": {
+              "baspi4Ref": "A11.1.4",
+              "discriminator": {
+                "propertyName": "riskIndicator"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "riskIndicator": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "riskIndicator": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "summary": {
+                      "baspi4Ref": "A11.1.4.2"
+                    }
+                  },
+                  "required": [
+                    "summary"
+                  ]
+                }
+              ],
+              "required": [
+                "riskIndicator"
+              ],
+              "properties": {
+                "riskIndicator": {
+                  "baspi4Ref": "A11.1.4.1"
+                }
+              }
+            }
+          }
+        },
+        "otherIssues": {
+          "baspi4Ref": "A11",
+          "required": [
+            "excessiveNoise",
+            "crime",
+            "cautionOrConviction",
+            "failedTransactionsInLast12Months"
+          ],
+          "properties": {
+            "excessiveNoise": {
+              "baspi4Ref": "A11.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A11.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A11.2.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A11.2.1"
+                }
+              }
+            },
+            "crime": {
+              "baspi4Ref": "A11.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A11.3.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A11.3.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A11.3.1"
+                }
+              }
+            },
+            "cautionOrConviction": {
+              "baspi4Ref": "A11.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A11.4.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A11.4.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A11.4.1"
+                }
+              }
+            },
+            "failedTransactionsInLast12Months": {
+              "baspi4Ref": "A11.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A11.5.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A11.5.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A11.5.1"
+                }
+              }
+            }
+          }
+        },
+        "additionalInformation": {
+          "baspi4Ref": "A12",
+          "required": [
+            "restrictionsOnUseNotCompliedWith",
+            "otherMaterialIssue",
+            "otherCharges"
+          ],
+          "properties": {
+            "restrictionsOnUseNotCompliedWith": {
+              "baspi4Ref": "A12.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A12.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A12.1.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A12.1.1"
+                }
+              }
+            },
+            "otherMaterialIssue": {
+              "baspi4Ref": "A12.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A12.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A12.2.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A12.2.1"
+                }
+              }
+            },
+            "otherCharges": {
+              "baspi4Ref": "A12.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A12.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A12.3.1"
+                }
+              }
+            }
+          }
+        },
+        "consumerProtectionRegulationsDeclaration": {
+          "baspi4Ref": "A13",
+          "required": [
+            "consumerProtectionRegulationsResponse"
+          ],
+          "properties": {
+            "consumerProtectionRegulationsResponse": {
+              "baspi4Ref": "A13.1"
+            }
+          }
+        },
+        "legalOwners": {
+          "baspi4Ref": "B1",
+          "required": [
+            "namesOfLegalOwners"
+          ],
+          "properties": {
+            "namesOfLegalOwners": {
+              "baspi4Ref": "B1.1",
+              "items": {
+                "discriminator": {
+                  "propertyName": "ownerType"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Private individual"
+                        ]
+                      },
+                      "firstName": {
+                        "baspi4Ref": "B1.1.2"
+                      },
+                      "middleNames": {
+                        "baspi4Ref": "B1.1.3"
+                      },
+                      "lastName": {
+                        "baspi4Ref": "B1.1.4"
+                      }
+                    },
+                    "required": [
+                      "firstName",
+                      "lastName"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "ownerType": {
+                        "enum": [
+                          "Organisation"
+                        ]
+                      },
+                      "organisationName": {
+                        "baspi4Ref": "B1.1.5"
+                      }
+                    },
+                    "required": [
+                      "organisationName"
+                    ]
+                  }
+                ],
+                "baspi4Ref": "B1.1",
+                "required": [
+                  "ownerType"
+                ],
+                "properties": {
+                  "ownerType": {
+                    "baspi4Ref": "B1.1.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "legalBoundaries": {
+          "baspi4Ref": "B2.1",
+          "required": [
+            "partOutsideLegalOwnership",
+            "partOnSeparateSiteOrDeed",
+            "boundariesDifferFromTitlePlan",
+            "boundaryAlterationProposal",
+            "ownership",
+            "haveBoundaryFeaturesMoved",
+            "adjacentLandIncluded",
+            "flyingFreehold"
+          ],
+          "properties": {
+            "partOutsideLegalOwnership": {
+              "baspi4Ref": "A9.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A9.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A9.1.1"
+                }
+              }
+            },
+            "partOnSeparateSiteOrDeed": {
+              "baspi4Ref": "A9.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A9.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A9.2.1"
+                }
+              }
+            },
+            "boundariesDifferFromTitlePlan": {
+              "baspi4Ref": "A9.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A9.3.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "A9.3.3"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A9.3.1"
+                }
+              }
+            },
+            "boundaryAlterationProposal": {
+              "baspi4Ref": "A9.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "A9.4.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A9.4.1"
+                }
+              }
+            },
+            "ownership": {
+              "baspi4Ref": "B2.1.0",
+              "discriminator": {
+                "propertyName": "areBoundariesUniform"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "uniformBoundaries": {
+                      "baspi4Ref": "B2.1.0.2",
+                      "required": [
+                        "left",
+                        "right",
+                        "rear",
+                        "front"
+                      ],
+                      "properties": {
+                        "left": {
+                          "baspi4Ref": "B2.1.1"
+                        },
+                        "right": {
+                          "baspi4Ref": "B2.1.2"
+                        },
+                        "rear": {
+                          "baspi4Ref": "B2.1.3"
+                        },
+                        "front": {
+                          "baspi4Ref": "B2.1.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "No"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B2.1.5"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "B2.1.6"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                },
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "areBoundariesUniform"
+              ],
+              "properties": {
+                "areBoundariesUniform": {
+                  "baspi4Ref": "B2.1.0.1"
+                }
+              }
+            },
+            "haveBoundaryFeaturesMoved": {
+              "baspi4Ref": "B2.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B2.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B2.2.1"
+                }
+              }
+            },
+            "adjacentLandIncluded": {
+              "baspi4Ref": "B2.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B2.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B2.3.1"
+                }
+              }
+            },
+            "flyingFreehold": {
+              "baspi4Ref": "B2.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B2.5.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B2.5.1"
+                }
+              }
+            }
+          }
+        },
+        "servicesCrossing": {
+          "baspi4Ref": "B3",
+          "required": [
+            "pipesWiresCablesDrainsToProperty",
+            "pipesWiresCablesDrainsFromProperty",
+            "formalOrInformalAgreements"
+          ],
+          "properties": {
+            "pipesWiresCablesDrainsToProperty": {
+              "baspi4Ref": "B3.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B3.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "B3.1.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B3.1.1"
+                }
+              }
+            },
+            "pipesWiresCablesDrainsFromProperty": {
+              "baspi4Ref": "B3.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B3.2.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "B3.2.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B3.2.1"
+                }
+              }
+            },
+            "formalOrInformalAgreements": {
+              "baspi4Ref": "B3.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B3.3.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "B3.3.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B3.3.1"
+                }
+              }
+            }
+          }
+        },
+        "electricalWorks": {
+          "baspi4Ref": "B4",
+          "required": [
+            "testedByQualifiedElectrician",
+            "electricalWorkSince2005"
+          ],
+          "properties": {
+            "testedByQualifiedElectrician": {
+              "baspi4Ref": "B4.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "yearTested": {
+                      "baspi4Ref": "B4.1.2"
+                    },
+                    "attachments": {
+                      "baspi4Ref": "B4.1.3"
+                    }
+                  },
+                  "required": [
+                    "yearTested",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B4.1.1"
+                }
+              }
+            },
+            "electricalWorkSince2005": {
+              "baspi4Ref": "B4.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "yearWorkCarriedOut": {
+                      "baspi4Ref": "B4.2.2"
+                    },
+                    "details": {
+                      "baspi4Ref": "B4.2.3"
+                    },
+                    "suppliedCertificate": {
+                      "baspi4Ref": "B4.2.4.1",
+                      "required": [
+                        "certificateType",
+                        "attachments"
+                      ],
+                      "properties": {
+                        "certificateType": {
+                          "baspi4Ref": "B4.2.3.1"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B4.2.3.2"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "yearWorkCarriedOut",
+                    "details",
+                    "suppliedCertificate"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B4.2.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "smartHomeSystems": {
+          "baspi4Ref": "B7.4",
+          "discriminator": {
+            "propertyName": "hasSmartHomeSystems"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "hasSmartHomeSystems": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "hasSmartHomeSystems": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "heatingAndPower": {
+                  "baspi4Ref": "B7.4.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B7.4.2.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B7.4.2.1"
+                    }
+                  }
+                },
+                "security": {
+                  "baspi4Ref": "B7.4.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B7.4.3.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B7.4.3.1"
+                    }
+                  }
+                },
+                "entertainment": {
+                  "baspi4Ref": "B7.4.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B7.4.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B7.4.4.1"
+                    }
+                  }
+                },
+                "handoverOnCompletion": {
+                  "baspi4Ref": "B7.4.2"
+                }
+              },
+              "required": [
+                "heatingAndPower",
+                "security",
+                "entertainment",
+                "handoverOnCompletion"
+              ]
+            }
+          ],
+          "required": [
+            "hasSmartHomeSystems"
+          ],
+          "properties": {
+            "hasSmartHomeSystems": {
+              "baspi4Ref": "B7.4.1"
+            }
+          }
+        },
+        "guaranteesWarrantiesAndIndemnityInsurances": {
+          "baspi4Ref": "B5",
+          "discriminator": {
+            "propertyName": "hasValidGuaranteesOrWarranties"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "newHomeWarranty": {
+                  "baspi4Ref": "B5.1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B5.1.1.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.1.1"
+                    }
+                  }
+                },
+                "roofingWork": {
+                  "baspi4Ref": "B5.1.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.2.1"
+                    }
+                  }
+                },
+                "dampProofingTreatment": {
+                  "baspi4Ref": "B5.1.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.3.1"
+                    }
+                  }
+                },
+                "timberRotOrInfestationTreatment": {
+                  "baspi4Ref": "B5.1.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.4.1"
+                    }
+                  }
+                },
+                "centralHeatingAndorPlumbing": {
+                  "baspi4Ref": "B5.1.5",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.5.1"
+                    }
+                  }
+                },
+                "doubleGlazing": {
+                  "baspi4Ref": "B5.1.6",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.6.1"
+                    }
+                  }
+                },
+                "electricalRepairOrInstallation": {
+                  "baspi4Ref": "B5.1.7",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.7.1"
+                    }
+                  }
+                },
+                "subsidenceWork": {
+                  "baspi4Ref": "B5.1.8",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.8.1"
+                    }
+                  }
+                },
+                "solarPanels": {
+                  "baspi4Ref": "B5.1.9",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.9.1"
+                    }
+                  }
+                },
+                "otherGuarantees": {
+                  "baspi4Ref": "B5.1.10",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B5.1.10.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.1.10.1"
+                    }
+                  }
+                },
+                "outstandingClaimsOrApplications": {
+                  "baspi4Ref": "B5.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B5.2.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.2.3"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.2.1"
+                    }
+                  }
+                },
+                "titleDefectInsurance": {
+                  "baspi4Ref": "B5.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi4Ref": "B5.3.2"
+                        },
+                        "attachments": {
+                          "baspi4Ref": "B5.3.3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi4Ref": "B5.3.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "timberRotOrInfestationTreatment",
+                "centralHeatingAndorPlumbing",
+                "doubleGlazing",
+                "electricalRepairOrInstallation",
+                "subsidenceWork",
+                "solarPanels",
+                "otherGuarantees",
+                "outstandingClaimsOrApplications",
+                "titleDefectInsurance"
+              ]
+            }
+          ],
+          "required": [
+            "hasValidGuaranteesOrWarranties"
+          ],
+          "properties": {
+            "hasValidGuaranteesOrWarranties": {
+              "baspi4Ref": "B5.1"
+            }
+          }
+        },
+        "occupiers": {
+          "baspi4Ref": "B6",
+          "required": [
+            "sellerLivesAtProperty",
+            "othersAged17OrOver"
+          ],
+          "properties": {
+            "sellerLivesAtProperty": {
+              "baspi4Ref": "B6.1",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B6.1.1"
+                }
+              }
+            },
+            "othersAged17OrOver": {
+              "baspi4Ref": "B6.2",
+              "discriminator": {
+                "propertyName": "hasOthersAged17OrOver"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "hasOthersAged17OrOver": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "hasOthersAged17OrOver": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "aged17OrOverNames": {
+                      "baspi4Ref": "B6.2.2"
+                    },
+                    "aged17OrOverTenantsOrLodgers": {
+                      "baspi4Ref": "B6.2.3",
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "B6.2.2.1"
+                        }
+                      }
+                    },
+                    "vacantPossession": {
+                      "baspi4Ref": "B6.2.4",
+                      "discriminator": {
+                        "propertyName": "soldWithVacantPossession"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "soldWithVacantPossession": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "baspi4Ref": "B6.2.4.2"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "B6.2.4.3"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "soldWithVacantPossession": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "aged17OrOverAgreedToLeave": {
+                              "baspi4Ref": "B6.3.1",
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "B6.3.1.1"
+                                }
+                              }
+                            },
+                            "aged17OrOverWillSignToConfirmWillVacate": {
+                              "baspi4Ref": "B6.3.2",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    },
+                                    "details": {
+                                      "baspi4Ref": "B6.3.2.2"
+                                    },
+                                    "attachments": {
+                                      "baspi4Ref": "B6.3.2.3"
+                                    }
+                                  },
+                                  "required": [
+                                    "details",
+                                    "attachments"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "baspi4Ref": "B6.3.2.1"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "aged17OrOverAgreedToLeave",
+                            "aged17OrOverWillSignToConfirmWillVacate"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "soldWithVacantPossession"
+                      ],
+                      "properties": {
+                        "soldWithVacantPossession": {
+                          "baspi4Ref": "B6.2.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "aged17OrOverNames",
+                    "aged17OrOverTenantsOrLodgers",
+                    "vacantPossession"
+                  ]
+                }
+              ],
+              "required": [
+                "hasOthersAged17OrOver"
+              ],
+              "properties": {
+                "hasOthersAged17OrOver": {
+                  "baspi4Ref": "B6.2.1"
+                }
+              }
+            }
+          }
+        },
+        "completionAndMoving": {
+          "baspi4Ref": "B7",
+          "required": [
+            "sellerWillEnsure",
+            "otherPropertyInChain",
+            "moveRestrictionDates",
+            "digitalPropertyLogbook",
+            "sufficientToRepayAllMortgages"
+          ],
+          "properties": {
+            "sellerWillEnsure": {
+              "baspi4Ref": "B7.1",
+              "properties": {
+                "removeRubbish": {
+                  "baspi4Ref": "B7.1.1"
+                },
+                "replaceLightFittings": {
+                  "baspi4Ref": "B7.1.2"
+                },
+                "takeReasonableCare": {
+                  "baspi4Ref": "B7.1.3"
+                },
+                "leaveKeys": {
+                  "baspi4Ref": "B7.1.4"
+                }
+              }
+            },
+            "otherPropertyInChain": {
+              "baspi4Ref": "B7.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "propertyDependencyType": {
+                      "baspi4Ref": "B7.2.2"
+                    },
+                    "dependentPropertyAddress": {
+                      "baspi4Ref": "B7.2.3",
+                      "required": [
+                        "line1",
+                        "postcode"
+                      ],
+                      "properties": {
+                        "line1": {
+                          "baspi4Ref": "B7.2.3.1"
+                        },
+                        "line2": {
+                          "baspi4Ref": "B7.2.3.2"
+                        },
+                        "line3": {
+                          "baspi4Ref": "B7.2.3.3"
+                        },
+                        "town": {
+                          "baspi4Ref": "B7.2.3.4"
+                        },
+                        "postcode": {
+                          "baspi4Ref": "B7.2.3.5"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "propertyDependencyType",
+                    "dependentPropertyAddress"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B7.2.1"
+                }
+              }
+            },
+            "moveRestrictionDates": {
+              "baspi4Ref": "B7.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi4Ref": "B7.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B7.3.1"
+                }
+              }
+            },
+            "digitalPropertyLogbook": {
+              "baspi4Ref": "B7.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "logbookProvider": {
+                      "baspi4Ref": "B7.5.2"
+                    },
+                    "willHandoverLogbook": {
+                      "baspi4Ref": "B7.5.2"
+                    }
+                  },
+                  "required": [
+                    "logbookProvider",
+                    "willHandoverLogbook"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "B7.5.1"
+                }
+              }
+            },
+            "sufficientToRepayAllMortgages": {
+              "baspi4Ref": "B7.6",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi4Ref": "A7.6.1"
+                }
+              }
+            }
+          }
+        },
+        "confirmationOfAccuracyByOwners": {
+          "baspi4Ref": "B8",
+          "required": [
+            "confirmWillProvideAdditionalDocumentation",
+            "confirmInformationIsAccurate"
+          ],
+          "properties": {
+            "confirmWillProvideAdditionalDocumentation": {
+              "baspi4Ref": "B8.1"
+            },
+            "confirmInformationIsAccurate": {
+              "baspi4Ref": "B8.2"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/v3/overlays/baspi5.json
+++ b/src/schemas/v3/overlays/baspi5.json
@@ -1,13 +1,103 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/baspi.json",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/baspi5.json",
   "required": [
     "participants",
     "propertyPack"
   ],
   "properties": {
     "participants": {
+      "baspi5Ref": "B1",
       "items": {
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer",
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller"
+                ]
+              },
+              "sellersCapacity": {
+                "baspi5Ref": "B1.3",
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi5Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi5Ref": "B1.3.3"
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi5Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi5Ref": "B1.3.3"
+                      }
+                    },
+                    "required": [
+                      "sellersCapacityDetails",
+                      "attachments"
+                    ]
+                  }
+                ],
+                "required": [
+                  "capacity"
+                ],
+                "properties": {
+                  "capacity": {
+                    "baspi5Ref": "B1.3.1"
+                  }
+                }
+              }
+            },
+            "required": [
+              "sellersCapacity"
+            ]
+          }
+        ],
         "required": [
           "name",
           "email",
@@ -25,65 +115,12 @@
               "line1",
               "postcode"
             ]
-          },
-          "sellersCapacity": {
-            "baspiRef": "B1.3",
-            "discriminator": {
-              "propertyName": "capacity"
-            },
-            "oneOf": [
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Legal Owner",
-                      "Mortgagee in Possession"
-                    ]
-                  },
-                  "sellersCapacityDetails": {
-                    "baspiRef": "B1.3.2"
-                  },
-                  "attachments": {
-                    "baspiRef": "B1.3.3"
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Personal Representative for a Deceased Owner",
-                      "Under Power of Attorney",
-                      "Other"
-                    ]
-                  },
-                  "sellersCapacityDetails": {
-                    "baspiRef": "B1.3.2"
-                  },
-                  "attachments": {
-                    "baspiRef": "B1.3.3"
-                  }
-                },
-                "required": [
-                  "sellersCapacityDetails",
-                  "attachments"
-                ]
-              }
-            ],
-            "required": [
-              "capacity"
-            ],
-            "properties": {
-              "capacity": {
-                "baspiRef": "B1.3.1"
-              }
-            }
           }
         }
       }
     },
     "propertyPack": {
-      "baspiRef": "0",
+      "baspi5Ref": "0",
       "required": [
         "uprn",
         "address",
@@ -121,31 +158,31 @@
       ],
       "properties": {
         "address": {
-          "baspiRef": "A1.1",
+          "baspi5Ref": "A1.1",
           "required": [
             "line1",
             "postcode"
           ],
           "properties": {
             "line1": {
-              "baspiRef": "A1.1.1"
+              "baspi5Ref": "A1.1.1"
             },
             "line2": {
-              "baspiRef": "A1.1.2"
+              "baspi5Ref": "A1.1.2"
             },
             "line3": {
-              "baspiRef": "A1.1.3"
+              "baspi5Ref": "A1.1.3"
             },
             "town": {
-              "baspiRef": "A1.1.4"
+              "baspi5Ref": "A1.1.4"
             },
             "postcode": {
-              "baspiRef": "A1.1.5"
+              "baspi5Ref": "A1.1.5"
             }
           }
         },
         "uprn": {
-          "baspiRef": "A1.1.5"
+          "baspi5Ref": "A1.1.5"
         },
         "media": {
           "items": {
@@ -154,14 +191,112 @@
             ]
           }
         },
+        "buildInformation": {
+          "baspi5Ref": "A1.8",
+          "properties": {
+            "building": {
+              "baspi5Ref": "A1.8",
+              "discriminator": {
+                "propertyName": "propertyType"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "propertyType": {
+                      "enum": [
+                        "Other"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "propertyType": {
+                      "enum": [
+                        "House",
+                        "Bungalow"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "propertyType": {
+                      "enum": [
+                        "Maisonette",
+                        "Flat"
+                      ]
+                    },
+                    "numberOfFloors": {
+                      "baspi5Ref": "A1.8.5.2"
+                    },
+                    "entranceFloor": {
+                      "baspi5Ref": "A1.8.5.1"
+                    },
+                    "overCommercialPremises": {
+                      "baspi5Ref": "A1.8.6",
+                      "discriminator": {
+                        "propertyName": "isLocatedOverCommercialPremises"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "isLocatedOverCommercialPremises": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "isLocatedOverCommercialPremises": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "baspi5Ref": "A1.8.6.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "isLocatedOverCommercialPremises": {
+                          "baspi5Ref": "A1.8.6.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "numberOfFloors",
+                    "entranceFloor",
+                    "overCommercialPremises"
+                  ]
+                }
+              ],
+              "required": [
+                "propertyType"
+              ],
+              "properties": {
+                "propertyType": {
+                  "baspi5Ref": "A1.8"
+                }
+              }
+            }
+          }
+        },
         "delayFactors": {
-          "baspiRef": "A1.2",
+          "baspi5Ref": "A1.2",
           "required": [
             "hasDelayFactors"
           ],
           "properties": {
             "hasDelayFactors": {
-              "baspiRef": "A1.2.1",
+              "baspi5Ref": "A1.2.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -183,10 +318,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.2.2"
+                      "baspi5Ref": "A1.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.2.3"
+                      "baspi5Ref": "A1.2.3"
                     }
                   },
                   "required": [
@@ -200,20 +335,20 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.1.1"
+                  "baspi5Ref": "A10.1.1"
                 }
               }
             }
           }
         },
         "ownership": {
-          "baspiRef": "A1.3",
+          "baspi5Ref": "A1.3",
           "required": [
             "ownershipsToBeTransferred"
           ],
           "properties": {
             "ownershipsToBeTransferred": {
-              "baspiRef": "A1.3",
+              "baspi5Ref": "A1.3",
               "items": {
                 "discriminator": {
                   "propertyName": "ownershipType"
@@ -227,7 +362,7 @@
                         ]
                       },
                       "wholeFreeholdForSale": {
-                        "baspiRef": "A1.3.0.2.1",
+                        "baspi5Ref": "A1.3.0.2.1",
                         "discriminator": {
                           "propertyName": "yesNo"
                         },
@@ -249,7 +384,7 @@
                                 ]
                               },
                               "details": {
-                                "baspiRef": "A1.3.0.2.2"
+                                "baspi5Ref": "A1.3.0.2.2"
                               }
                             },
                             "required": [
@@ -262,7 +397,7 @@
                         ],
                         "properties": {
                           "yesNo": {
-                            "baspiRef": "A1.3.0.2.1"
+                            "baspi5Ref": "A1.3.0.2.1"
                           }
                         }
                       }
@@ -280,27 +415,27 @@
                         ]
                       },
                       "managedFreeholdOrCommonholdInformation": {
-                        "baspiRef": "A1.5",
+                        "baspi5Ref": "A1.5",
                         "required": [
                           "contactDetails",
                           "serviceCharge"
                         ],
                         "properties": {
                           "contactDetails": {
-                            "baspiRef": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "required": [
                               "rentchargeOwner",
                               "managingAgent"
                             ],
                             "properties": {
                               "rentchargeOwner": {
-                                "baspiRef": "A1.5.4",
+                                "baspi5Ref": "A1.5.4",
                                 "required": [
                                   "contact"
                                 ],
                                 "properties": {
                                   "contact": {
-                                    "baspiRef": "A1.5.4.1",
+                                    "baspi5Ref": "A1.5.4.1",
                                     "required": [
                                       "nameOrOrganisation",
                                       "address",
@@ -308,47 +443,47 @@
                                     ],
                                     "properties": {
                                       "nameOrOrganisation": {
-                                        "baspiRef": "A1.5.4.1.1"
+                                        "baspi5Ref": "A1.5.4.1.1"
                                       },
                                       "address": {
-                                        "baspiRef": "A1.5.4.1.2",
+                                        "baspi5Ref": "A1.5.4.1.2",
                                         "required": [
                                           "line1",
                                           "postcode"
                                         ],
                                         "properties": {
                                           "line1": {
-                                            "baspiRef": "A1.5.4.1.2.1"
+                                            "baspi5Ref": "A1.5.4.1.2.1"
                                           },
                                           "line2": {
-                                            "baspiRef": "A1.5.4.1.2.2"
+                                            "baspi5Ref": "A1.5.4.1.2.2"
                                           },
                                           "line3": {
-                                            "baspiRef": "A1.5.4.1.2.3"
+                                            "baspi5Ref": "A1.5.4.1.2.3"
                                           },
                                           "town": {
-                                            "baspiRef": "A1.5.4.1.2.4"
+                                            "baspi5Ref": "A1.5.4.1.2.4"
                                           },
                                           "postcode": {
-                                            "baspiRef": "A1.5.4.1.2.5"
+                                            "baspi5Ref": "A1.5.4.1.2.5"
                                           }
                                         }
                                       },
                                       "emailAddress": {
-                                        "baspiRef": "A1.5.5.1.3"
+                                        "baspi5Ref": "A1.5.5.1.3"
                                       }
                                     }
                                   }
                                 }
                               },
                               "managingAgent": {
-                                "baspiRef": "A1.5.5",
+                                "baspi5Ref": "A1.5.5",
                                 "required": [
                                   "contact"
                                 ],
                                 "properties": {
                                   "contact": {
-                                    "baspiRef": "A1.5.5.1",
+                                    "baspi5Ref": "A1.5.5.1",
                                     "required": [
                                       "nameOrOrganisation",
                                       "telephone",
@@ -356,34 +491,34 @@
                                     ],
                                     "properties": {
                                       "nameOrOrganisation": {
-                                        "baspiRef": "A1.5.5.1.1"
+                                        "baspi5Ref": "A1.5.5.1.1"
                                       },
                                       "address": {
-                                        "baspiRef": "A1.5.5.1.2",
+                                        "baspi5Ref": "A1.5.5.1.2",
                                         "required": [
                                           "line1",
                                           "postcode"
                                         ],
                                         "properties": {
                                           "line1": {
-                                            "baspiRef": "A1.5.5.1.2.1"
+                                            "baspi5Ref": "A1.5.5.1.2.1"
                                           },
                                           "line2": {
-                                            "baspiRef": "A1.5.5.1.2.2"
+                                            "baspi5Ref": "A1.5.5.1.2.2"
                                           },
                                           "line3": {
-                                            "baspiRef": "A1.5.5.1.2.3"
+                                            "baspi5Ref": "A1.5.5.1.2.3"
                                           },
                                           "town": {
-                                            "baspiRef": "A1.5.5.1.2.4"
+                                            "baspi5Ref": "A1.5.5.1.2.4"
                                           },
                                           "postcode": {
-                                            "baspiRef": "A1.5.5.1.2.5"
+                                            "baspi5Ref": "A1.5.5.1.2.5"
                                           }
                                         }
                                       },
                                       "emailAddress": {
-                                        "baspiRef": "A1.5.5.1.3"
+                                        "baspi5Ref": "A1.5.5.1.3"
                                       }
                                     }
                                   }
@@ -394,7 +529,7 @@
                           "transferAndRegistration": {
                             "properties": {
                               "requirementsToBeMemberOfManagementCompany": {
-                                "baspiRef": "A1.5.6",
+                                "baspi5Ref": "A1.5.6",
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -423,14 +558,14 @@
                                 ],
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.6.1"
+                                    "baspi5Ref": "A1.5.6.1"
                                   }
                                 }
                               }
                             }
                           },
                           "serviceCharge": {
-                            "baspiRef": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "required": [
                               "annualServiceCharge",
                               "largeAdditionalExpense",
@@ -438,10 +573,10 @@
                             ],
                             "properties": {
                               "annualServiceCharge": {
-                                "baspiRef": "A1.5.1.1.2"
+                                "baspi5Ref": "A1.5.1.1.2"
                               },
                               "largeAdditionalExpense": {
-                                "baspiRef": "A1.5.2.1",
+                                "baspi5Ref": "A1.5.3.1",
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -463,7 +598,7 @@
                                         ]
                                       },
                                       "details": {
-                                        "baspiRef": "A1.5.2.3"
+                                        "baspi5Ref": "A1.5.3.3"
                                       }
                                     },
                                     "required": [
@@ -476,12 +611,12 @@
                                 ],
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.2.2"
+                                    "baspi5Ref": "A1.5.3.2"
                                   }
                                 }
                               },
                               "transferFees": {
-                                "baspiRef": "A1.5.3",
+                                "baspi5Ref": "A1.5.4",
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -503,7 +638,7 @@
                                         ]
                                       },
                                       "details": {
-                                        "baspiRef": "A1.5.3.2"
+                                        "baspi5Ref": "A1.5.4.2"
                                       }
                                     }
                                   }
@@ -511,9 +646,10 @@
                                 "required": [
                                   "yesNo"
                                 ],
+                                "title": "Additional fees payable on sale or letting, if known",
                                 "properties": {
                                   "yesNo": {
-                                    "baspiRef": "A1.5.3.1"
+                                    "baspi5Ref": "A1.5.4.1"
                                   }
                                 }
                               }
@@ -534,7 +670,7 @@
                         ]
                       },
                       "leaseholdInformation": {
-                        "baspiRef": "A1.5",
+                        "baspi5Ref": "A1.5",
                         "required": [
                           "sharedOwnership",
                           "leaseTerm",
@@ -545,7 +681,7 @@
                         ],
                         "properties": {
                           "sharedOwnership": {
-                            "baspiRef": "A1.3.1",
+                            "baspi5Ref": "A1.3.1",
                             "discriminator": {
                               "propertyName": "isSharedOwnership"
                             },
@@ -567,13 +703,13 @@
                                     ]
                                   },
                                   "sharedOwnershipPercentage": {
-                                    "baspiRef": "A1.3.1.1"
+                                    "baspi5Ref": "A1.3.1.1"
                                   },
                                   "sharedOwnershipRent": {
-                                    "baspiRef": "A1.3.1.2"
+                                    "baspi5Ref": "A1.3.1.2"
                                   },
                                   "sharedOwnershipRentFrequency": {
-                                    "baspiRef": "A1.3.1.3"
+                                    "baspi5Ref": "A1.3.1.3"
                                   }
                                 },
                                 "required": [
@@ -588,46 +724,46 @@
                             ],
                             "properties": {
                               "isSharedOwnership": {
-                                "baspiRef": "A1.3.1"
+                                "baspi5Ref": "A1.3.1"
                               }
                             }
                           },
                           "leaseTerm": {
-                            "baspiRef": "A1.4.1",
+                            "baspi5Ref": "A1.4.1",
                             "required": [
                               "startYearOfLease",
                               "lengthOfLeaseInYears"
                             ],
                             "properties": {
                               "startYearOfLease": {
-                                "baspiRef": "A1.4.1.1"
+                                "baspi5Ref": "A1.4.1.1"
                               },
                               "lengthOfLeaseInYears": {
-                                "baspiRef": "A1.4.1.2"
+                                "baspi5Ref": "A1.4.1.2"
                               }
                             }
                           },
                           "contactDetails": {
-                            "baspiRef": "A1.5.4",
+                            "baspi5Ref": "A1.5.4",
                             "required": [
                               "contacts"
                             ],
                             "properties": {
                               "contacts": {
-                                "baspiRef": "A1.5.4.",
+                                "baspi5Ref": "A1.5.4",
                                 "required": [
                                   "landlord",
                                   "managingAgent"
                                 ],
                                 "properties": {
                                   "landlord": {
-                                    "baspiRef": "A1.5.4",
+                                    "baspi5Ref": "A1.5.5",
                                     "required": [
                                       "contact"
                                     ],
                                     "properties": {
                                       "contact": {
-                                        "baspiRef": "A1.5.4.1",
+                                        "baspi5Ref": "A1.5.5.1",
                                         "required": [
                                           "nameOrOrganisation",
                                           "address",
@@ -635,47 +771,47 @@
                                         ],
                                         "properties": {
                                           "nameOrOrganisation": {
-                                            "baspiRef": "A1.5.4.1.1"
+                                            "baspi5Ref": "A1.5.5.1.1"
                                           },
                                           "address": {
-                                            "baspiRef": "A1.5.4.1.2",
+                                            "baspi5Ref": "A1.5.5.1.2",
                                             "required": [
                                               "line1",
                                               "postcode"
                                             ],
                                             "properties": {
                                               "line1": {
-                                                "baspiRef": "A1.5.4.1.2.1"
+                                                "baspi5Ref": "A1.5.5.1.2.1"
                                               },
                                               "line2": {
-                                                "baspiRef": "A1.5.4.1.2.2"
+                                                "baspi5Ref": "A1.5.5.1.2.2"
                                               },
                                               "line3": {
-                                                "baspiRef": "A1.5.4.1.2.3"
+                                                "baspi5Ref": "A1.5.5.1.2.3"
                                               },
                                               "town": {
-                                                "baspiRef": "A1.5.4.1.2.4"
+                                                "baspi5Ref": "A1.5.5.1.2.4"
                                               },
                                               "postcode": {
-                                                "baspiRef": "A1.5.4.1.2.5"
+                                                "baspi5Ref": "A1.5.5.1.2.5"
                                               }
                                             }
                                           },
                                           "emailAddress": {
-                                            "baspiRef": "A1.5.4.3"
+                                            "baspi5Ref": "A1.5.5.3"
                                           }
                                         }
                                       }
                                     }
                                   },
                                   "managingAgent": {
-                                    "baspiRef": "A1.5.5",
+                                    "baspi5Ref": "A1.5.6",
                                     "required": [
                                       "contact"
                                     ],
                                     "properties": {
                                       "contact": {
-                                        "baspiRef": "A1.5.5.1",
+                                        "baspi5Ref": "A1.5.6.1",
                                         "required": [
                                           "nameOrOrganisation",
                                           "address",
@@ -683,34 +819,34 @@
                                         ],
                                         "properties": {
                                           "nameOrOrganisation": {
-                                            "baspiRef": "A1.5.5.1.1"
+                                            "baspi5Ref": "A1.5.6.1.1"
                                           },
                                           "address": {
-                                            "baspiRef": "A1.5.5.1.2",
+                                            "baspi5Ref": "A1.5.6.1.2",
                                             "required": [
                                               "line1",
                                               "postcode"
                                             ],
                                             "properties": {
                                               "line1": {
-                                                "baspiRef": "A1.5.5.1.2.1"
+                                                "baspi5Ref": "A1.5.6.1.2.1"
                                               },
                                               "line2": {
-                                                "baspiRef": "A1.5.5.1.2.2"
+                                                "baspi5Ref": "A1.5.6.1.2.2"
                                               },
                                               "line3": {
-                                                "baspiRef": "A1.5.5.1.2.3"
+                                                "baspi5Ref": "A1.5.6.1.2.3"
                                               },
                                               "town": {
-                                                "baspiRef": "A1.5.5.1.2.4"
+                                                "baspi5Ref": "A1.5.6.1.2.4"
                                               },
                                               "postcode": {
-                                                "baspiRef": "A1.5.5.1.2.5"
+                                                "baspi5Ref": "A1.5.6.1.2.5"
                                               }
                                             }
                                           },
                                           "emailAddress": {
-                                            "baspiRef": "A1.5.5.1.3"
+                                            "baspi5Ref": "A1.5.6.1.3"
                                           }
                                         }
                                       }
@@ -732,13 +868,13 @@
                             }
                           },
                           "transferAndRegistration": {
-                            "baspiRef": "A1.5.6",
+                            "baspi5Ref": "A1.5.6",
                             "required": [
                               "requirementsToBeMemberOfManagementCompany"
                             ],
                             "properties": {
                               "requirementsToBeMemberOfManagementCompany": {
-                                "baspiRef": "A1.5.6",
+                                "baspi5Ref": "A1.5.7",
                                 "discriminator": {
                                   "propertyName": "yesNoNotApplicable"
                                 },
@@ -766,16 +902,17 @@
                                 "required": [
                                   "yesNoNotApplicable"
                                 ],
+                                "title": "Is the owner of the Property required to become a director in a management company for the maintenance of shared amenities?",
                                 "properties": {
                                   "yesNoNotApplicable": {
-                                    "baspiRef": "A1.5.6.1"
+                                    "baspi5Ref": "A1.5.7.1"
                                   }
                                 }
                               }
                             }
                           },
                           "groundRent": {
-                            "baspiRef": "A1.4.2",
+                            "baspi5Ref": "A1.4.2",
                             "discriminator": {
                               "propertyName": "isGroundRentPayable"
                             },
@@ -797,10 +934,10 @@
                                     ]
                                   },
                                   "annualGroundRent": {
-                                    "baspiRef": "A1.4.2.2"
+                                    "baspi5Ref": "A1.4.2.2"
                                   },
                                   "rentSubjectToIncrease": {
-                                    "baspiRef": "A1.4.2.3",
+                                    "baspi5Ref": "A1.4.2.3",
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -822,10 +959,10 @@
                                             ]
                                           },
                                           "rentReviewFrequency": {
-                                            "baspiRef": "A1.4.2.3.2"
+                                            "baspi5Ref": "A1.4.2.3.2"
                                           },
                                           "rentIncreaseCalculated": {
-                                            "baspiRef": "A1.4.2.3.3"
+                                            "baspi5Ref": "A1.4.2.3.3"
                                           }
                                         },
                                         "required": [
@@ -839,7 +976,7 @@
                                     ],
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "A1.4.2.3.1"
+                                        "baspi5Ref": "A1.4.2.3.1"
                                       }
                                     }
                                   }
@@ -855,12 +992,12 @@
                             ],
                             "properties": {
                               "isGroundRentPayable": {
-                                "baspiRef": "A1.4.2.1"
+                                "baspi5Ref": "A1.4.2.1"
                               }
                             }
                           },
                           "serviceCharge": {
-                            "baspiRef": "A1.5.1",
+                            "baspi5Ref": "A1.5.1",
                             "discriminator": {
                               "propertyName": "sellerContributesToServiceCharge"
                             },
@@ -882,10 +1019,10 @@
                                     ]
                                   },
                                   "annualServiceCharge": {
-                                    "baspiRef": "A1.5.1.1.2"
+                                    "baspi5Ref": "A1.5.1.1.2"
                                   },
                                   "largeAdditionalExpense": {
-                                    "baspiRef": "A1.5.2.1",
+                                    "baspi5Ref": "A1.5.2.1",
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -907,7 +1044,7 @@
                                             ]
                                           },
                                           "details": {
-                                            "baspiRef": "A1.5.2.3"
+                                            "baspi5Ref": "A1.5.2.3"
                                           }
                                         },
                                         "required": [
@@ -920,12 +1057,12 @@
                                     ],
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "A1.5.2.2"
+                                        "baspi5Ref": "A1.5.2.2"
                                       }
                                     }
                                   },
                                   "reserveFund": {
-                                    "baspiRef": "1.5.2.1",
+                                    "baspi5Ref": "1.5.2.1",
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -945,6 +1082,9 @@
                                             "enum": [
                                               "Yes"
                                             ]
+                                          },
+                                          "contributionIncludedInServiceCharge": {
+                                            "baspi5Ref": "1.5.2.1.2"
                                           }
                                         }
                                       }
@@ -952,14 +1092,15 @@
                                     "required": [
                                       "yesNo"
                                     ],
+                                    "title": "Is there a reserve fund (also known as sinking fund or replacement fund)?",
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "1.5.2.1.1"
+                                        "baspi5Ref": "1.5.2.1.1"
                                       }
                                     }
                                   },
                                   "transferFees": {
-                                    "baspiRef": "A1.5.3",
+                                    "baspi5Ref": "A1.5.3",
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -981,7 +1122,7 @@
                                             ]
                                           },
                                           "details": {
-                                            "baspiRef": "A1.5.3.2"
+                                            "baspi5Ref": "A1.5.3.2"
                                           }
                                         }
                                       }
@@ -991,7 +1132,7 @@
                                     ],
                                     "properties": {
                                       "yesNo": {
-                                        "baspiRef": "A1.5.3.1"
+                                        "baspi5Ref": "A1.5.3.1"
                                       }
                                     }
                                   }
@@ -1008,7 +1149,7 @@
                             ],
                             "properties": {
                               "sellerContributesToServiceCharge": {
-                                "baspiRef": "A1.5.1.1"
+                                "baspi5Ref": "A1.5.1.1"
                               }
                             }
                           }
@@ -1027,7 +1168,7 @@
                         ]
                       },
                       "otherOwnershipDetails": {
-                        "baspiRef": "A1.3.2"
+                        "baspi5Ref": "A1.3.2"
                       }
                     },
                     "required": [
@@ -1035,16 +1176,16 @@
                     ]
                   }
                 ],
-                "baspiRef": "A1.3.0",
+                "baspi5Ref": "A1.3.0",
                 "required": [
                   "ownershipType"
                 ],
                 "properties": {
                   "titleNumber": {
-                    "baspiRef": "A1.3.0.1"
+                    "baspi5Ref": "A1.3.0.1"
                   },
                   "ownershipType": {
-                    "baspiRef": "A1.3.0.2"
+                    "baspi5Ref": "A1.3.0.2"
                   }
                 }
               }
@@ -1052,7 +1193,7 @@
           }
         },
         "parking": {
-          "baspiRef": "A1.6",
+          "baspi5Ref": "A1.6",
           "required": [
             "parkingArrangements",
             "controlledParking",
@@ -1060,34 +1201,115 @@
           ],
           "properties": {
             "parkingArrangements": {
-              "baspiRef": "A1.6.0"
+              "baspi5Ref": "A1.6.0"
             },
             "controlledParking": {
-              "baspiRef": "A1.6.2",
+              "baspi5Ref": "A1.6.0.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "annualCostOfPermit": {
+                      "baspi5Ref": "A1.6.0.2.2"
+                    }
+                  },
+                  "required": [
+                    "annualCostOfPermit"
+                  ]
+                }
+              ],
               "required": [
                 "yesNo"
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.6.2.1"
+                  "baspi5Ref": "A1.6.0.2.1"
+                }
+              }
+            },
+            "vehicleTypeRestriction": {
+              "baspi5Ref": "A1.6.0.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "baspi5Ref": "A1.6.0.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi5Ref": "A1.6.0.3.1"
                 }
               }
             },
             "electricVehicleChargingPoint": {
-              "baspiRef": "A1.6.1",
+              "baspi5Ref": "A1.6.1",
               "required": [
                 "yesNo"
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.6.1.1"
+                  "baspi5Ref": "A1.6.1.1"
+                }
+              }
+            },
+            "locatedInUlez": {
+              "baspi5Ref": "A1.6.2",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi5Ref": "A1.6.2.1"
                 }
               }
             }
           }
         },
         "listingAndConservation": {
-          "baspiRef": "A1.7",
+          "baspi5Ref": "A1.7",
           "required": [
             "isListed",
             "isConservationArea",
@@ -1095,7 +1317,7 @@
           ],
           "properties": {
             "isListed": {
-              "baspiRef": "A1.7.1",
+              "baspi5Ref": "A1.7.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1118,10 +1340,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.7.1.2"
+                      "baspi5Ref": "A1.7.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.7.1.3"
+                      "baspi5Ref": "A1.7.1.3"
                     }
                   },
                   "required": [
@@ -1135,12 +1357,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.7.1.1"
+                  "baspi5Ref": "A1.7.1.1"
                 }
               }
             },
             "isConservationArea": {
-              "baspiRef": "A1.7.2",
+              "baspi5Ref": "A1.7.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1163,10 +1385,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.7.2.2"
+                      "baspi5Ref": "A1.7.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.7.2.3"
+                      "baspi5Ref": "A1.7.2.3"
                     }
                   },
                   "required": [
@@ -1180,12 +1402,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.7.2.1"
+                  "baspi5Ref": "A1.7.2.1"
                 }
               }
             },
             "hasTreePreservationOrder": {
-              "baspiRef": "A1.7.3",
+              "baspi5Ref": "A1.7.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1208,7 +1430,7 @@
                       ]
                     },
                     "workCarriedOut": {
-                      "baspiRef": "A1.7.3.2",
+                      "baspi5Ref": "A1.7.3.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1230,10 +1452,10 @@
                               ]
                             },
                             "consentsObtained": {
-                              "baspiRef": "A1.7.3.3"
+                              "baspi5Ref": "A1.7.3.3"
                             },
                             "attachments": {
-                              "baspiRef": "A1.7.3.4"
+                              "baspi5Ref": "A1.7.3.4"
                             }
                           },
                           "required": [
@@ -1246,7 +1468,7 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A1.7.3.2.1"
+                          "baspi5Ref": "A1.7.3.2.1"
                         }
                       }
                     }
@@ -1261,14 +1483,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.7.3.1"
+                  "baspi5Ref": "A1.7.3.1"
                 }
               }
             }
           }
         },
         "typeOfConstruction": {
-          "baspiRef": "A1.8",
+          "baspi5Ref": "A1.8",
           "required": [
             "isStandardForm",
             "buildingSafety",
@@ -1276,7 +1498,7 @@
           ],
           "properties": {
             "isStandardForm": {
-              "baspiRef": "A1.8.1",
+              "baspi5Ref": "A1.8.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1298,7 +1520,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.8.1.2"
+                      "baspi5Ref": "A1.8.1.2"
                     }
                   },
                   "required": [
@@ -1311,12 +1533,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.8.1.1"
+                  "baspi5Ref": "A1.8.1.1"
                 }
               }
             },
             "buildingSafety": {
-              "baspiRef": "A1.8.2",
+              "baspi5Ref": "A1.8.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1338,22 +1560,22 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.8.2.2"
+                      "baspi5Ref": "A1.8.2.2"
                     },
                     "workAlreadyDone": {
-                      "baspiRef": "A1.8.2.2"
+                      "baspi5Ref": "A1.8.2.2"
                     },
                     "workToBeDone": {
-                      "baspiRef": "A1.8.2.2"
+                      "baspi5Ref": "A1.8.2.2"
                     },
                     "potentialCost": {
-                      "baspiRef": "A1.8.2.2"
+                      "baspi5Ref": "A1.8.2.2"
                     },
                     "abilityToResideAtProperty": {
-                      "baspiRef": "A1.8.2.2"
+                      "baspi5Ref": "A1.8.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.8.2.3"
+                      "baspi5Ref": "A1.8.2.3"
                     }
                   },
                   "required": [
@@ -1368,7 +1590,7 @@
               "title": "Are you aware of any remediation required to the property due to building safety?",
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.8.2.1",
+                  "baspi5Ref": "A1.8.2.1",
                   "enum": [
                     "Yes",
                     "No"
@@ -1377,7 +1599,7 @@
               }
             },
             "sprayFoamInsulation": {
-              "baspiRef": "A1.8.4",
+              "baspi5Ref": "A1.8.4",
               "discriminator": {
                 "propertyName": "hasSprayFoamInstalled"
               },
@@ -1399,10 +1621,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.8.4.2"
+                      "baspi5Ref": "A1.8.4.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.8.4.3"
+                      "baspi5Ref": "A1.8.4.3"
                     }
                   },
                   "required": [
@@ -1416,38 +1638,41 @@
               ],
               "properties": {
                 "hasSprayFoamInstalled": {
-                  "baspiRef": "A1.8.4.1"
+                  "baspi5Ref": "A1.8.4.1"
                 }
               }
+            },
+            "accessibilityAndAdaptations": {
+              "baspi5Ref": "A12.2"
             }
           }
         },
         "energyEfficiency": {
-          "baspiRef": "A1.8.3",
+          "baspi5Ref": "A1.8.3",
           "required": [
             "certificate",
             "greenDealLoan"
           ],
           "properties": {
             "certificate": {
-              "baspiRef": "A1.8.3.1",
+              "baspi5Ref": "A1.8.3.1",
               "required": [
                 "currentEnergyRating"
               ],
               "properties": {
                 "currentEnergyRating": {
-                  "baspiRef": "A1.8.3.1.1"
+                  "baspi5Ref": "A1.8.3.1.1"
                 }
               }
             },
             "greenDealLoan": {
-              "baspiRef": "A7.3",
+              "baspi5Ref": "A7.3",
               "required": [
                 "hasGreenDealLoan"
               ],
               "properties": {
                 "hasGreenDealLoan": {
-                  "baspiRef": "A7.3",
+                  "baspi5Ref": "A7.3",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -1469,10 +1694,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A7.3.2"
+                          "baspi5Ref": "A7.3.2"
                         },
                         "attachments": {
-                          "baspiRef": "A7.3.3"
+                          "baspi5Ref": "A7.3.3"
                         }
                       },
                       "required": [
@@ -1486,7 +1711,7 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.3.1"
+                      "baspi5Ref": "A7.3.1"
                     }
                   }
                 }
@@ -1495,17 +1720,17 @@
           }
         },
         "councilTax": {
-          "baspiRef": "A1.9",
+          "baspi5Ref": "A1.9",
           "required": [
             "councilTaxBand",
             "councilTaxAffectingAlterations"
           ],
           "properties": {
             "councilTaxBand": {
-              "baspiRef": "A1.9.1"
+              "baspi5Ref": "A1.9.1"
             },
             "councilTaxAffectingAlterations": {
-              "baspiRef": "A1.9.2",
+              "baspi5Ref": "A1.9.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1527,10 +1752,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A1.9.2.2"
+                      "baspi5Ref": "A1.9.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A1.9.2.3"
+                      "baspi5Ref": "A1.9.2.3"
                     }
                   },
                   "required": [
@@ -1543,21 +1768,21 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A1.9.2.1"
+                  "baspi5Ref": "A1.9.2.1"
                 }
               }
             }
           }
         },
         "disputesAndComplaints": {
-          "baspiRef": "A2",
+          "baspi5Ref": "A2",
           "required": [
             "hasDisputesAndComplaints",
             "leadingToDisputesAndComplaints"
           ],
           "properties": {
             "hasDisputesAndComplaints": {
-              "baspiRef": "A2.1.1",
+              "baspi5Ref": "A2.1.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1579,7 +1804,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A2.1.1.2"
+                      "baspi5Ref": "A2.1.1.2"
                     }
                   },
                   "required": [
@@ -1592,12 +1817,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A2.1.1.1"
+                  "baspi5Ref": "A2.1.1.1"
                 }
               }
             },
             "leadingToDisputesAndComplaints": {
-              "baspiRef": "A2.1.2",
+              "baspi5Ref": "A2.1.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1619,7 +1844,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A2.1.2.2"
+                      "baspi5Ref": "A2.1.2.2"
                     }
                   },
                   "required": [
@@ -1632,14 +1857,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A2.1.2.1"
+                  "baspi5Ref": "A2.1.2.1"
                 }
               }
             }
           }
         },
         "alterationsAndChanges": {
-          "baspiRef": "A3",
+          "baspi5Ref": "A3",
           "required": [
             "hasStructuralAlterations",
             "changeOfUse",
@@ -1651,7 +1876,7 @@
           ],
           "properties": {
             "hasStructuralAlterations": {
-              "baspiRef": "A3.1",
+              "baspi5Ref": "A3.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1673,10 +1898,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.1.2"
+                      "baspi5Ref": "A3.1.2"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1689,7 +1914,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -1705,7 +1930,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2"
+                              "baspi5Ref": "A3.5.1.2"
                             }
                           },
                           "required": [
@@ -1718,12 +1943,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1"
+                          "baspi5Ref": "A3.5.1.1"
                         }
                       }
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1736,7 +1961,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3"
+                              "baspi5Ref": "A3.5.2.3"
                             }
                           },
                           "required": [
@@ -1752,7 +1977,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2"
+                              "baspi5Ref": "A3.5.2.2"
                             }
                           },
                           "required": [
@@ -1765,12 +1990,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1"
+                          "baspi5Ref": "A3.5.2.1"
                         }
                       }
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1783,7 +2008,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -1799,7 +2024,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2"
+                              "baspi5Ref": "A3.5.3.2"
                             }
                           },
                           "required": [
@@ -1812,12 +2037,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1"
+                          "baspi5Ref": "A3.5.3.1"
                         }
                       }
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1830,7 +2055,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -1846,7 +2071,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2"
+                              "baspi5Ref": "A3.5.4.2"
                             }
                           },
                           "required": [
@@ -1859,7 +2084,7 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1"
+                          "baspi5Ref": "A3.5.4.1"
                         }
                       }
                     }
@@ -1878,12 +2103,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.1.1"
+                  "baspi5Ref": "A3.1.1"
                 }
               }
             },
             "changeOfUse": {
-              "baspiRef": "A3.2",
+              "baspi5Ref": "A3.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -1905,13 +2130,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.2.2"
+                      "baspi5Ref": "A3.2.2"
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.2.3"
+                      "baspi5Ref": "A3.2.3"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1924,7 +2149,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -1940,7 +2165,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2"
+                              "baspi5Ref": "A3.5.1.2"
                             }
                           },
                           "required": [
@@ -1953,12 +2178,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1"
+                          "baspi5Ref": "A3.5.1.1"
                         }
                       }
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -1971,7 +2196,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -1987,7 +2212,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2"
+                              "baspi5Ref": "A3.5.2.2"
                             }
                           },
                           "required": [
@@ -2000,12 +2225,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1"
+                          "baspi5Ref": "A3.5.2.1"
                         }
                       }
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2018,7 +2243,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -2034,7 +2259,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2"
+                              "baspi5Ref": "A3.5.3.2"
                             }
                           },
                           "required": [
@@ -2047,12 +2272,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1"
+                          "baspi5Ref": "A3.5.3.1"
                         }
                       }
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2065,7 +2290,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -2081,7 +2306,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2"
+                              "baspi5Ref": "A3.5.4.2"
                             }
                           },
                           "required": [
@@ -2094,7 +2319,7 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1"
+                          "baspi5Ref": "A3.5.4.1"
                         }
                       }
                     }
@@ -2114,12 +2339,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.2.1"
+                  "baspi5Ref": "A3.2.1"
                 }
               }
             },
             "windowReplacementsSince2002": {
-              "baspiRef": "A3.3",
+              "baspi5Ref": "A3.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2141,13 +2366,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.3.2"
+                      "baspi5Ref": "A3.3.2"
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.3.3"
+                      "baspi5Ref": "A3.3.3"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2160,7 +2385,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -2176,7 +2401,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2"
+                              "baspi5Ref": "A3.5.1.2"
                             }
                           },
                           "required": [
@@ -2189,12 +2414,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1"
+                          "baspi5Ref": "A3.5.1.1"
                         }
                       }
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2207,7 +2432,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3"
+                              "baspi5Ref": "A3.5.2.3"
                             }
                           },
                           "required": [
@@ -2223,7 +2448,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2"
+                              "baspi5Ref": "A3.5.2.2"
                             }
                           },
                           "required": [
@@ -2236,12 +2461,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1"
+                          "baspi5Ref": "A3.5.2.1"
                         }
                       }
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2254,7 +2479,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.3.3"
+                              "baspi5Ref": "A3.5.3.3"
                             }
                           },
                           "required": [
@@ -2270,7 +2495,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2"
+                              "baspi5Ref": "A3.5.3.2"
                             }
                           },
                           "required": [
@@ -2283,12 +2508,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1"
+                          "baspi5Ref": "A3.5.3.1"
                         }
                       }
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2301,7 +2526,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.4.3"
+                              "baspi5Ref": "A3.5.4.3"
                             }
                           },
                           "required": [
@@ -2317,7 +2542,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2"
+                              "baspi5Ref": "A3.5.4.2"
                             }
                           },
                           "required": [
@@ -2330,7 +2555,7 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1"
+                          "baspi5Ref": "A3.5.4.1"
                         }
                       }
                     }
@@ -2350,12 +2575,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.3.1"
+                  "baspi5Ref": "A3.3.1"
                 }
               }
             },
             "hasAddedConservatory": {
-              "baspiRef": "A3.4",
+              "baspi5Ref": "A3.4",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2377,13 +2602,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.4.2"
+                      "baspi5Ref": "A3.4.2"
                     },
                     "yearCompleted": {
-                      "baspiRef": "A3.4.3"
+                      "baspi5Ref": "A3.4.3"
                     },
                     "buildingRegApproval": {
-                      "baspiRef": "A3.5.1",
+                      "baspi5Ref": "A3.5.1",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2396,7 +2621,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.1.3"
+                              "baspi5Ref": "A3.5.1.3"
                             }
                           },
                           "required": [
@@ -2412,7 +2637,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.1.2"
+                              "baspi5Ref": "A3.5.1.2"
                             }
                           },
                           "required": [
@@ -2425,12 +2650,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.1.1"
+                          "baspi5Ref": "A3.5.1.1"
                         }
                       }
                     },
                     "planningPermission": {
-                      "baspiRef": "A3.5.2",
+                      "baspi5Ref": "A3.5.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2443,7 +2668,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.2.3"
+                              "baspi5Ref": "A3.5.2.3"
                             }
                           },
                           "required": [
@@ -2459,7 +2684,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.2.2"
+                              "baspi5Ref": "A3.5.2.2"
                             }
                           },
                           "required": [
@@ -2472,12 +2697,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.2.1"
+                          "baspi5Ref": "A3.5.2.1"
                         }
                       }
                     },
                     "listedBuildingConsent": {
-                      "baspiRef": "A3.5.3",
+                      "baspi5Ref": "A3.5.3",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2490,7 +2715,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.3.3"
+                              "baspi5Ref": "A3.5.3.3"
                             }
                           },
                           "required": [
@@ -2506,7 +2731,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.3.2"
+                              "baspi5Ref": "A3.5.3.2"
                             }
                           },
                           "required": [
@@ -2519,12 +2744,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.3.1"
+                          "baspi5Ref": "A3.5.3.1"
                         }
                       }
                     },
                     "deedRestrictionConsent": {
-                      "baspiRef": "A3.5.4",
+                      "baspi5Ref": "A3.5.4",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -2537,7 +2762,7 @@
                               ]
                             },
                             "attachments": {
-                              "baspiRef": "A3.5.4.3"
+                              "baspi5Ref": "A3.5.4.3"
                             }
                           },
                           "required": [
@@ -2553,7 +2778,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "A3.5.4.2"
+                              "baspi5Ref": "A3.5.4.2"
                             }
                           },
                           "required": [
@@ -2566,7 +2791,7 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "A3.5.4.1"
+                          "baspi5Ref": "A3.5.4.1"
                         }
                       }
                     }
@@ -2586,12 +2811,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.4.1"
+                  "baspi5Ref": "A3.4.1"
                 }
               }
             },
             "worksUnfinished": {
-              "baspiRef": "A3.6",
+              "baspi5Ref": "A3.6",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2613,10 +2838,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.6.2"
+                      "baspi5Ref": "A3.6.2"
                     },
                     "attachments": {
-                      "baspiRef": "A3.6.3"
+                      "baspi5Ref": "A3.6.3"
                     }
                   },
                   "required": [
@@ -2630,12 +2855,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.6.1"
+                  "baspi5Ref": "A3.6.1"
                 }
               }
             },
             "planningPermissionBreaches": {
-              "baspiRef": "A3.7",
+              "baspi5Ref": "A3.7",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2657,13 +2882,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.7.2"
+                      "baspi5Ref": "A3.7.2"
                     },
                     "willingToInsure": {
-                      "baspiRef": "A3.9"
+                      "baspi5Ref": "A3.9"
                     },
                     "attachments": {
-                      "baspiRef": "A3.7.3"
+                      "baspi5Ref": "A3.7.3"
                     }
                   },
                   "required": [
@@ -2678,12 +2903,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.7.1"
+                  "baspi5Ref": "A3.7.1"
                 }
               }
             },
             "unresolvedPlanningIssues": {
-              "baspiRef": "A3.8",
+              "baspi5Ref": "A3.8",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2705,13 +2930,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A3.8.2"
+                      "baspi5Ref": "A3.8.2"
                     },
                     "willingToInsure": {
-                      "baspiRef": "A3.9"
+                      "baspi5Ref": "A3.9"
                     },
                     "attachments": {
-                      "baspiRef": "A3.8.3"
+                      "baspi5Ref": "A3.8.3"
                     }
                   },
                   "required": [
@@ -2726,14 +2951,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A3.8.1"
+                  "baspi5Ref": "A3.8.1"
                 }
               }
             }
           }
         },
         "notices": {
-          "baspiRef": "A4",
+          "baspi5Ref": "A4",
           "required": [
             "neighbourDevelopment",
             "planningApplication",
@@ -2745,7 +2970,7 @@
           ],
           "properties": {
             "neighbourDevelopment": {
-              "baspiRef": "A4.1",
+              "baspi5Ref": "A4.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2767,10 +2992,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.1.2"
+                      "baspi5Ref": "A4.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.1.3"
+                      "baspi5Ref": "A4.1.3"
                     }
                   },
                   "required": [
@@ -2784,12 +3009,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.1.1"
+                  "baspi5Ref": "A4.1.1"
                 }
               }
             },
             "planningApplication": {
-              "baspiRef": "A4.2",
+              "baspi5Ref": "A4.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2811,10 +3036,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.2.2"
+                      "baspi5Ref": "A4.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.2.3"
+                      "baspi5Ref": "A4.2.3"
                     }
                   },
                   "required": [
@@ -2828,12 +3053,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.2.1"
+                  "baspi5Ref": "A4.2.1"
                 }
               }
             },
             "requiredMaintenance": {
-              "baspiRef": "A4.3",
+              "baspi5Ref": "A4.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2855,10 +3080,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.3.2"
+                      "baspi5Ref": "A4.3.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.3.3"
+                      "baspi5Ref": "A4.3.3"
                     }
                   },
                   "required": [
@@ -2872,12 +3097,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.3.1"
+                  "baspi5Ref": "A4.3.1"
                 }
               }
             },
             "listedBuildingApplication": {
-              "baspiRef": "A4.4",
+              "baspi5Ref": "A4.4",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2899,10 +3124,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.4.2"
+                      "baspi5Ref": "A4.4.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.4.3"
+                      "baspi5Ref": "A4.4.3"
                     }
                   },
                   "required": [
@@ -2916,12 +3141,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.4.1"
+                  "baspi5Ref": "A4.4.1"
                 }
               }
             },
             "infrastructureProject": {
-              "baspiRef": "A4.5",
+              "baspi5Ref": "A4.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2943,10 +3168,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.5.2"
+                      "baspi5Ref": "A4.5.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.5.3"
+                      "baspi5Ref": "A4.5.3"
                     }
                   },
                   "required": [
@@ -2960,12 +3185,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.5.1"
+                  "baspi5Ref": "A4.5.1"
                 }
               }
             },
             "partyWallAct": {
-              "baspiRef": "A4.6",
+              "baspi5Ref": "A4.6",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -2987,10 +3212,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.6.2"
+                      "baspi5Ref": "A4.6.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.6.3"
+                      "baspi5Ref": "A4.6.3"
                     }
                   },
                   "required": [
@@ -3004,12 +3229,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.6.1"
+                  "baspi5Ref": "A4.6.1"
                 }
               }
             },
             "otherNotices": {
-              "baspiRef": "A4.7",
+              "baspi5Ref": "A4.7",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3031,10 +3256,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A4.7.2"
+                      "baspi5Ref": "A4.7.2"
                     },
                     "attachments": {
-                      "baspiRef": "A4.7.3"
+                      "baspi5Ref": "A4.7.3"
                     }
                   },
                   "required": [
@@ -3048,14 +3273,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A4.7.1"
+                  "baspi5Ref": "A4.7.1"
                 }
               }
             }
           }
         },
         "specialistIssues": {
-          "baspiRef": "A5",
+          "baspi5Ref": "A5",
           "required": [
             "dryRotEtcTreatment",
             "containsAsbestos",
@@ -3065,7 +3290,7 @@
           ],
           "properties": {
             "dryRotEtcTreatment": {
-              "baspiRef": "A5.1",
+              "baspi5Ref": "A5.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3087,10 +3312,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A5.1.2"
+                      "baspi5Ref": "A5.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "A5.1.3"
+                      "baspi5Ref": "A5.1.3"
                     }
                   },
                   "required": [
@@ -3104,12 +3329,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.1.1"
+                  "baspi5Ref": "A5.1.1"
                 }
               }
             },
             "containsAsbestos": {
-              "baspiRef": "A5.2",
+              "baspi5Ref": "A5.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3131,10 +3356,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A5.2.2"
+                      "baspi5Ref": "A5.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A5.2.3"
+                      "baspi5Ref": "A5.2.3"
                     }
                   },
                   "required": [
@@ -3148,12 +3373,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.2.1"
+                  "baspi5Ref": "A5.2.1"
                 }
               }
             },
             "japaneseKnotweed": {
-              "baspiRef": "A5.3",
+              "baspi5Ref": "A5.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3176,10 +3401,10 @@
                       ]
                     },
                     "managementPlanInPlace": {
-                      "baspiRef": "A5.3.2"
+                      "baspi5Ref": "A5.3.2"
                     },
                     "attachments": {
-                      "baspiRef": "A5.3.3"
+                      "baspi5Ref": "A5.3.3"
                     }
                   },
                   "required": [
@@ -3192,7 +3417,7 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.3.1",
+                  "baspi5Ref": "A5.3.1",
                   "enum": [
                     "Yes",
                     "No"
@@ -3201,7 +3426,7 @@
               }
             },
             "subsidenceOrStructuralFault": {
-              "baspiRef": "A5.4",
+              "baspi5Ref": "A5.4",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3223,10 +3448,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A5.4.2"
+                      "baspi5Ref": "A5.4.2"
                     },
                     "attachments": {
-                      "baspiRef": "A5.4.3"
+                      "baspi5Ref": "A5.4.3"
                     }
                   },
                   "required": [
@@ -3240,12 +3465,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.4.1"
+                  "baspi5Ref": "A5.4.1"
                 }
               }
             },
             "ongoingHealthOrSafetyIssue": {
-              "baspiRef": "A5.5",
+              "baspi5Ref": "A5.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3267,10 +3492,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A5.5.2"
+                      "baspi5Ref": "A5.5.2"
                     },
                     "attachments": {
-                      "baspiRef": "A5.5.3"
+                      "baspi5Ref": "A5.5.3"
                     }
                   },
                   "required": [
@@ -3284,21 +3509,21 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A5.5.1"
+                  "baspi5Ref": "A5.5.1"
                 }
               }
             }
           }
         },
         "fixturesAndFittings": {
-          "baspiRef": "A6",
+          "baspi5Ref": "A6",
           "required": [
             "itemsToRemove",
             "itemsToInclude"
           ],
           "properties": {
             "itemsToRemove": {
-              "baspiRef": "A6.1",
+              "baspi5Ref": "A6.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3320,7 +3545,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A6.1.2"
+                      "baspi5Ref": "A6.1.2"
                     }
                   },
                   "required": [
@@ -3333,12 +3558,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A6.1.1"
+                  "baspi5Ref": "A6.1.1"
                 }
               }
             },
             "itemsToInclude": {
-              "baspiRef": "A6.2",
+              "baspi5Ref": "A6.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3360,7 +3585,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A6.2.2"
+                      "baspi5Ref": "A6.2.2"
                     }
                   },
                   "required": [
@@ -3373,14 +3598,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A6.2.1"
+                  "baspi5Ref": "A6.2.1"
                 }
               }
             }
           }
         },
         "electricity": {
-          "baspiRef": "A7.1.0.1",
+          "baspi5Ref": "A7.1.0.1",
           "required": [
             "mainsElectricity",
             "solarPanels",
@@ -3388,7 +3613,7 @@
           ],
           "properties": {
             "mainsElectricity": {
-              "baspiRef": "A7.1.0.1",
+              "baspi5Ref": "A7.1.0.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3410,19 +3635,19 @@
                       ]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.1.2"
+                      "baspi5Ref": "A7.1.0.1.2"
                     },
                     "electricityMeter": {
-                      "baspiRef": "B4.4",
+                      "baspi5Ref": "B4.4",
                       "required": [
                         "location"
                       ],
                       "properties": {
                         "location": {
-                          "baspiRef": "4.4.1"
+                          "baspi5Ref": "4.4.1"
                         },
                         "attachments": {
-                          "baspiRef": "4.4.2"
+                          "baspi5Ref": "4.4.2"
                         }
                       }
                     }
@@ -3439,10 +3664,10 @@
                       ]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.1.3"
+                      "baspi5Ref": "A7.1.0.1.3"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.1.2"
+                      "baspi5Ref": "A7.1.0.1.2"
                     }
                   },
                   "required": [
@@ -3455,12 +3680,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.1.1"
+                  "baspi5Ref": "A7.1.0.1.1"
                 }
               }
             },
             "solarPanels": {
-              "baspiRef": "A7.1.0.8",
+              "baspi5Ref": "A7.1.0.8",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3482,13 +3707,13 @@
                       ]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.8.2"
+                      "baspi5Ref": "A7.1.0.8.2"
                     },
                     "yearInstalled": {
-                      "baspiRef": "B4.3.1"
+                      "baspi5Ref": "B4.3.1"
                     },
                     "panelsOwnedOutright": {
-                      "baspiRef": "B4.3.2",
+                      "baspi5Ref": "B4.3.2",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -3510,10 +3735,10 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "B4.3.2.2"
+                              "baspi5Ref": "B4.3.2.2"
                             },
                             "attachments": {
-                              "baspiRef": "B4.3.2.3"
+                              "baspi5Ref": "B4.3.2.3"
                             }
                           },
                           "required": [
@@ -3527,12 +3752,12 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B4.3.2.1"
+                          "baspi5Ref": "B4.3.2.1"
                         }
                       }
                     },
                     "panelProviderLease": {
-                      "baspiRef": "B4.3.3",
+                      "baspi5Ref": "B4.3.3",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -3554,10 +3779,10 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "4.3.3.2"
+                              "baspi5Ref": "4.3.3.2"
                             },
                             "attachments": {
-                              "baspiRef": "4.3.3.3"
+                              "baspi5Ref": "4.3.3.3"
                             }
                           },
                           "required": [
@@ -3571,15 +3796,15 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "4.3.3.1"
+                          "baspi5Ref": "4.3.3.1"
                         }
                       }
                     },
                     "lastMaintained": {
-                      "baspiRef": "B4.3.4"
+                      "baspi5Ref": "B4.3.4"
                     },
                     "inGoodWorkingOrder": {
-                      "baspiRef": "B4.3.5",
+                      "baspi5Ref": "B4.3.5",
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -3601,7 +3826,7 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "B4.3.5.2"
+                              "baspi5Ref": "B4.3.5.2"
                             }
                           },
                           "required": [
@@ -3614,32 +3839,32 @@
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B4.3.5.1"
+                          "baspi5Ref": "B4.3.5.1"
                         }
                       }
                     },
                     "isConnectedToNationalGrid": {
-                      "baspiRef": "B4.3.6"
+                      "baspi5Ref": "B4.3.6"
                     },
                     "photovoltaicMeterPanelLocation": {
-                      "baspiRef": "B4.7",
+                      "baspi5Ref": "B4.7",
                       "properties": {
                         "description": {
-                          "baspiRef": "4.7.1"
+                          "baspi5Ref": "4.7.1"
                         },
                         "attachments": {
-                          "baspiRef": "4.7.2"
+                          "baspi5Ref": "4.7.2"
                         }
                       }
                     },
                     "photovoltaicBatteriesLocation": {
-                      "baspiRef": "B4.8",
+                      "baspi5Ref": "B4.8",
                       "properties": {
                         "description": {
-                          "baspiRef": "4.8.1"
+                          "baspi5Ref": "4.8.1"
                         },
                         "attachments": {
-                          "baspiRef": "4.8.2"
+                          "baspi5Ref": "4.8.2"
                         }
                       }
                     }
@@ -3661,10 +3886,10 @@
                       ]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.8.3"
+                      "baspi5Ref": "A7.1.0.8.3"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.8.2"
+                      "baspi5Ref": "A7.1.0.8.2"
                     }
                   },
                   "required": [
@@ -3677,12 +3902,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.8.1"
+                  "baspi5Ref": "A7.1.0.8.1"
                 }
               }
             },
-            "otherSources": {
-              "baspiRef": "A7.1.0.9",
+            "heatPump": {
+              "baspi5Ref": "A7.1.0.9",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -3704,9 +3929,19 @@
                       ]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.9.2"
+                      "baspi5Ref": "A7.1.0.10.2"
+                    },
+                    "dateInstalled": {
+                      "baspi5Ref": "A7.1.0.10.3"
+                    },
+                    "attachments": {
+                      "baspi5Ref": "A7.1.0.10.4"
                     }
-                  }
+                  },
+                  "required": [
+                    "dateInstalled",
+                    "attachments"
+                  ]
                 },
                 {
                   "properties": {
@@ -3716,13 +3951,13 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A7.1.0.9.2"
+                      "baspi5Ref": "A7.1.0.10.2"
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.9.3"
+                      "baspi5Ref": "A7.1.0.10.3"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.9.4"
+                      "baspi5Ref": "A7.1.0.10.4"
                     }
                   },
                   "required": [
@@ -3735,14 +3970,72 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.9.1"
+                  "baspi5Ref": "A7.1.0.10.1"
+                }
+              }
+            },
+            "otherSources": {
+              "baspi5Ref": "A7.1.0.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "baspi5Ref": "A7.1.0.9.2"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "baspi5Ref": "A7.1.0.9.2"
+                    },
+                    "dateToBeConnected": {
+                      "baspi5Ref": "A7.1.0.9.3"
+                    },
+                    "supplier": {
+                      "baspi5Ref": "A7.1.0.9.4"
+                    }
+                  },
+                  "required": [
+                    "dateToBeConnected"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "baspi5Ref": "A7.1.0.9.1"
                 }
               }
             }
           }
         },
         "waterAndDrainage": {
-          "baspiRef": "A7.1.0",
+          "baspi5Ref": "A7.1.0",
           "required": [
             "water",
             "drainage",
@@ -3750,13 +4043,13 @@
           ],
           "properties": {
             "water": {
-              "baspiRef": "A7.1.0.10",
+              "baspi5Ref": "A7.1.0.10",
               "required": [
                 "mainsWater"
               ],
               "properties": {
                 "mainsWater": {
-                  "baspiRef": "A7.1.0.10.0",
+                  "baspi5Ref": "A7.1.0.10.0",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -3778,21 +4071,21 @@
                           ]
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.10.2"
+                          "baspi5Ref": "A7.1.0.10.2"
                         },
                         "stopcock": {
-                          "baspiRef": "B4.6.1",
+                          "baspi5Ref": "B4.6.1",
                           "properties": {
                             "location": {
-                              "baspiRef": "4.6.1.1"
+                              "baspi5Ref": "4.6.1.1"
                             },
                             "attachments": {
-                              "baspiRef": "4.6.1.2"
+                              "baspi5Ref": "4.6.1.2"
                             }
                           }
                         },
                         "waterMeter": {
-                          "baspiRef": "A7.",
+                          "baspi5Ref": "A7.",
                           "discriminator": {
                             "propertyName": "isSupplyMetered"
                           },
@@ -3814,10 +4107,10 @@
                                   ]
                                 },
                                 "location": {
-                                  "baspiRef": "4.6.2.1"
+                                  "baspi5Ref": "4.6.2.1"
                                 },
                                 "attachments": {
-                                  "baspiRef": "4.6.2.2"
+                                  "baspi5Ref": "4.6.2.2"
                                 }
                               },
                               "required": [
@@ -3830,7 +4123,7 @@
                           ],
                           "properties": {
                             "isSupplyMetered": {
-                              "baspiRef": "B4.6.2"
+                              "baspi5Ref": "B4.6.2"
                             }
                           }
                         }
@@ -3848,10 +4141,10 @@
                           ]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.10.3"
+                          "baspi5Ref": "A7.1.0.10.3"
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.10.2"
+                          "baspi5Ref": "A7.1.0.10.2"
                         }
                       },
                       "required": [
@@ -3864,21 +4157,21 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.1.0.10.1"
+                      "baspi5Ref": "A7.1.0.10.1"
                     }
                   }
                 }
               }
             },
             "drainage": {
-              "baspiRef": "A7.1.0.12",
+              "baspi5Ref": "A7.1.0.12",
               "required": [
                 "mainsSurfaceWaterDrainage",
                 "mainsFoulDrainage"
               ],
               "properties": {
                 "mainsSurfaceWaterDrainage": {
-                  "baspiRef": "A7.1.0.12.0",
+                  "baspi5Ref": "A7.1.0.12.0",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -3910,7 +4203,7 @@
                           ]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.12.3"
+                          "baspi5Ref": "A7.1.0.12.3"
                         }
                       },
                       "required": [
@@ -3923,12 +4216,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.1.0.12.1"
+                      "baspi5Ref": "A7.1.0.12.1"
                     }
                   }
                 },
                 "mainsFoulDrainage": {
-                  "baspiRef": "A7.1.0.11",
+                  "baspi5Ref": "A7.1.0.11",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -3941,7 +4234,7 @@
                           ]
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.11.2"
+                          "baspi5Ref": "A7.1.0.11.2"
                         }
                       }
                     },
@@ -3953,10 +4246,10 @@
                           ]
                         },
                         "dateToBeConnected": {
-                          "baspiRef": "A7.1.0.11.2"
+                          "baspi5Ref": "A7.1.0.11.2"
                         },
                         "supplier": {
-                          "baspiRef": "A7.1.0.11.3"
+                          "baspi5Ref": "A7.1.0.11.3"
                         }
                       },
                       "required": [
@@ -3972,7 +4265,7 @@
                           ]
                         },
                         "offMainsDrainageSystem": {
-                          "baspiRef": "A7.1.10.13",
+                          "baspi5Ref": "A7.1.10.13",
                           "discriminator": {
                             "propertyName": "offMainsDrainageSystemType"
                           },
@@ -3994,10 +4287,10 @@
                                   ]
                                 },
                                 "dateReplaced": {
-                                  "baspiRef": "A7.1.0.14.2"
+                                  "baspi5Ref": "A7.1.0.14.2"
                                 },
                                 "dateLastEmptied": {
-                                  "baspiRef": "A7.1.0.14.3"
+                                  "baspi5Ref": "A7.1.0.14.3"
                                 }
                               },
                               "required": [
@@ -4013,7 +4306,7 @@
                                   ]
                                 },
                                 "dateLastEmptied": {
-                                  "baspiRef": "A7.1.0.15.2"
+                                  "baspi5Ref": "A7.1.0.15.2"
                                 }
                               },
                               "required": [
@@ -4028,13 +4321,13 @@
                                   ]
                                 },
                                 "dateInstalled": {
-                                  "baspiRef": "A7.1.0.16.2"
+                                  "baspi5Ref": "A7.1.0.16.2"
                                 },
                                 "dateLastServiced": {
-                                  "baspiRef": "A7.1.0.16.3"
+                                  "baspi5Ref": "A7.1.0.16.3"
                                 },
                                 "attachments": {
-                                  "baspiRef": "A7.1.0.16.3"
+                                  "baspi5Ref": "A7.1.0.16.3"
                                 }
                               },
                               "required": [
@@ -4063,10 +4356,10 @@
                           ],
                           "properties": {
                             "offMainsDrainageSystemType": {
-                              "baspiRef": "A7.1"
+                              "baspi5Ref": "A7.1"
                             },
                             "otherConnectedProperties": {
-                              "baspiRef": "A7.1.1",
+                              "baspi5Ref": "A7.1.1",
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -4088,10 +4381,10 @@
                                       ]
                                     },
                                     "numberOfPropertiesSharing": {
-                                      "baspiRef": "A7.1.1.1"
+                                      "baspi5Ref": "A7.1.1.1"
                                     },
                                     "details": {
-                                      "baspiRef": "A7.1.1.2"
+                                      "baspi5Ref": "A7.1.1.2"
                                     }
                                   },
                                   "required": [
@@ -4105,12 +4398,12 @@
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.1.1"
+                                  "baspi5Ref": "A7.1.1.1"
                                 }
                               }
                             },
                             "plantOnOtherLand": {
-                              "baspiRef": "A7.1.2",
+                              "baspi5Ref": "A7.1.2",
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -4132,7 +4425,7 @@
                                       ]
                                     },
                                     "attachments": {
-                                      "baspiRef": "7.1.2.2"
+                                      "baspi5Ref": "7.1.2.2"
                                     }
                                   },
                                   "required": [
@@ -4145,12 +4438,12 @@
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "7.1.2.1"
+                                  "baspi5Ref": "7.1.2.1"
                                 }
                               }
                             },
                             "plantRegistered": {
-                              "baspiRef": "A7.1.3",
+                              "baspi5Ref": "A7.1.3",
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -4172,7 +4465,7 @@
                                       ]
                                     },
                                     "attachments": {
-                                      "baspiRef": "A7.1.3.2"
+                                      "baspi5Ref": "A7.1.3.2"
                                     }
                                   },
                                   "required": [
@@ -4185,12 +4478,12 @@
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.3.1"
+                                  "baspi5Ref": "A7.1.3.1"
                                 }
                               }
                             },
                             "plantDrainsIntoWaterway": {
-                              "baspiRef": "A7.1.4",
+                              "baspi5Ref": "A7.1.4",
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -4212,7 +4505,7 @@
                                       ]
                                     },
                                     "dischargeCompliesWithGBR": {
-                                      "baspiRef": "A7.1.4.1"
+                                      "baspi5Ref": "A7.1.4.1"
                                     }
                                   },
                                   "required": [
@@ -4225,7 +4518,7 @@
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "A7.1.4.1"
+                                  "baspi5Ref": "A7.1.4.1"
                                 }
                               }
                             }
@@ -4239,14 +4532,14 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A7.1.0.11.1"
+                      "baspi5Ref": "A7.1.0.11.1"
                     }
                   }
                 }
               }
             },
             "maintenanceAgreements": {
-              "baspiRef": "A7.2",
+              "baspi5Ref": "A7.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -4268,10 +4561,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A7.2.2"
+                      "baspi5Ref": "A7.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A7.2.3"
+                      "baspi5Ref": "A7.2.3"
                     }
                   },
                   "required": [
@@ -4285,20 +4578,20 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.2.1"
+                  "baspi5Ref": "A7.2.1"
                 }
               }
             }
           }
         },
         "heating": {
-          "baspiRef": "A7.4",
+          "baspi5Ref": "A7.4",
           "required": [
             "heatingSystem"
           ],
           "properties": {
             "heatingSystem": {
-              "baspiRef": "A7.4.0",
+              "baspi5Ref": "A7.4.0",
               "discriminator": {
                 "propertyName": "heatingType"
               },
@@ -4321,7 +4614,7 @@
                       ]
                     },
                     "centralHeatingDetails": {
-                      "baspiRef": "A7.4.0.0",
+                      "baspi5Ref": "A7.4.0.0",
                       "required": [
                         "centralHeatingFuel",
                         "centralHeatingInstalled",
@@ -4332,7 +4625,7 @@
                       ],
                       "properties": {
                         "centralHeatingFuel": {
-                          "baspiRef": "A7.4.0.1",
+                          "baspi5Ref": "A7.4.0.1",
                           "discriminator": {
                             "propertyName": "centralHeatingFuelType"
                           },
@@ -4345,19 +4638,19 @@
                                   ]
                                 },
                                 "supplier": {
-                                  "baspiRef": "A7.1.0"
+                                  "baspi5Ref": "A7.1.0"
                                 },
                                 "gasMeter": {
-                                  "baspiRef": "B4.5",
+                                  "baspi5Ref": "B4.5",
                                   "required": [
                                     "location"
                                   ],
                                   "properties": {
                                     "location": {
-                                      "baspiRef": "4.5.1"
+                                      "baspi5Ref": "4.5.1"
                                     },
                                     "attachments": {
-                                      "baspiRef": "4.5.2"
+                                      "baspi5Ref": "4.5.2"
                                     }
                                   }
                                 }
@@ -4386,7 +4679,7 @@
                                   ]
                                 },
                                 "supplier": {
-                                  "baspiRef": "A7.1.0"
+                                  "baspi5Ref": "A7.1.0"
                                 }
                               }
                             },
@@ -4398,7 +4691,7 @@
                                   ]
                                 },
                                 "otherCentralHeatingFuelType": {
-                                  "baspiRef": "A7.4.0.3"
+                                  "baspi5Ref": "A7.4.0.3"
                                 }
                               },
                               "required": [
@@ -4411,15 +4704,15 @@
                           ],
                           "properties": {
                             "centralHeatingFuelType": {
-                              "baspiRef": "A7.4.0.2"
+                              "baspi5Ref": "A7.4.0.2"
                             }
                           }
                         },
                         "centralHeatingInstalled": {
-                          "baspiRef": "A7.4.1"
+                          "baspi5Ref": "A7.4.1"
                         },
                         "boilerInstallationCertificate": {
-                          "baspiRef": "A7.4.1.1",
+                          "baspi5Ref": "A7.4.1.1",
                           "discriminator": {
                             "propertyName": "yesNo"
                           },
@@ -4441,7 +4734,7 @@
                                   ]
                                 },
                                 "attachments": {
-                                  "baspiRef": "A7.4.1.2"
+                                  "baspi5Ref": "A7.4.1.2"
                                 }
                               },
                               "required": [
@@ -4454,18 +4747,18 @@
                           ],
                           "properties": {
                             "yesNo": {
-                              "baspiRef": "A10.1.1"
+                              "baspi5Ref": "A10.1.1"
                             }
                           }
                         },
                         "heatingLastServicedDate": {
-                          "baspiRef": "A7.4.2.1"
+                          "baspi5Ref": "A7.4.2.1"
                         },
                         "heatingLastServicedReport": {
-                          "baspiRef": "A7.4.2.2"
+                          "baspi5Ref": "A7.4.2.2"
                         },
                         "heatingInGoodWorkingOrder": {
-                          "baspiRef": "A7.4.3",
+                          "baspi5Ref": "A7.4.3",
                           "discriminator": {
                             "propertyName": "yesNo"
                           },
@@ -4487,7 +4780,7 @@
                                   ]
                                 },
                                 "details": {
-                                  "baspiRef": "A7.4.3.2"
+                                  "baspi5Ref": "A7.4.3.2"
                                 }
                               },
                               "required": [
@@ -4500,7 +4793,7 @@
                           ],
                           "properties": {
                             "yesNo": {
-                              "baspiRef": "A7.4.3.1"
+                              "baspi5Ref": "A7.4.3.1"
                             }
                           }
                         }
@@ -4515,7 +4808,7 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     }
                   }
@@ -4526,22 +4819,23 @@
               ],
               "properties": {
                 "heatingType": {
-                  "baspiRef": "A7.4.0"
+                  "baspi5Ref": "A7.4.0"
                 }
               }
             }
           }
         },
         "connectivity": {
-          "baspiRef": "A7",
+          "baspi5Ref": "A7",
           "required": [
             "telephone",
             "cableSatelliteTV",
-            "broadband"
+            "broadband",
+            "mobilePhone"
           ],
           "properties": {
             "telephone": {
-              "baspiRef": "A7.1.0.5",
+              "baspi5Ref": "A7.1.0.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -4563,7 +4857,7 @@
                       ]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.5.2"
+                      "baspi5Ref": "A7.1.0.5.2"
                     }
                   }
                 },
@@ -4575,10 +4869,10 @@
                       ]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.5.3"
+                      "baspi5Ref": "A7.1.0.5.3"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.5.2"
+                      "baspi5Ref": "A7.1.0.5.2"
                     }
                   },
                   "required": [
@@ -4591,12 +4885,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.5.1"
+                  "baspi5Ref": "A7.1.0.5.1"
                 }
               }
             },
             "cableSatelliteTV": {
-              "baspiRef": "A7.1.0.6",
+              "baspi5Ref": "A7.1.0.6",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -4618,7 +4912,7 @@
                       ]
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.6.2"
+                      "baspi5Ref": "A7.1.0.6.2"
                     }
                   }
                 },
@@ -4630,10 +4924,10 @@
                       ]
                     },
                     "dateToBeConnected": {
-                      "baspiRef": "A7.1.0.6.3"
+                      "baspi5Ref": "A7.1.0.6.3"
                     },
                     "supplier": {
-                      "baspiRef": "A7.1.0.6.2"
+                      "baspi5Ref": "A7.1.0.6.2"
                     }
                   },
                   "required": [
@@ -4646,22 +4940,61 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.1.0.6.1"
+                  "baspi5Ref": "A7.1.0.6.1"
                 }
               }
             },
             "broadband": {
-              "baspiRef": "A7.1.0.7",
+              "baspi5Ref": "A7.1.0.7",
               "properties": {
                 "typeOfConnection": {
-                  "baspiRef": "A7.1.0.7.2"
+                  "baspi5Ref": "A7.1.0.7.2"
+                }
+              }
+            },
+            "mobilePhone": {
+              "baspi5Ref": "A7.1.0.8",
+              "properties": {
+                "knownSignalIssues": {
+                  "baspi5Ref": "A7.1.0.8.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi5Ref": "A7.1.0.8.2"
+                    }
+                  }
                 }
               }
             }
           }
         },
         "insurance": {
-          "baspiRef": "A8",
+          "baspi5Ref": "A8",
           "discriminator": {
             "propertyName": "isInsured"
           },
@@ -4674,10 +5007,10 @@
                   ]
                 },
                 "details": {
-                  "baspiRef": "A8.1.1"
+                  "baspi5Ref": "A8.1.1"
                 },
                 "landlordInsuresIfFlat": {
-                  "baspiRef": "A8.1.2"
+                  "baspi5Ref": "A8.1.2"
                 }
               },
               "required": [
@@ -4692,179 +5025,8 @@
                     "Yes"
                   ]
                 },
-                "difficultiesObtainingInsurance": {
-                  "baspiRef": "A8.1.2.1",
-                  "required": [
-                    "abnormalRiseInPremiums",
-                    "subjectToHighExcesses",
-                    "subjectToUnusualConditions",
-                    "refused"
-                  ],
-                  "properties": {
-                    "abnormalRiseInPremiums": {
-                      "baspiRef": "A8.1.2.1.1",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.1.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.1.1"
-                        }
-                      }
-                    },
-                    "subjectToHighExcesses": {
-                      "baspiRef": "A8.1.2.1.2",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.2.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.2.1"
-                        }
-                      }
-                    },
-                    "subjectToUnusualConditions": {
-                      "baspiRef": "A8.1.2.1.3",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.3.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.3.1"
-                        }
-                      }
-                    },
-                    "refused": {
-                      "baspiRef": "A8.1.2.1.4",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "baspiRef": "A8.1.2.1.4.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "baspiRef": "A8.1.2.1.4.1"
-                        }
-                      }
-                    }
-                  }
-                },
                 "insuranceClaims": {
-                  "baspiRef": "A8.2",
+                  "baspi5Ref": "A8.2",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -4886,7 +5048,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A8.2.1"
+                          "baspi5Ref": "A8.2.1"
                         }
                       },
                       "required": [
@@ -4899,28 +5061,199 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A8.2.1"
+                      "baspi5Ref": "A8.2.1"
                     }
                   }
                 }
               },
               "required": [
-                "difficultiesObtainingInsurance",
                 "insuranceClaims"
               ]
             }
           ],
           "required": [
+            "difficultiesObtainingInsurance",
             "isInsured"
           ],
           "properties": {
+            "difficultiesObtainingInsurance": {
+              "baspi5Ref": "A8.1.2.1",
+              "required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "properties": {
+                "abnormalRiseInPremiums": {
+                  "baspi5Ref": "A8.1.2.1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi5Ref": "A8.1.2.1.1.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi5Ref": "A8.1.2.1.1.1"
+                    }
+                  }
+                },
+                "subjectToHighExcesses": {
+                  "baspi5Ref": "A8.1.2.1.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi5Ref": "A8.1.2.1.2.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi5Ref": "A8.1.2.1.2.1"
+                    }
+                  }
+                },
+                "subjectToUnusualConditions": {
+                  "baspi5Ref": "A8.1.2.1.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi5Ref": "A8.1.2.1.3.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi5Ref": "A8.1.2.1.3.1"
+                    }
+                  }
+                },
+                "refused": {
+                  "baspi5Ref": "A8.1.2.1.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "baspi5Ref": "A8.1.2.1.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "baspi5Ref": "A8.1.2.1.4.1"
+                    }
+                  }
+                }
+              }
+            },
             "isInsured": {
-              "baspiRef": "A8.1"
+              "baspi5Ref": "A8.1"
             }
           }
         },
         "rightsAndInformalArrangements": {
-          "baspiRef": "A10",
+          "baspi5Ref": "A10",
           "required": [
             "sharedContributions",
             "neighbouringLandRights",
@@ -4929,7 +5262,7 @@
           ],
           "properties": {
             "sharedContributions": {
-              "baspiRef": "A10.1",
+              "baspi5Ref": "A10.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -4951,7 +5284,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A10.1.2"
+                      "baspi5Ref": "A10.1.2"
                     }
                   },
                   "required": [
@@ -4964,12 +5297,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.1.1"
+                  "baspi5Ref": "A10.1.1"
                 }
               }
             },
             "neighbouringLandRights": {
-              "baspiRef": "A10.2",
+              "baspi5Ref": "A10.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -4991,10 +5324,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A10.2.2"
+                      "baspi5Ref": "A10.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A10.2.3"
+                      "baspi5Ref": "A10.2.3"
                     }
                   },
                   "required": [
@@ -5008,12 +5341,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.2.1"
+                  "baspi5Ref": "A10.2.1"
                 }
               }
             },
             "accessRestrictionAttempts": {
-              "baspiRef": "A10.3",
+              "baspi5Ref": "A10.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5035,7 +5368,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A10.3.2"
+                      "baspi5Ref": "A10.3.2"
                     }
                   },
                   "required": [
@@ -5048,12 +5381,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A10.3.1"
+                  "baspi5Ref": "A10.3.1"
                 }
               }
             },
             "rightsOrArrangements": {
-              "baspiRef": "A10.4",
+              "baspi5Ref": "A10.4",
               "required": [
                 "publicRightOfWay",
                 "rightsOfLight",
@@ -5066,7 +5399,7 @@
               ],
               "properties": {
                 "publicRightOfWay": {
-                  "baspiRef": "A10.4.1",
+                  "baspi5Ref": "A10.4.1",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5088,10 +5421,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.1.2"
+                          "baspi5Ref": "A10.4.1.2"
                         },
                         "attachments": {
-                          "baspiRef": "A10.4.1.3"
+                          "baspi5Ref": "A10.4.1.3"
                         }
                       },
                       "required": [
@@ -5105,12 +5438,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.1.1"
+                      "baspi5Ref": "A10.4.1.1"
                     }
                   }
                 },
                 "rightsOfLight": {
-                  "baspiRef": "A10.4.2a",
+                  "baspi5Ref": "A10.4.2a",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5132,7 +5465,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.2a.2"
+                          "baspi5Ref": "A10.4.2a.2"
                         }
                       },
                       "required": [
@@ -5145,12 +5478,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.2a.1"
+                      "baspi5Ref": "A10.4.2a.1"
                     }
                   }
                 },
                 "rightsOfSupport": {
-                  "baspiRef": "A10.4.2b",
+                  "baspi5Ref": "A10.4.2b",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5172,7 +5505,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.2b.2"
+                          "baspi5Ref": "A10.4.2b.2"
                         }
                       },
                       "required": [
@@ -5185,12 +5518,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.2b.1"
+                      "baspi5Ref": "A10.4.2b.1"
                     }
                   }
                 },
                 "rightsCreatedThroughCustom": {
-                  "baspiRef": "A10.4.3a",
+                  "baspi5Ref": "A10.4.3a",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5212,7 +5545,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.3a2"
+                          "baspi5Ref": "A10.4.3a2"
                         }
                       },
                       "required": [
@@ -5225,12 +5558,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.3a1"
+                      "baspi5Ref": "A10.4.3a1"
                     }
                   }
                 },
                 "rightsToTakeFromLand": {
-                  "baspiRef": "A10.4.3b",
+                  "baspi5Ref": "A10.4.3b",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5252,7 +5585,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.3b2"
+                          "baspi5Ref": "A10.4.3b2"
                         }
                       },
                       "required": [
@@ -5265,12 +5598,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.3b1"
+                      "baspi5Ref": "A10.4.3b1"
                     }
                   }
                 },
                 "minesAndMinerals": {
-                  "baspiRef": "A10.4.4",
+                  "baspi5Ref": "A10.4.4",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5292,7 +5625,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.4.2"
+                          "baspi5Ref": "A10.4.4.2"
                         }
                       },
                       "required": [
@@ -5305,12 +5638,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.4.1"
+                      "baspi5Ref": "A10.4.4.1"
                     }
                   }
                 },
                 "churchChancel": {
-                  "baspiRef": "A10.4.5",
+                  "baspi5Ref": "A10.4.5",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5332,7 +5665,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.5.2"
+                          "baspi5Ref": "A10.4.5.2"
                         }
                       },
                       "required": [
@@ -5345,12 +5678,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.5.1"
+                      "baspi5Ref": "A10.4.5.1"
                     }
                   }
                 },
                 "otherRights": {
-                  "baspiRef": "A10.4.6",
+                  "baspi5Ref": "A10.4.6",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5372,7 +5705,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A10.4.6.2"
+                          "baspi5Ref": "A10.4.6.2"
                         }
                       },
                       "required": [
@@ -5385,7 +5718,7 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A10.4.6.1"
+                      "baspi5Ref": "A10.4.6.1"
                     }
                   }
                 }
@@ -5394,15 +5727,16 @@
           }
         },
         "environmentalIssues": {
-          "baspiRef": "A11.1",
+          "baspi5Ref": "A11.1",
           "required": [
             "flooding",
             "radon",
+            "coastalErosion",
             "otherEnvironmental"
           ],
           "properties": {
             "flooding": {
-              "baspiRef": "A11.1.1",
+              "baspi5Ref": "A11.1.1",
               "required": [
                 "historicalFlooding"
               ],
@@ -5418,7 +5752,7 @@
                   }
                 },
                 "historicalFlooding": {
-                  "baspiRef": "A11.1.2",
+                  "baspi5Ref": "A11.1.2",
                   "discriminator": {
                     "propertyName": "hasBeenFlooded"
                   },
@@ -5440,10 +5774,10 @@
                           ]
                         },
                         "typeOfFlooding": {
-                          "baspiRef": "A11.1.2.2"
+                          "baspi5Ref": "A11.1.2.2"
                         },
                         "details": {
-                          "baspiRef": "A11.1.2.1"
+                          "baspi5Ref": "A11.1.2.1"
                         }
                       },
                       "required": [
@@ -5457,21 +5791,21 @@
                   ],
                   "properties": {
                     "hasBeenFlooded": {
-                      "baspiRef": "A11.1.2.1"
+                      "baspi5Ref": "A11.1.2.1"
                     }
                   }
                 }
               }
             },
             "radon": {
-              "baspiRef": "A11.1.3",
+              "baspi5Ref": "A11.1.3",
               "required": [
                 "remedialMeasuresOnConstruction",
                 "radonTest"
               ],
               "properties": {
                 "radonTest": {
-                  "baspiRef": "A11.1.3",
+                  "baspi5Ref": "A11.1.3",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -5493,10 +5827,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "A11.1.3.2"
+                          "baspi5Ref": "A11.1.3.2"
                         },
                         "attachments": {
-                          "baspiRef": "A11.1.3.3"
+                          "baspi5Ref": "A11.1.3.3"
                         }
                       },
                       "required": [
@@ -5510,25 +5844,51 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A11.1.3.1"
+                      "baspi5Ref": "A11.1.3.1"
                     }
                   }
                 },
                 "remedialMeasuresOnConstruction": {
-                  "baspiRef": "A11.1.3.4",
+                  "baspi5Ref": "A11.1.3.4",
                   "required": [
                     "yesNo"
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "A11.1.3.4.1"
+                      "baspi5Ref": "A11.1.3.4.1"
                     }
                   }
                 }
               }
             },
+            "coastalErosion": {
+              "baspi5Ref": "A11.1.2",
+              "discriminator": {
+                "propertyName": "riskIndicator"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "riskIndicator": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "riskIndicator": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
             "otherEnvironmental": {
-              "baspiRef": "A11.1.4",
+              "baspi5Ref": "A11.1.4",
               "discriminator": {
                 "propertyName": "riskIndicator"
               },
@@ -5551,7 +5911,7 @@
                       ]
                     },
                     "summary": {
-                      "baspiRef": "A11.1.4.2"
+                      "baspi5Ref": "A11.1.4.2"
                     }
                   },
                   "required": [
@@ -5564,23 +5924,22 @@
               ],
               "properties": {
                 "riskIndicator": {
-                  "baspiRef": "A11.1.4.1"
+                  "baspi5Ref": "A11.1.4.1"
                 }
               }
             }
           }
         },
         "otherIssues": {
-          "baspiRef": "A11",
+          "baspi5Ref": "A11",
           "required": [
             "excessiveNoise",
             "crime",
-            "cautionOrConviction",
             "failedTransactionsInLast12Months"
           ],
           "properties": {
             "excessiveNoise": {
-              "baspiRef": "A11.2",
+              "baspi5Ref": "A11.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5602,10 +5961,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A11.2.2"
+                      "baspi5Ref": "A11.3.2"
                     },
                     "attachments": {
-                      "baspiRef": "A11.2.3"
+                      "baspi5Ref": "A11.3.3"
                     }
                   },
                   "required": [
@@ -5618,12 +5977,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.2.1"
+                  "baspi5Ref": "A11.3.1"
                 }
               }
             },
             "crime": {
-              "baspiRef": "A11.3",
+              "baspi5Ref": "A11.4",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5645,10 +6004,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A11.3.2"
+                      "baspi5Ref": "A11.4.2"
                     },
                     "attachments": {
-                      "baspiRef": "A11.3.3"
+                      "baspi5Ref": "A11.4.3"
                     }
                   },
                   "required": [
@@ -5661,55 +6020,25 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.3.1"
+                  "baspi5Ref": "A11.4.1"
                 }
               }
             },
             "cautionOrConviction": {
-              "baspiRef": "A11.4",
-              "discriminator": {
-                "propertyName": "yesNo"
-              },
+              "required": [
+                "yesNo"
+              ],
               "oneOf": [
+                null,
                 {
-                  "properties": {
-                    "yesNo": {
-                      "enum": [
-                        "No"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "yesNo": {
-                      "enum": [
-                        "Yes"
-                      ]
-                    },
-                    "details": {
-                      "baspiRef": "A11.4.2"
-                    },
-                    "attachments": {
-                      "baspiRef": "A11.4.3"
-                    }
-                  },
                   "required": [
                     "details"
                   ]
                 }
-              ],
-              "required": [
-                "yesNo"
-              ],
-              "properties": {
-                "yesNo": {
-                  "baspiRef": "A11.4.1"
-                }
-              }
+              ]
             },
             "failedTransactionsInLast12Months": {
-              "baspiRef": "A11.5",
+              "baspi5Ref": "A11.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5731,10 +6060,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A11.5.2"
+                      "baspi5Ref": "A11.5.2"
                     },
                     "attachments": {
-                      "baspiRef": "A11.5.3"
+                      "baspi5Ref": "A11.5.3"
                     }
                   },
                   "required": [
@@ -5747,14 +6076,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A11.5.1"
+                  "baspi5Ref": "A11.5.1"
                 }
               }
             }
           }
         },
         "additionalInformation": {
-          "baspiRef": "A12",
+          "baspi5Ref": "A12",
           "required": [
             "restrictionsOnUseNotCompliedWith",
             "otherMaterialIssue",
@@ -5762,7 +6091,7 @@
           ],
           "properties": {
             "restrictionsOnUseNotCompliedWith": {
-              "baspiRef": "A12.1",
+              "baspi5Ref": "A12.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5784,10 +6113,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A12.1.2"
+                      "baspi5Ref": "A12.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "A12.1.3"
+                      "baspi5Ref": "A12.1.3"
                     }
                   },
                   "required": [
@@ -5800,12 +6129,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.1.1"
+                  "baspi5Ref": "A12.1.1"
                 }
               }
             },
             "otherMaterialIssue": {
-              "baspiRef": "A12.2",
+              "baspi5Ref": "A12.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5827,10 +6156,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A12.2.2"
+                      "baspi5Ref": "A12.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "A12.2.3"
+                      "baspi5Ref": "A12.2.3"
                     }
                   },
                   "required": [
@@ -5843,12 +6172,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.2.1"
+                  "baspi5Ref": "A12.2.1"
                 }
               }
             },
             "otherCharges": {
-              "baspiRef": "A12.3",
+              "baspi5Ref": "A12.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -5870,7 +6199,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A12.3.2"
+                      "baspi5Ref": "A12.3.2"
                     }
                   },
                   "required": [
@@ -5883,31 +6212,31 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A12.3.1"
+                  "baspi5Ref": "A12.3.1"
                 }
               }
             }
           }
         },
         "consumerProtectionRegulationsDeclaration": {
-          "baspiRef": "A13",
+          "baspi5Ref": "A13",
           "required": [
             "consumerProtectionRegulationsResponse"
           ],
           "properties": {
             "consumerProtectionRegulationsResponse": {
-              "baspiRef": "A13.1"
+              "baspi5Ref": "A13.1"
             }
           }
         },
         "legalOwners": {
-          "baspiRef": "B1",
+          "baspi5Ref": "B1",
           "required": [
             "namesOfLegalOwners"
           ],
           "properties": {
             "namesOfLegalOwners": {
-              "baspiRef": "B1.1",
+              "baspi5Ref": "B1.1",
               "items": {
                 "discriminator": {
                   "propertyName": "ownerType"
@@ -5921,13 +6250,13 @@
                         ]
                       },
                       "firstName": {
-                        "baspiRef": "B1.1.2"
+                        "baspi5Ref": "B1.1.2"
                       },
                       "middleNames": {
-                        "baspiRef": "B1.1.3"
+                        "baspi5Ref": "B1.1.3"
                       },
                       "lastName": {
-                        "baspiRef": "B1.1.4"
+                        "baspi5Ref": "B1.1.4"
                       }
                     },
                     "required": [
@@ -5943,7 +6272,7 @@
                         ]
                       },
                       "organisationName": {
-                        "baspiRef": "B1.1.5"
+                        "baspi5Ref": "B1.1.5"
                       }
                     },
                     "required": [
@@ -5951,13 +6280,13 @@
                     ]
                   }
                 ],
-                "baspiRef": "B1.1",
+                "baspi5Ref": "B1.1",
                 "required": [
                   "ownerType"
                 ],
                 "properties": {
                   "ownerType": {
-                    "baspiRef": "B1.1.1"
+                    "baspi5Ref": "B1.1.1"
                   }
                 }
               }
@@ -5965,7 +6294,7 @@
           }
         },
         "legalBoundaries": {
-          "baspiRef": "B2.1",
+          "baspi5Ref": "B2.1",
           "required": [
             "partOutsideLegalOwnership",
             "partOnSeparateSiteOrDeed",
@@ -5978,7 +6307,7 @@
           ],
           "properties": {
             "partOutsideLegalOwnership": {
-              "baspiRef": "A9.1",
+              "baspi5Ref": "A9.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6000,7 +6329,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A9.1.2"
+                      "baspi5Ref": "A9.1.2"
                     }
                   },
                   "required": [
@@ -6013,12 +6342,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.1.1"
+                  "baspi5Ref": "A9.1.1"
                 }
               }
             },
             "partOnSeparateSiteOrDeed": {
-              "baspiRef": "A9.2",
+              "baspi5Ref": "A9.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6040,7 +6369,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A9.2.2"
+                      "baspi5Ref": "A9.2.2"
                     }
                   },
                   "required": [
@@ -6053,12 +6382,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.2.1"
+                  "baspi5Ref": "A9.2.1"
                 }
               }
             },
             "boundariesDifferFromTitlePlan": {
-              "baspiRef": "A9.3",
+              "baspi5Ref": "A9.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6080,10 +6409,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A9.3.2"
+                      "baspi5Ref": "A9.3.2"
                     },
                     "attachments": {
-                      "baspiRef": "A9.3.3"
+                      "baspi5Ref": "A9.3.3"
                     }
                   },
                   "required": [
@@ -6097,12 +6426,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.3.1"
+                  "baspi5Ref": "A9.3.1"
                 }
               }
             },
             "boundaryAlterationProposal": {
-              "baspiRef": "A9.4",
+              "baspi5Ref": "A9.4",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6124,7 +6453,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "A9.4.2"
+                      "baspi5Ref": "A9.4.2"
                     }
                   },
                   "required": [
@@ -6137,12 +6466,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A9.4.1"
+                  "baspi5Ref": "A9.4.1"
                 }
               }
             },
             "ownership": {
-              "baspiRef": "B2.1.0",
+              "baspi5Ref": "B2.1.0",
               "discriminator": {
                 "propertyName": "areBoundariesUniform"
               },
@@ -6155,7 +6484,7 @@
                       ]
                     },
                     "uniformBoundaries": {
-                      "baspiRef": "B2.1.0.2",
+                      "baspi5Ref": "B2.1.0.2",
                       "required": [
                         "left",
                         "right",
@@ -6164,16 +6493,16 @@
                       ],
                       "properties": {
                         "left": {
-                          "baspiRef": "B2.1.1"
+                          "baspi5Ref": "B2.1.1"
                         },
                         "right": {
-                          "baspiRef": "B2.1.2"
+                          "baspi5Ref": "B2.1.2"
                         },
                         "rear": {
-                          "baspiRef": "B2.1.3"
+                          "baspi5Ref": "B2.1.3"
                         },
                         "front": {
-                          "baspiRef": "B2.1.4"
+                          "baspi5Ref": "B2.1.4"
                         }
                       }
                     }
@@ -6187,10 +6516,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B2.1.5"
+                      "baspi5Ref": "B2.1.5"
                     },
                     "attachments": {
-                      "baspiRef": "B2.1.6"
+                      "baspi5Ref": "B2.1.6"
                     }
                   },
                   "required": [
@@ -6213,12 +6542,12 @@
               ],
               "properties": {
                 "areBoundariesUniform": {
-                  "baspiRef": "B2.1.0.1"
+                  "baspi5Ref": "B2.1.0.1"
                 }
               }
             },
             "haveBoundaryFeaturesMoved": {
-              "baspiRef": "B2.2",
+              "baspi5Ref": "B2.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6241,7 +6570,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B2.2.2"
+                      "baspi5Ref": "B2.2.2"
                     }
                   },
                   "required": [
@@ -6254,12 +6583,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.2.1"
+                  "baspi5Ref": "B2.2.1"
                 }
               }
             },
             "adjacentLandIncluded": {
-              "baspiRef": "B2.3",
+              "baspi5Ref": "B2.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6282,7 +6611,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B2.3.2"
+                      "baspi5Ref": "B2.3.2"
                     }
                   },
                   "required": [
@@ -6295,12 +6624,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.3.1"
+                  "baspi5Ref": "B2.3.1"
                 }
               }
             },
             "flyingFreehold": {
-              "baspiRef": "B2.5",
+              "baspi5Ref": "B2.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6323,7 +6652,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B2.5.2"
+                      "baspi5Ref": "B2.5.2"
                     }
                   },
                   "required": [
@@ -6336,14 +6665,14 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B2.5.1"
+                  "baspi5Ref": "B2.5.1"
                 }
               }
             }
           }
         },
         "servicesCrossing": {
-          "baspiRef": "B3",
+          "baspi5Ref": "B3",
           "required": [
             "pipesWiresCablesDrainsToProperty",
             "pipesWiresCablesDrainsFromProperty",
@@ -6351,7 +6680,7 @@
           ],
           "properties": {
             "pipesWiresCablesDrainsToProperty": {
-              "baspiRef": "B3.1",
+              "baspi5Ref": "B3.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6374,10 +6703,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B3.1.2"
+                      "baspi5Ref": "B3.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "B3.1.3"
+                      "baspi5Ref": "B3.1.3"
                     }
                   },
                   "required": [
@@ -6390,12 +6719,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.1.1"
+                  "baspi5Ref": "B3.1.1"
                 }
               }
             },
             "pipesWiresCablesDrainsFromProperty": {
-              "baspiRef": "B3.2",
+              "baspi5Ref": "B3.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6418,10 +6747,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B3.2.2"
+                      "baspi5Ref": "B3.2.2"
                     },
                     "attachments": {
-                      "baspiRef": "B3.2.3"
+                      "baspi5Ref": "B3.2.3"
                     }
                   },
                   "required": [
@@ -6434,12 +6763,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.2.1"
+                  "baspi5Ref": "B3.2.1"
                 }
               }
             },
             "formalOrInformalAgreements": {
-              "baspiRef": "B3.3",
+              "baspi5Ref": "B3.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6462,10 +6791,10 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B3.3.2"
+                      "baspi5Ref": "B3.3.2"
                     },
                     "attachments": {
-                      "baspiRef": "B3.3.3"
+                      "baspi5Ref": "B3.3.3"
                     }
                   },
                   "required": [
@@ -6478,21 +6807,21 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B3.3.1"
+                  "baspi5Ref": "B3.3.1"
                 }
               }
             }
           }
         },
         "electricalWorks": {
-          "baspiRef": "B4",
+          "baspi5Ref": "B4",
           "required": [
             "testedByQualifiedElectrician",
             "electricalWorkSince2005"
           ],
           "properties": {
             "testedByQualifiedElectrician": {
-              "baspiRef": "B4.1",
+              "baspi5Ref": "B4.1",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6514,10 +6843,10 @@
                       ]
                     },
                     "yearTested": {
-                      "baspiRef": "B4.1.2"
+                      "baspi5Ref": "B4.1.2"
                     },
                     "attachments": {
-                      "baspiRef": "B4.1.3"
+                      "baspi5Ref": "B4.1.3"
                     }
                   },
                   "required": [
@@ -6531,12 +6860,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B4.1.1"
+                  "baspi5Ref": "B4.1.1"
                 }
               }
             },
             "electricalWorkSince2005": {
-              "baspiRef": "B4.2",
+              "baspi5Ref": "B4.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -6559,23 +6888,23 @@
                       ]
                     },
                     "yearWorkCarriedOut": {
-                      "baspiRef": "B4.2.2"
+                      "baspi5Ref": "B4.2.2"
                     },
                     "details": {
-                      "baspiRef": "B4.2.3"
+                      "baspi5Ref": "B4.2.3"
                     },
                     "suppliedCertificate": {
-                      "baspiRef": "B4.2.4.1",
+                      "baspi5Ref": "B4.2.4.1",
                       "required": [
                         "certificateType",
                         "attachments"
                       ],
                       "properties": {
                         "certificateType": {
-                          "baspiRef": "B4.2.3.1"
+                          "baspi5Ref": "B4.2.3.1"
                         },
                         "attachments": {
-                          "baspiRef": "B4.2.3.2"
+                          "baspi5Ref": "B4.2.3.2"
                         }
                       }
                     }
@@ -6592,7 +6921,7 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B4.2.1",
+                  "baspi5Ref": "B4.2.1",
                   "enum": [
                     "Yes",
                     "No"
@@ -6603,7 +6932,7 @@
           }
         },
         "smartHomeSystems": {
-          "baspiRef": "B7.4",
+          "baspi5Ref": "B7.4",
           "discriminator": {
             "propertyName": "hasSmartHomeSystems"
           },
@@ -6625,7 +6954,7 @@
                   ]
                 },
                 "heatingAndPower": {
-                  "baspiRef": "B7.4.2",
+                  "baspi5Ref": "B7.4.2",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6647,7 +6976,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B7.4.2.2"
+                          "baspi5Ref": "B7.4.2.2"
                         }
                       },
                       "required": [
@@ -6660,12 +6989,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.2.1"
+                      "baspi5Ref": "B7.4.2.1"
                     }
                   }
                 },
                 "security": {
-                  "baspiRef": "B7.4.3",
+                  "baspi5Ref": "B7.4.3",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6687,7 +7016,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B7.4.3.2"
+                          "baspi5Ref": "B7.4.3.2"
                         }
                       },
                       "required": [
@@ -6700,12 +7029,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.3.1"
+                      "baspi5Ref": "B7.4.3.1"
                     }
                   }
                 },
                 "entertainment": {
-                  "baspiRef": "B7.4.4",
+                  "baspi5Ref": "B7.4.4",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6727,7 +7056,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B7.4.4.2"
+                          "baspi5Ref": "B7.4.4.2"
                         }
                       },
                       "required": [
@@ -6740,12 +7069,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B7.4.4.1"
+                      "baspi5Ref": "B7.4.4.1"
                     }
                   }
                 },
                 "handoverOnCompletion": {
-                  "baspiRef": "B7.4.2"
+                  "baspi5Ref": "B7.4.2"
                 }
               },
               "required": [
@@ -6761,12 +7090,12 @@
           ],
           "properties": {
             "hasSmartHomeSystems": {
-              "baspiRef": "B7.4.1"
+              "baspi5Ref": "B7.4.1"
             }
           }
         },
         "guaranteesWarrantiesAndIndemnityInsurances": {
-          "baspiRef": "B5",
+          "baspi5Ref": "B5",
           "discriminator": {
             "propertyName": "hasValidGuaranteesOrWarranties"
           },
@@ -6788,7 +7117,7 @@
                   ]
                 },
                 "newHomeWarranty": {
-                  "baspiRef": "B5.1.1",
+                  "baspi5Ref": "B5.1.1",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6810,10 +7139,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.3"
+                          "baspi5Ref": "B5.1.1.3"
                         }
                       },
                       "required": [
@@ -6827,12 +7156,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.1.1"
+                      "baspi5Ref": "B5.1.1.1"
                     }
                   }
                 },
                 "roofingWork": {
-                  "baspiRef": "B5.1.2",
+                  "baspi5Ref": "B5.1.2",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6854,7 +7183,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -6867,12 +7196,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.2.1"
+                      "baspi5Ref": "B5.1.2.1"
                     }
                   }
                 },
                 "dampProofingTreatment": {
-                  "baspiRef": "B5.1.3",
+                  "baspi5Ref": "B5.1.3",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6894,7 +7223,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -6907,12 +7236,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.3.1"
+                      "baspi5Ref": "B5.1.3.1"
                     }
                   }
                 },
                 "timberRotOrInfestationTreatment": {
-                  "baspiRef": "B5.1.4",
+                  "baspi5Ref": "B5.1.4",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6934,7 +7263,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -6947,12 +7276,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.4.1"
+                      "baspi5Ref": "B5.1.4.1"
                     }
                   }
                 },
                 "centralHeatingAndorPlumbing": {
-                  "baspiRef": "B5.1.5",
+                  "baspi5Ref": "B5.1.5",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -6974,7 +7303,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -6987,12 +7316,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.5.1"
+                      "baspi5Ref": "B5.1.5.1"
                     }
                   }
                 },
                 "doubleGlazing": {
-                  "baspiRef": "B5.1.6",
+                  "baspi5Ref": "B5.1.6",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7014,7 +7343,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -7027,12 +7356,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.6.1"
+                      "baspi5Ref": "B5.1.6.1"
                     }
                   }
                 },
                 "electricalRepairOrInstallation": {
-                  "baspiRef": "B5.1.7",
+                  "baspi5Ref": "B5.1.7",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7054,7 +7383,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -7067,12 +7396,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.7.1"
+                      "baspi5Ref": "B5.1.7.1"
                     }
                   }
                 },
                 "subsidenceWork": {
-                  "baspiRef": "B5.1.8",
+                  "baspi5Ref": "B5.1.8",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7094,7 +7423,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -7107,12 +7436,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.8.1"
+                      "baspi5Ref": "B5.1.8.1"
                     }
                   }
                 },
                 "solarPanels": {
-                  "baspiRef": "B5.1.9",
+                  "baspi5Ref": "B5.1.9",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7134,7 +7463,7 @@
                           ]
                         },
                         "attachments": {
-                          "baspiRef": "B5.1.1.2"
+                          "baspi5Ref": "B5.1.1.2"
                         }
                       },
                       "required": [
@@ -7147,12 +7476,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.9.1"
+                      "baspi5Ref": "B5.1.9.1"
                     }
                   }
                 },
                 "otherGuarantees": {
-                  "baspiRef": "B5.1.10",
+                  "baspi5Ref": "B5.1.10",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7174,7 +7503,7 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B5.1.10.2"
+                          "baspi5Ref": "B5.1.10.2"
                         }
                       },
                       "required": [
@@ -7187,12 +7516,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.1.10.1"
+                      "baspi5Ref": "B5.1.10.1"
                     }
                   }
                 },
                 "outstandingClaimsOrApplications": {
-                  "baspiRef": "B5.2",
+                  "baspi5Ref": "B5.2",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7214,10 +7543,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B5.2.2"
+                          "baspi5Ref": "B5.2.2"
                         },
                         "attachments": {
-                          "baspiRef": "B5.2.3"
+                          "baspi5Ref": "B5.2.3"
                         }
                       },
                       "required": [
@@ -7230,12 +7559,12 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.2.1"
+                      "baspi5Ref": "B5.2.1"
                     }
                   }
                 },
                 "titleDefectInsurance": {
-                  "baspiRef": "B5.3",
+                  "baspi5Ref": "B5.3",
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -7257,10 +7586,10 @@
                           ]
                         },
                         "details": {
-                          "baspiRef": "B5.3.2"
+                          "baspi5Ref": "B5.3.2"
                         },
                         "attachments": {
-                          "baspiRef": "B5.3.3"
+                          "baspi5Ref": "B5.3.3"
                         }
                       },
                       "required": [
@@ -7274,7 +7603,7 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspiRef": "B5.3.1"
+                      "baspi5Ref": "B5.3.1"
                     }
                   }
                 }
@@ -7300,30 +7629,30 @@
           ],
           "properties": {
             "hasValidGuaranteesOrWarranties": {
-              "baspiRef": "B5.1"
+              "baspi5Ref": "B5.1"
             }
           }
         },
         "occupiers": {
-          "baspiRef": "B6",
+          "baspi5Ref": "B6",
           "required": [
             "sellerLivesAtProperty",
             "othersAged17OrOver"
           ],
           "properties": {
             "sellerLivesAtProperty": {
-              "baspiRef": "B6.1",
+              "baspi5Ref": "B6.1",
               "required": [
                 "yesNo"
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B6.1.1"
+                  "baspi5Ref": "B6.1.1"
                 }
               }
             },
             "othersAged17OrOver": {
-              "baspiRef": "B6.2",
+              "baspi5Ref": "B6.2",
               "discriminator": {
                 "propertyName": "hasOthersAged17OrOver"
               },
@@ -7345,21 +7674,21 @@
                       ]
                     },
                     "aged17OrOverNames": {
-                      "baspiRef": "B6.2.2"
+                      "baspi5Ref": "B6.2.2"
                     },
                     "aged17OrOverTenantsOrLodgers": {
-                      "baspiRef": "B6.2.3",
+                      "baspi5Ref": "B6.2.3",
                       "required": [
                         "yesNo"
                       ],
                       "properties": {
                         "yesNo": {
-                          "baspiRef": "B6.2.2.1"
+                          "baspi5Ref": "B6.2.2.1"
                         }
                       }
                     },
                     "vacantPossession": {
-                      "baspiRef": "B6.2.4",
+                      "baspi5Ref": "B6.2.4",
                       "discriminator": {
                         "propertyName": "soldWithVacantPossession"
                       },
@@ -7372,10 +7701,10 @@
                               ]
                             },
                             "details": {
-                              "baspiRef": "B6.2.4.2"
+                              "baspi5Ref": "B6.2.4.2"
                             },
                             "attachments": {
-                              "baspiRef": "B6.2.4.3"
+                              "baspi5Ref": "B6.2.4.3"
                             }
                           },
                           "required": [
@@ -7390,18 +7719,18 @@
                               ]
                             },
                             "aged17OrOverAgreedToLeave": {
-                              "baspiRef": "B6.3.1",
+                              "baspi5Ref": "B6.3.1",
                               "required": [
                                 "yesNo"
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "B6.3.1.1"
+                                  "baspi5Ref": "B6.3.1.1"
                                 }
                               }
                             },
                             "aged17OrOverWillSignToConfirmWillVacate": {
-                              "baspiRef": "B6.3.2",
+                              "baspi5Ref": "B6.3.2",
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -7423,10 +7752,10 @@
                                       ]
                                     },
                                     "details": {
-                                      "baspiRef": "B6.3.2.2"
+                                      "baspi5Ref": "B6.3.2.2"
                                     },
                                     "attachments": {
-                                      "baspiRef": "B6.3.2.3"
+                                      "baspi5Ref": "B6.3.2.3"
                                     }
                                   },
                                   "required": [
@@ -7440,7 +7769,7 @@
                               ],
                               "properties": {
                                 "yesNo": {
-                                  "baspiRef": "B6.3.2.1"
+                                  "baspi5Ref": "B6.3.2.1"
                                 }
                               }
                             }
@@ -7456,7 +7785,7 @@
                       ],
                       "properties": {
                         "soldWithVacantPossession": {
-                          "baspiRef": "B6.2.4.1"
+                          "baspi5Ref": "B6.2.4.1"
                         }
                       }
                     }
@@ -7473,14 +7802,14 @@
               ],
               "properties": {
                 "hasOthersAged17OrOver": {
-                  "baspiRef": "B6.2.1"
+                  "baspi5Ref": "B6.2.1"
                 }
               }
             }
           }
         },
         "completionAndMoving": {
-          "baspiRef": "B7",
+          "baspi5Ref": "B7",
           "required": [
             "sellerWillEnsure",
             "otherPropertyInChain",
@@ -7490,24 +7819,24 @@
           ],
           "properties": {
             "sellerWillEnsure": {
-              "baspiRef": "B7.1",
+              "baspi5Ref": "B7.1",
               "properties": {
                 "removeRubbish": {
-                  "baspiRef": "B7.1.1"
+                  "baspi5Ref": "B7.1.1"
                 },
                 "replaceLightFittings": {
-                  "baspiRef": "B7.1.2"
+                  "baspi5Ref": "B7.1.2"
                 },
                 "takeReasonableCare": {
-                  "baspiRef": "B7.1.3"
+                  "baspi5Ref": "B7.1.3"
                 },
                 "leaveKeys": {
-                  "baspiRef": "B7.1.4"
+                  "baspi5Ref": "B7.1.4"
                 }
               }
             },
             "otherPropertyInChain": {
-              "baspiRef": "B7.2",
+              "baspi5Ref": "B7.2",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -7529,29 +7858,29 @@
                       ]
                     },
                     "propertyDependencyType": {
-                      "baspiRef": "B7.2.2"
+                      "baspi5Ref": "B7.2.2"
                     },
                     "dependentPropertyAddress": {
-                      "baspiRef": "B7.2.3",
+                      "baspi5Ref": "B7.2.3",
                       "required": [
                         "line1",
                         "postcode"
                       ],
                       "properties": {
                         "line1": {
-                          "baspiRef": "B7.2.3.1"
+                          "baspi5Ref": "B7.2.3.1"
                         },
                         "line2": {
-                          "baspiRef": "B7.2.3.2"
+                          "baspi5Ref": "B7.2.3.2"
                         },
                         "line3": {
-                          "baspiRef": "B7.2.3.3"
+                          "baspi5Ref": "B7.2.3.3"
                         },
                         "town": {
-                          "baspiRef": "B7.2.3.4"
+                          "baspi5Ref": "B7.2.3.4"
                         },
                         "postcode": {
-                          "baspiRef": "B7.2.3.5"
+                          "baspi5Ref": "B7.2.3.5"
                         }
                       }
                     }
@@ -7567,12 +7896,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.2.1"
+                  "baspi5Ref": "B7.2.1"
                 }
               }
             },
             "moveRestrictionDates": {
-              "baspiRef": "B7.3",
+              "baspi5Ref": "B7.3",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -7594,7 +7923,7 @@
                       ]
                     },
                     "details": {
-                      "baspiRef": "B7.3.2"
+                      "baspi5Ref": "B7.3.2"
                     }
                   },
                   "required": [
@@ -7607,12 +7936,12 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.3.1"
+                  "baspi5Ref": "B7.3.1"
                 }
               }
             },
             "digitalPropertyLogbook": {
-              "baspiRef": "B7.5",
+              "baspi5Ref": "B7.5",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -7634,10 +7963,10 @@
                       ]
                     },
                     "logbookProvider": {
-                      "baspiRef": "B7.5.2"
+                      "baspi5Ref": "B7.5.2"
                     },
                     "willHandoverLogbook": {
-                      "baspiRef": "B7.5.2"
+                      "baspi5Ref": "B7.5.2"
                     }
                   },
                   "required": [
@@ -7651,35 +7980,35 @@
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "B7.5.1"
+                  "baspi5Ref": "B7.5.1"
                 }
               }
             },
             "sufficientToRepayAllMortgages": {
-              "baspiRef": "B7.6",
+              "baspi5Ref": "B7.6",
               "required": [
                 "yesNo"
               ],
               "properties": {
                 "yesNo": {
-                  "baspiRef": "A7.6.1"
+                  "baspi5Ref": "A7.6.1"
                 }
               }
             }
           }
         },
         "confirmationOfAccuracyByOwners": {
-          "baspiRef": "B8",
+          "baspi5Ref": "B8",
           "required": [
             "confirmWillProvideAdditionalDocumentation",
             "confirmInformationIsAccurate"
           ],
           "properties": {
             "confirmWillProvideAdditionalDocumentation": {
-              "baspiRef": "B8.1"
+              "baspi5Ref": "B8.1"
             },
             "confirmInformationIsAccurate": {
-              "baspiRef": "B8.2"
+              "baspi5Ref": "B8.2"
             }
           }
         }

--- a/src/schemas/v3/overlays/nts.json
+++ b/src/schemas/v3/overlays/nts.json
@@ -587,6 +587,30 @@
             },
             "controlledParking": {
               "ntsRef": "B4.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -1160,7 +1184,7 @@
                 }
               }
             },
-            "otherSources": {
+            "heatPump": {
               "ntsRef": "B3.8",
               "discriminator": {
                 "propertyName": "yesNo"
@@ -1209,6 +1233,62 @@
               "properties": {
                 "yesNo": {
                   "ntsRef": "B3.8.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "otherSources": {
+              "ntsRef": "B3.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ntsRef": "B3.9.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "ntsRef": "B3.9.2"
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "B3.9.1",
                   "enum": [
                     "Yes",
                     "No"
@@ -1598,7 +1678,7 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     },
                     "details": {

--- a/src/schemas/v3/overlays/ntsl.json
+++ b/src/schemas/v3/overlays/ntsl.json
@@ -257,6 +257,30 @@
             },
             "controlledParking": {
               "ntslRef": "B4.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -830,7 +854,7 @@
                 }
               }
             },
-            "otherSources": {
+            "heatPump": {
               "ntslRef": "B3.8",
               "discriminator": {
                 "propertyName": "yesNo"
@@ -879,6 +903,62 @@
               "properties": {
                 "yesNo": {
                   "ntslRef": "B3.8.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "otherSources": {
+              "ntslRef": "B3.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ntslRef": "B3.9.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "ntslRef": "B3.9.2"
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ntslRef": "B3.9.1",
                   "enum": [
                     "Yes",
                     "No"
@@ -1268,7 +1348,7 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     },
                     "details": {

--- a/src/schemas/v3/overlays/oc1.json
+++ b/src/schemas/v3/overlays/oc1.json
@@ -37,16 +37,34 @@
                         }
                       },
                       "propertyAddress": {
-                        "required": [
-                          "addressLine"
-                        ],
-                        "properties": {
-                          "postcodeZone": {
+                        "oneOf": [
+                          {
+                            "items": {
+                              "required": [
+                                "addressLine"
+                              ],
+                              "properties": {
+                                "postcodeZone": {
+                                  "required": [
+                                    "postcode"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          {
                             "required": [
-                              "postcode"
-                            ]
+                              "addressLine"
+                            ],
+                            "properties": {
+                              "postcodeZone": {
+                                "required": [
+                                  "postcode"
+                                ]
+                              }
+                            }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "required": [

--- a/src/schemas/v3/overlays/piq.json
+++ b/src/schemas/v3/overlays/piq.json
@@ -3,38 +3,70 @@
   "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/piq.json",
   "properties": {
     "participants": {
+      "piqRef": "B1",
       "items": {
-        "properties": {
-          "sellersCapacity": {
-            "piqRef": "B1.3.1",
-            "discriminator": {
-              "propertyName": "capacity"
-            },
-            "oneOf": [
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Legal Owner",
-                      "Mortgagee in Possession"
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Personal Representative for a Deceased Owner",
-                      "Under Power of Attorney",
-                      "Other"
-                    ]
-                  }
-                }
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer",
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
+                ]
               }
-            ]
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller"
+                ]
+              },
+              "sellersCapacity": {
+                "piqRef": "B1.3.1",
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
           }
-        }
+        ]
       }
     },
     "propertyPack": {
@@ -1262,6 +1294,44 @@
                 }
               ]
             },
+            "heatPump": {
+              "piqRef": "A7.1.19",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "supplier": {
+                      "piqRef": "A7.1.20"
+                    }
+                  }
+                }
+              ]
+            },
             "otherSources": {
               "piqRef": "A7.1.19",
               "discriminator": {
@@ -1567,7 +1637,7 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     }
                   }
@@ -1674,158 +1744,151 @@
         },
         "insurance": {
           "properties": {
-            "isInsured": {
-              "piqRef": "A8.2"
-            }
-          },
-          "oneOf": [
-            null,
-            {
+            "difficultiesObtainingInsurance": {
+              "piqRef": "A8.1",
               "properties": {
-                "difficultiesObtainingInsurance": {
-                  "piqRef": "A8.1",
+                "abnormalRiseInPremiums": {
+                  "piqRef": "A8.1a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "piqRef": "A8.1a1.1"
+                        }
+                      }
+                    }
+                  ],
                   "properties": {
-                    "abnormalRiseInPremiums": {
-                      "piqRef": "A8.1a",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "piqRef": "A8.1a1.1"
-                            }
-                          }
-                        }
-                      ],
+                    "yesNo": {
+                      "piqRef": "A8.1a1"
+                    }
+                  }
+                },
+                "subjectToHighExcesses": {
+                  "piqRef": "A8.1b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
                       "properties": {
                         "yesNo": {
-                          "piqRef": "A8.1a1"
+                          "enum": [
+                            "No"
+                          ]
                         }
                       }
                     },
-                    "subjectToHighExcesses": {
-                      "piqRef": "A8.1b",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "piqRef": "A8.1b2"
-                            }
-                          }
-                        }
-                      ],
+                    {
                       "properties": {
                         "yesNo": {
-                          "piqRef": "A8.1b1"
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "piqRef": "A8.1b2"
+                        }
+                      }
+                    }
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "piqRef": "A8.1b1"
+                    }
+                  }
+                },
+                "subjectToUnusualConditions": {
+                  "piqRef": "A8.1c",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
                         }
                       }
                     },
-                    "subjectToUnusualConditions": {
-                      "piqRef": "A8.1c",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "piqRef": "A8.1c2"
-                            }
-                          }
-                        }
-                      ],
+                    {
                       "properties": {
                         "yesNo": {
-                          "piqRef": "A8.1c1"
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "piqRef": "A8.1c2"
+                        }
+                      }
+                    }
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "piqRef": "A8.1c1"
+                    }
+                  }
+                },
+                "refused": {
+                  "piqRef": "A8.1d",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
                         }
                       }
                     },
-                    "refused": {
-                      "piqRef": "A8.1d",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "piqRef": "A8.1d2"
-                            }
-                          }
-                        }
-                      ],
+                    {
                       "properties": {
                         "yesNo": {
-                          "piqRef": "A8.1d1"
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "piqRef": "A8.1d2"
                         }
                       }
+                    }
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "piqRef": "A8.1d1"
                     }
                   }
                 }
               }
+            },
+            "isInsured": {
+              "piqRef": "A8.2"
             }
-          ]
+          }
         },
         "rightsAndInformalArrangements": {
           "properties": {

--- a/src/schemas/v3/overlays/rds.json
+++ b/src/schemas/v3/overlays/rds.json
@@ -4,43 +4,48 @@
   "properties": {
     "participants": {
       "items": {
-        "properties": {
-          "sellersCapacity": {
-            "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
-            "discriminator": {
-              "propertyName": "capacity"
-            },
-            "oneOf": [
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Legal Owner",
-                      "Mortgagee in Possession"
-                    ]
+        "oneOf": [
+          null,
+          {
+            "properties": {
+              "sellersCapacity": {
+                "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "rdsRef": "Participants/OtherDocumentation"
+                      }
+                    }
                   },
-                  "sellersCapacityDetails": {
-                    "rdsRef": "Participants/OtherDocumentation"
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "rdsRef": "Participants/OtherDocumentation"
+                      }
+                    }
                   }
-                }
-              },
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
-                      "Personal Representative for a Deceased Owner",
-                      "Under Power of Attorney",
-                      "Other"
-                    ]
-                  },
-                  "sellersCapacityDetails": {
-                    "rdsRef": "Participants/OtherDocumentation"
-                  }
-                }
+                ]
               }
-            ]
+            }
           }
-        }
+        ]
       }
     },
     "propertyPack": {
@@ -1982,6 +1987,9 @@
         },
         "insurance": {
           "properties": {
+            "difficultiesObtainingInsurance": {
+              "rdsRef": "Insurance/Flags,Insurance/refusalReason=?"
+            },
             "isInsured": {
               "rdsRef": "Insurance/isInsured=no|yes|true|false"
             }
@@ -1990,9 +1998,6 @@
             null,
             {
               "properties": {
-                "difficultiesObtainingInsurance": {
-                  "rdsRef": "Insurance/Flags,Insurance/refusalReason=?"
-                },
                 "insuranceClaims": {
                   "rdsRef": "Insurance/Claims",
                   "discriminator": {

--- a/src/schemas/v3/overlays/sr24.json
+++ b/src/schemas/v3/overlays/sr24.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/sr24.json",
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "saleReadyDeclarations": {
+          "sr24Ref": "1",
+          "required": [
+            "authorisedToActOnBehalfOfAllSellers",
+            "authorisationToShare"
+          ],
+          "properties": {
+            "authorisedToActOnBehalfOfAllSellers": {
+              "sr24Ref": "1.1"
+            },
+            "authorisationToShare": {
+              "sr24Ref": "1.2"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/v3/overlays/ta6.json
+++ b/src/schemas/v3/overlays/ta6.json
@@ -69,6 +69,30 @@
             },
             "controlledParking": {
               "ta6Ref": "9.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -2264,7 +2288,7 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     }
                   }
@@ -2431,178 +2455,6 @@
                     "Yes"
                   ]
                 },
-                "difficultiesObtainingInsurance": {
-                  "ta6Ref": "6.4",
-                  "required": [
-                    "abnormalRiseInPremiums",
-                    "subjectToHighExcesses",
-                    "subjectToUnusualConditions",
-                    "refused"
-                  ],
-                  "title": "Has any buildings insurance taken out by the seller ever been:",
-                  "properties": {
-                    "abnormalRiseInPremiums": {
-                      "ta6Ref": "6.4a",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "ta6Ref": "6.4.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "ta6Ref": "6.4a1"
-                        }
-                      }
-                    },
-                    "subjectToHighExcesses": {
-                      "ta6Ref": "6.4b",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "ta6Ref": "6.4.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "ta6Ref": "6.4b1"
-                        }
-                      }
-                    },
-                    "subjectToUnusualConditions": {
-                      "ta6Ref": "6.4c",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "ta6Ref": "6.4.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "ta6Ref": "6.4c1"
-                        }
-                      }
-                    },
-                    "refused": {
-                      "ta6Ref": "6.4d",
-                      "discriminator": {
-                        "propertyName": "yesNo"
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "ta6Ref": "6.4.2"
-                            }
-                          },
-                          "required": [
-                            "details"
-                          ]
-                        }
-                      ],
-                      "required": [
-                        "yesNo"
-                      ],
-                      "properties": {
-                        "yesNo": {
-                          "ta6Ref": "6.4d1"
-                        }
-                      }
-                    }
-                  }
-                },
                 "insuranceClaims": {
                   "ta6Ref": "6.5",
                   "discriminator": {
@@ -2645,15 +2497,187 @@
                 }
               },
               "required": [
-                "difficultiesObtainingInsurance",
                 "insuranceClaims"
               ]
             }
           ],
           "required": [
+            "difficultiesObtainingInsurance",
             "isInsured"
           ],
           "properties": {
+            "difficultiesObtainingInsurance": {
+              "ta6Ref": "6.4",
+              "required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "title": "Has any buildings insurance taken out by the seller ever been:",
+              "properties": {
+                "abnormalRiseInPremiums": {
+                  "ta6Ref": "6.4a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6Ref": "6.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6Ref": "6.4a1"
+                    }
+                  }
+                },
+                "subjectToHighExcesses": {
+                  "ta6Ref": "6.4b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6Ref": "6.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6Ref": "6.4b1"
+                    }
+                  }
+                },
+                "subjectToUnusualConditions": {
+                  "ta6Ref": "6.4c",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6Ref": "6.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6Ref": "6.4c1"
+                    }
+                  }
+                },
+                "refused": {
+                  "ta6Ref": "6.4d",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6Ref": "6.4.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6Ref": "6.4d1"
+                    }
+                  }
+                }
+              }
+            },
             "isInsured": {
               "ta6Ref": "6.1",
               "title": "Does the seller insure the property?"

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -41,6 +41,18 @@
             "title": "Name",
             "type": "object",
             "properties": {
+              "title": {
+                "title": "Title or honorific",
+                "type": "string",
+                "enum": [
+                  "Mr",
+                  "Mrs",
+                  "Miss",
+                  "Ms",
+                  "Mx",
+                  "Dr"
+                ]
+              },
               "firstName": {
                 "title": "First name",
                 "type": "string",
@@ -54,6 +66,10 @@
                 "title": "lastName",
                 "type": "string",
                 "minLength": 1
+              },
+              "maidenName": {
+                "title": "Middle name(s)",
+                "type": "string"
               },
               "preferredName": {
                 "title": "Preferred name / known as",
@@ -79,6 +95,24 @@
             "title": "Address",
             "type": "object",
             "properties": {
+              "buildingNumber": {
+                "title": "Building number",
+                "type": "string",
+                "minLength": 1
+              },
+              "buildingName": {
+                "title": "Building name",
+                "type": "string"
+              },
+              "subBuilding": {
+                "title": "Sub building name",
+                "type": "string"
+              },
+              "street": {
+                "title": "Street",
+                "type": "string",
+                "minLength": 1
+              },
               "line1": {
                 "title": "Address 1",
                 "type": "string",
@@ -100,6 +134,23 @@
                 "title": "Postcode",
                 "type": "string",
                 "minLength": 1
+              },
+              "homeNation": {
+                "title": "Home nation",
+                "type": "string",
+                "enum": [
+                  "England",
+                  "Wales",
+                  "Scotland",
+                  "Northern Ireland"
+                ]
+              },
+              "countryCode": {
+                "title": "Country code",
+                "description": "ISO 3166-1 alpha-3 country code",
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 3
               }
             }
           },
@@ -131,73 +182,103 @@
           },
           "externalIds": {
             "type": "object"
-          },
-          "sellersCapacity": {
-            "title": "Capacity in which the Seller sells",
-            "type": "object",
+          }
+        },
+        "oneOf": [
+          {
             "properties": {
-              "capacity": {
-                "type": "string",
-                "title": "",
+              "role": {
                 "enum": [
-                  "Legal Owner",
-                  "Personal Representative for a Deceased Owner",
-                  "Under Power of Attorney",
-                  "Mortgagee in Possession",
-                  "Other"
+                  "Buyer",
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
                 ]
               }
-            },
-            "oneOf": [
-              {
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller"
+                ]
+              },
+              "sellersCapacity": {
+                "title": "Capacity in which the Seller sells",
+                "type": "object",
                 "properties": {
                   "capacity": {
+                    "type": "string",
+                    "title": "",
                     "enum": [
                       "Legal Owner",
-                      "Mortgagee in Possession"
-                    ]
-                  },
-                  "sellersCapacityDetails": {
-                    "title": "Please provide details if applicable",
-                    "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
-                    "type": "string"
-                  },
-                  "attachments": {
-                    "title": "Attachments",
-                    "type": "string",
-                    "enum": [
-                      "Attached",
-                      "To follow"
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "capacity": {
-                    "enum": [
                       "Personal Representative for a Deceased Owner",
                       "Under Power of Attorney",
+                      "Mortgagee in Possession",
                       "Other"
                     ]
-                  },
-                  "sellersCapacityDetails": {
-                    "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
-                    "type": "string"
-                  },
-                  "attachments": {
-                    "title": "Attachments",
-                    "type": "string",
-                    "enum": [
-                      "Attached",
-                      "To follow"
-                    ]
                   }
-                }
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "title": "Please provide details if applicable",
+                        "description": "(for example if the sellers names do not match the legal owners on the title deed due to change of name on marriage)",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": [
+                          "Attached",
+                          "To follow"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": [
+                          "Attached",
+                          "To follow"
+                        ]
+                      }
+                    }
+                  }
+                ]
               }
-            ]
+            }
           }
-        }
+        ]
       }
     },
     "propertyPack": {
@@ -208,6 +289,24 @@
           "title": "Property Address",
           "type": "object",
           "properties": {
+            "buildingNumber": {
+              "title": "Building number",
+              "type": "string",
+              "minLength": 1
+            },
+            "buildingName": {
+              "title": "Building name",
+              "type": "string"
+            },
+            "subBuilding": {
+              "title": "Sub building name",
+              "type": "string"
+            },
+            "street": {
+              "title": "Street",
+              "type": "string",
+              "minLength": 1
+            },
             "line1": {
               "title": "Address line 1",
               "type": "string",
@@ -229,6 +328,23 @@
               "title": "Postcode",
               "type": "string",
               "minLength": 1
+            },
+            "homeNation": {
+              "title": "Home nation",
+              "type": "string",
+              "enum": [
+                "England",
+                "Wales",
+                "Scotland",
+                "Northern Ireland"
+              ]
+            },
+            "countryCode": {
+              "title": "Country code",
+              "description": "ISO 3166-1 alpha-3 country code",
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 3
             }
           }
         },
@@ -310,6 +426,19 @@
           "properties": {
             "localAuthorityName": {
               "title": "Local authority name",
+              "description": "The name of the local authority responsible for searches and planning (district or unitary as applicable)",
+              "type": "string"
+            },
+            "districtCouncil": {
+              "title": "Name of the district council, if not unitary",
+              "type": "string"
+            },
+            "countyCouncil": {
+              "title": "Name of the county council, if not unitary",
+              "type": "string"
+            },
+            "unitaryAuthority": {
+              "title": "Unitary authority name, if applicable",
               "type": "string"
             },
             "localAuthorityReference": {
@@ -355,6 +484,14 @@
                 "Informal tender",
                 "Modern Method of Auction",
                 "Private treaty"
+              ]
+            },
+            "saleAtUndervalue": {
+              "title": "Is the property being sold at undervalue?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
               ]
             }
           }
@@ -522,7 +659,7 @@
                       "properties": {
                         "isLocatedOverCommercialPremises": {
                           "type": "string",
-                          "title": "Is the property located over commercial premises?",
+                          "title": "Is the property located in a building which includes commercial property E.g. shops, offices etc?",
                           "enum": [
                             "Yes",
                             "No"
@@ -597,6 +734,22 @@
                   ]
                 }
               }
+            },
+            "isHMO": {
+              "title": "Is the property a House in Multiple Occupation (HMO)?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
+            },
+            "isStudentAccommodation": {
+              "title": "Is the property student accommodation?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
             },
             "roomDimensions": {
               "title": "Room dimensions",
@@ -1130,6 +1283,40 @@
           "title": "Ownership",
           "type": "object",
           "properties": {
+            "numberOfSellers": {
+              "title": "How many sellers are involved in the transaction?",
+              "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
+              "type": "integer"
+            },
+            "numberOfNonUkResidentSellers": {
+              "title": "How many sellers are involved in the transaction who are resident outside the UK?",
+              "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
+              "type": "integer"
+            },
+            "hasHelpToBuyEquityLoan": {
+              "title": "Is the property being sold with a Help to Buy equity loan outstanding?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
+            },
+            "isFirstRegistration": {
+              "title": "Is this the first time the property is to be registered with HMLR?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
+            },
+            "isLimitedCompanySale": {
+              "title": "Is the property being sold by a Limited Company?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
+            },
             "ownershipsToBeTransferred": {
               "title": "Ownerships to be transferred on sale",
               "type": "array",
@@ -5356,6 +5543,14 @@
                                             "type": "string",
                                             "minLength": 1
                                           },
+                                          "contributionIncludedInServiceCharge": {
+                                            "title": "Is the annual contribution included in the stated service charge?",
+                                            "type": "string",
+                                            "enum": [
+                                              "Yes",
+                                              "No"
+                                            ]
+                                          },
                                           "sufficentToCoverSection20Expenditure": {
                                             "title": "Is the amount expected to be sufficient to cover the known Section 20 expenditure?",
                                             "type": "object",
@@ -7357,10 +7552,88 @@
                     "Not known"
                   ]
                 }
-              }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "annualCostOfPermit": {
+                      "title": "Annual cost of permit (£)",
+                      "type": "number"
+                    }
+                  }
+                }
+              ]
+            },
+            "vehicleTypeRestriction": {
+              "title": "Is there a restriction on the types of vehicle which may be parked?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Please provide details of the restriction",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
             },
             "electricVehicleChargingPoint": {
               "title": "Is there an electric vehicle charging point belonging to the property?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "locatedInUlez": {
+              "title": "Is the property and/or parking located in an Ultra Low Emission Zone (ULEZ)?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -15254,9 +15527,88 @@
                 }
               ]
             },
+            "heatPump": {
+              "title": "Ground or air source heat pump",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "To be connected",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Details",
+                      "type": "string"
+                    },
+                    "supplier": {
+                      "title": "Supplier",
+                      "type": "string"
+                    },
+                    "dateInstalled": {
+                      "title": "Date installed",
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "attachments": {
+                      "title": "If after 2013 please provide Building Regulations approval / MCS Certificate or equivalent.",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    },
+                    "details": {
+                      "title": "Details",
+                      "type": "string"
+                    },
+                    "dateToBeConnected": {
+                      "title": "Date to be connected",
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "supplier": {
+                      "title": "Supplier",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            },
             "otherSources": {
               "title": "Other sources",
-              "description": "Other sources include wind turbines, generators and other renewable technologies, for example ground source heat pumps. If you receive Renewable Heat Incentives please provide details and note that you will need to advise Ofgem when you complete the sale",
+              "description": "Other sources include wind turbines, generators and other renewable technologies. If you receive Renewable Heat Incentives please provide details and note that you will need to advise Ofgem when you complete the sale",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -16400,7 +16752,9 @@
                   "minLength": 1
                 },
                 "consequentialChargingBasis": {
-                  "title": "Will the basis for charging for sewerage and water services at the property change as a consequence of a change of occupation?"
+                  "title": "Will the basis for charging for sewerage and water services at the property change as a consequence of a change of occupation?",
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             }
@@ -16650,11 +17004,11 @@
                   "properties": {
                     "heatingType": {
                       "enum": [
-                        "Community heating system"
+                        "Communal heating system"
                       ]
                     },
                     "details": {
-                      "title": "Community heating system details",
+                      "title": "Communal heating system details",
                       "description": "Please describe how the cost of heating supply is charged, whether you have control over the energy supplier and whether you have any control over the heating.",
                       "type": "string",
                       "minLength": 1
@@ -17004,8 +17358,170 @@
           "title": "Insurance",
           "type": "object",
           "properties": {
+            "difficultiesObtainingInsurance": {
+              "title": "Have you had any difficulty obtaining competitively priced building insurance due to the structure or location of the property or had insurance refused?",
+              "type": "object",
+              "properties": {
+                "abnormalRiseInPremiums": {
+                  "title": "Subject to abnormal rise in premiums?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "subjectToHighExcesses": {
+                  "title": "Subject to high excesses?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "subjectToUnusualConditions": {
+                  "title": "Subject to unusual conditions?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "refused": {
+                  "title": "Refused?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
             "isInsured": {
-              "title": "Do you insure the property?",
+              "title": "Do you currently insure the property?",
               "type": "string",
               "enum": [
                 "Yes",
@@ -17043,168 +17559,6 @@
                   "enum": [
                     "Yes"
                   ]
-                },
-                "difficultiesObtainingInsurance": {
-                  "title": "Have you had any difficulty obtaining competitively priced building insurance due to the structure or location of the property or had insurance refused?",
-                  "type": "object",
-                  "properties": {
-                    "abnormalRiseInPremiums": {
-                      "title": "Subject to abnormal rise in premiums?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "type": "string",
-                          "title": "",
-                          "enum": [
-                            "Yes",
-                            "No"
-                          ]
-                        }
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    "subjectToHighExcesses": {
-                      "title": "Subject to high excesses?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "type": "string",
-                          "title": "",
-                          "enum": [
-                            "Yes",
-                            "No"
-                          ]
-                        }
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    "subjectToUnusualConditions": {
-                      "title": "Subject to unusual conditions?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "type": "string",
-                          "title": "",
-                          "enum": [
-                            "Yes",
-                            "No"
-                          ]
-                        }
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    "refused": {
-                      "title": "Refused?",
-                      "type": "object",
-                      "properties": {
-                        "yesNo": {
-                          "type": "string",
-                          "title": "",
-                          "enum": [
-                            "Yes",
-                            "No"
-                          ]
-                        }
-                      },
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "No"
-                              ]
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "yesNo": {
-                              "enum": [
-                                "Yes"
-                              ]
-                            },
-                            "details": {
-                              "title": "Provide details",
-                              "type": "string",
-                              "minLength": 1
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  }
                 },
                 "insuranceClaims": {
                   "title": "Have you ever made a claim against your building insurance in relation to the property?",
@@ -21259,6 +21613,20 @@
             },
             "confirmInformationIsAccurate": {
               "title": "I/we confirm that all information provided is accurate to the best of our knowledge and if we become aware of any change to/changes which alter the information supplied/provided prior to exchange of contracts for the sale of the property, I/we will update immediately notify the person marketing the property as well as my/our property lawyer",
+              "type": "boolean"
+            }
+          }
+        },
+        "saleReadyDeclarations": {
+          "title": "Confirmations to be supplied to confirm Sale Ready status",
+          "type": "object",
+          "properties": {
+            "authorisedToActOnBehalfOfAllSellers": {
+              "title": "I/we confirm that I am/we are authorised to supply data and documents in relation to this property on behalf of all the owners of the property",
+              "type": "boolean"
+            },
+            "authorisationToShare": {
+              "title": "I/we consent to the sharing of the information contained in the Sale Ready pack with the my/our legal representative and the buyer(s) and their legal representatives",
               "type": "boolean"
             }
           }
@@ -25664,29 +26032,62 @@
                         }
                       },
                       "propertyAddress": {
-                        "type": "object",
-                        "properties": {
-                          "postcodeZone": {
-                            "type": "object",
-                            "properties": {
-                              "postcode": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "addressLine": {
-                            "type": "object",
-                            "properties": {
-                              "line": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "postcodeZone": {
+                                  "type": "object",
+                                  "properties": {
+                                    "postcode": {
+                                      "type": "string"
+                                    }
+                                  }
                                 },
-                                "minItems": 0
+                                "addressLine": {
+                                  "type": "object",
+                                  "properties": {
+                                    "line": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "minItems": 0
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minItems": 0
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "postcodeZone": {
+                                "type": "object",
+                                "properties": {
+                                  "postcode": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "addressLine": {
+                                "type": "object",
+                                "properties": {
+                                  "line": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 0
+                                  }
+                                }
                               }
                             }
                           }
-                        }
+                        ]
                       },
                       "title": {
                         "type": "object",
@@ -33148,6 +33549,39 @@
                           }
                         }
                       }
+                    }
+                  }
+                }
+              },
+              "additionalDocuments": {
+                "title": "Additional documents referred to in title register",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "documentType": {
+                      "title": "Human-readable document type",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentTypeCode": {
+                      "title": "HMLR document type code",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "documentDate": {
+                      "title": "Date of original document",
+                      "type": "string",
+                      "fornat": "date"
+                    },
+                    "retrievedOn": {
+                      "title": "Datetime retrieved from HMLR",
+                      "type": "string",
+                      "fornat": "date-time"
+                    },
+                    "filedUnder": {
+                      "title": "Related title number",
+                      "type": "string"
                     }
                   }
                 }

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -177,7 +177,9 @@
               "Mortgage Broker",
               "Lender",
               "Landlord",
-              "Tenant"
+              "Tenant",
+              "Assistant",
+              "Giftor"
             ]
           },
           "externalIds": {
@@ -199,7 +201,9 @@
                   "Mortgage Broker",
                   "Lender",
                   "Landlord",
-                  "Tenant"
+                  "Tenant",
+                  "Assistant",
+                  "Giftor"
                 ]
               }
             }
@@ -220,9 +224,13 @@
                     "title": "",
                     "enum": [
                       "Legal Owner",
+                      "Deceased Owner",
                       "Personal Representative for a Deceased Owner",
                       "Under Power of Attorney",
                       "Mortgagee in Possession",
+                      "Company Director",
+		                  "Company Representative",
+		                  "Trustee",
                       "Other"
                     ]
                   }

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -191,7 +191,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -240,6 +239,18 @@
                     "properties": {
                       "capacity": {
                         "enum": [
+                          "Deceased Owner",
+                          "Company Director",
+		                      "Company Representative",
+		                      "Trustee"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
                           "Legal Owner",
                           "Mortgagee in Possession"
                         ]
@@ -270,6 +281,69 @@
                       },
                       "sellersCapacityDetails": {
                         "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": [
+                          "Attached",
+                          "To follow"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
+                ]
+              },
+              "buyersCapacity": {
+                "title": "Capacity in which the Buyer buys",
+                "type": "object",
+                "properties": {
+                  "capacity": {
+                    "type": "string",
+                    "title": "",
+                    "enum": [
+                      "Legal Buyer",
+                      "Under Power of Attorney",
+                      "Company Director",
+		                  "Company Representative",
+		                  "Trustee",
+                      "Other"
+                    ]
+                  }
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Buyer",
+                          "Company Director",
+		                      "Company Representative",
+		                      "Trustee"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Under Power of Attorney",
+                          "Other"
+                        ]
+                      },
+                      "buyersCapacityDetails": {
+                        "title": "Please provide details and provide any grant of representation or power of attorney",
                         "type": "string"
                       },
                       "attachments": {

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -34,6 +34,11 @@
       "capacity": {},
       "sellersCapacityDetails": {},
       "attachments": {}
+    },
+    "buyersCapacity": {
+      "capacity": {},
+      "buyersCapacityDetails": {},
+      "attachments": {}
     }
   },
   "propertyPack": {

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -7,17 +7,24 @@
       "firstName": {},
       "middleName": {},
       "lastName": {},
+      "maidenName": {},
       "preferredName": {}
     },
     "dateOfBirth": {},
     "phone": {},
     "email": {},
     "address": {
+      "buildingNumber": {},
+      "buildingName": {},
+      "subBuilding": {},
+      "street": {},
       "line1": {},
       "line2": {},
       "line 3": {},
       "town": {},
-      "postcode": {}
+      "postcode": {},
+      "homeNation": {},
+      "countryCode": {}
     },
     "organisation": {},
     "organisationReference": {},
@@ -31,11 +38,17 @@
   },
   "propertyPack": {
     "address": {
+      "buildingNumber": {},
+      "buildingName": {},
+      "subBuilding": {},
+      "street": {},
       "line1": {},
       "line2": {},
       "line3": {},
       "town": {},
-      "postcode": {}
+      "postcode": {},
+      "homeNation": {},
+      "countryCode": {}
     },
     "uprn": {},
     "location": {
@@ -55,6 +68,9 @@
     },
     "localAuthority": {
       "localAuthorityName": {},
+      "districtCouncil": {},
+      "countyCouncil": {},
+      "unitaryAuthority": {},
       "localAuthorityReference": {},
       "councilSearchTurnaroundTimeInWorkingDays": {},
       "regulatedSearchTurnaroundTimeInWorkingDays": {}
@@ -62,7 +78,8 @@
     "priceInformation": {
       "price": {},
       "priceQualifier": {},
-      "disposal": {}
+      "disposal": {},
+      "saleAtUndervalue": {}
     },
     "lettingInformation": {
       "rent": {},
@@ -98,6 +115,8 @@
       "isNewBuild": {
         "yesNo": {}
       },
+      "isHMO": {},
+      "isStudentAccommodation": {},
       "roomDimensions": {
         "hasFloorplan": {},
         "attachments": {},
@@ -186,6 +205,11 @@
       }
     },
     "ownership": {
+      "numberOfSellers": {},
+      "numberOfNonUkResidentSellers": {},
+      "hasHelpToBuyEquityLoan": {},
+      "isFirstRegistration": {},
+      "isLimitedCompanySale": {},
       "ownershipsToBeTransferred": {
         "titleNumber": {},
         "ownershipType": {},
@@ -778,6 +802,7 @@
             "reserveFund": {
               "yesNo": {},
               "details": {},
+              "contributionIncludedInServiceCharge": {},
               "sufficentToCoverSection20Expenditure": {
                 "yesNo": {},
                 "details": {}
@@ -1003,9 +1028,17 @@
         "yesNo": {}
       },
       "controlledParking": {
-        "yesNo": {}
+        "yesNo": {},
+        "annualCostOfPermit": {}
+      },
+      "vehicleTypeRestriction": {
+        "yesNo": {},
+        "details": {}
       },
       "electricVehicleChargingPoint": {
+        "yesNo": {}
+      },
+      "locatedInUlez": {
         "yesNo": {}
       }
     },
@@ -1966,6 +1999,14 @@
         },
         "dateToBeConnected": {}
       },
+      "heatPump": {
+        "yesNo": {},
+        "details": {},
+        "supplier": {},
+        "dateInstalled": {},
+        "attachments": {},
+        "dateToBeConnected": {}
+      },
       "otherSources": {
         "yesNo": {},
         "details": {},
@@ -2190,9 +2231,6 @@
       }
     },
     "insurance": {
-      "isInsured": {},
-      "details": {},
-      "landlordInsuresIfFlat": {},
       "difficultiesObtainingInsurance": {
         "abnormalRiseInPremiums": {
           "yesNo": {},
@@ -2211,6 +2249,9 @@
           "details": {}
         }
       },
+      "isInsured": {},
+      "details": {},
+      "landlordInsuresIfFlat": {},
       "insuranceClaims": {
         "yesNo": {},
         "details": {}
@@ -2765,6 +2806,10 @@
     "confirmationOfAccuracyByOwners": {
       "confirmWillProvideAdditionalDocumentation": {},
       "confirmInformationIsAccurate": {}
+    },
+    "saleReadyDeclarations": {
+      "authorisedToActOnBehalfOfAllSellers": {},
+      "authorisationToShare": {}
     },
     "localSearches": {
       "localLandCharges": {
@@ -3964,6 +4009,13 @@
             }
           }
         }
+      },
+      "additionalDocuments": {
+        "documentType": {},
+        "documentTypeCode": {},
+        "documentDate": {},
+        "retrievedOn": {},
+        "filedUnder": {}
       }
     },
     "searches": {

--- a/src/schemas/verifiedClaims/README.md
+++ b/src/schemas/verifiedClaims/README.md
@@ -1,0 +1,12 @@
+## README
+
+### About verified claims
+`pdtf-verified-claims.json` describes the schema container in which we store property `claims` and their corresponding `verification`.  
+
+This schema structure is strongly influenced by OpenID Connect for Identity Assurance 1.0's way of storing "verified claims". 
+
+More Details from the OIDC page which describes the details the nature of `verification` and `claims` objects: https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-representing-verified-claim
+
+Notes: 
+* For PDTF Schema, all data included in the `claims` object must adhere to [pdtf-transaction.json (v3)](../v3/pdtf-transaction.json)
+* For verification, there is more freedom in terms of the type of data that can currently be provided, see the documentation in the OIDC link above for details and examples.

--- a/src/schemas/verifiedClaims/pdtf-verified-claims.json
+++ b/src/schemas/verifiedClaims/pdtf-verified-claims.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://trust.propdata.org.uk/schemas/v1/pdtf-verified-claims.json",
+  "$id": "https://trust.propdata.org.uk/schemas/verifiedClaims/pdtf-verified-claims.json",
   "definitions": {
     "date_type": {
       "type": "string",

--- a/src/tests/v3/transactionSchema.test.js
+++ b/src/tests/v3/transactionSchema.test.js
@@ -22,14 +22,14 @@ test("exports a property pack schema, v3 with no overlay by default", () => {
   // expect(testSchema.$id).toEqual(
   //   "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json"
   // );
-  expect(testSchema.properties.propertyPack.properties.baspiRef).toEqual(
+  expect(testSchema.properties.propertyPack.properties.baspi5Ref).toEqual(
     undefined
   );
 });
 
 test("sample is valid BASPI", () => {
   const testSchema = getTransactionSchema(schemaId, ["baspiV4"]);
-  expect(testSchema.properties.propertyPack.baspiRef).toEqual("0");
+  expect(testSchema.properties.propertyPack.baspi4Ref).toEqual("0");
   const validator = getValidator(schemaId, ["baspiV4"]);
   const isValid = validator(exampleTransaction);
   if (!isValid) console.log(validator.errors);
@@ -201,9 +201,9 @@ test("correctly gets a subschema with multiple overlays", () => {
   const subschema = getSubschema(
     "/propertyPack/parking/parkingArrangements",
     schemaId,
-    ["baspiV4", "ta6ed4"]
+    ["baspiV5", "ta6ed4"]
   );
-  expect(subschema.baspiRef).toBe("A1.6.0");
+  expect(subschema.baspi5Ref).toBe("A1.6.0");
   expect(subschema.ta6Ref).toBe("9.1");
 });
 

--- a/src/utils/extractOverlay.js
+++ b/src/utils/extractOverlay.js
@@ -7,7 +7,8 @@ const merge = require("deepmerge");
 const combinedSchema = require("../schemas/v3/combined.json");
 
 const extractFields = [
-  "baspi",
+  "baspi4",
+  "baspi5",
   "nts",
   "ntsl",
   "ta6",
@@ -21,6 +22,7 @@ const extractFields = [
   "llc1",
   "rds",
   "oc1",
+  "sr24",
 ];
 
 const flattenSkeleton = (schema) => {


### PR DESCRIPTION
We're proposing the addition of two new roles, "Assistant" and "Giftor" both roles we've had with live transactions where these participants are neither a "Buyer", "Seller", or property professionals supporting the transaction. 

We're also proposing the addition of "Company Director", "Company Representative", "Trustee" and "Deceased Owner".

An argument can be made that a "Deceased Owner" cannot have the role of a "Seller" given they've passed; however, for ease of ascertaining that this participant belongs to a sale transaction, we have proposed "Deceased Owner" as a capacity under the role of "Seller".