### PR TITLE
3.6.0 release candidate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ node_modules
 
 # Claude Code guidance file
 CLAUDE.md
+
+# Proposals folder
+proposals/
+/tmp
+.npmrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance for AI coding agents when working with code in this repository.
 
 ## Overview
 
@@ -11,13 +11,17 @@ This repository contains the Property Data Trust Framework (PDTF) schemas - JSON
 ### Testing
 ```bash
 npm test          # Run all tests
-npm test:watch    # Run tests in watch mode
+npm run test:watch # Run tests in watch mode
 ```
 
 ### Development
 ```bash
-npm install       # Install dependencies
+npm install                       # Install dependencies
+npm run extract-overlays          # Regenerate v3 schemas and overlays from combined.json
+npm run extract-extension-overlays # Regenerate v3 extension overlays from combined.json
 ```
+
+**Important**: `src/schemas/v3/combined.json` is the source of truth for v3 schema changes. Never edit generated schema artifacts directly; there are no exceptions. Utility/source files may be edited normally. After changing `combined.json`, always run both overlay extraction commands so derived files stay in sync.
 
 ## Architecture
 
@@ -27,6 +31,7 @@ The PDTF uses a flexible overlay system where a base transaction schema can be e
 - **Base Schema**: Core transaction schema at `/src/schemas/v3/pdtf-transaction.json`
 - **Overlays**: Form-specific extensions in `/src/schemas/v3/overlays/` (e.g., baspi5.json, ta6.json)
 - **Merging**: Overlays are merged with the base schema using deepmerge with custom merge strategies
+- **Generated Files**: `pdtf-transaction.json`, `skeleton.json`, `compactSkeleton.txt`, `src/schemas/v3/overlays/*.json`, and `src/schemas/v3/overlays/extensions/*.json` are generated from `combined.json`
 
 ### Key Components
 
@@ -55,7 +60,6 @@ Use existing test patterns when adding new tests.
 
 ## Important Notes
 
-- Schema version is currently 3.4.0
 - All schemas use JSON Schema Draft 07
 - The repository publishes to npm as `@pdtf/schemas`
 - Overlays may contain fields from licensed forms (BASPI, PIQ, Law Society) - ensure compliance when rendering data

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Property Data Trust Framework (PDTF) Schemas provide standardized JSON Schem
 
 ## Project Goals & Status
 
-**Current Version:** 3.5.0 (3.6.0-41 available as a pre-release on branch/package-tag `next`)
+**Current Version:** 3.6.0 
 
 This schema framework aims to support the [Home Buying and Selling Group](https://homebuyingandsellinggroup.co.uk) 'Property Pack' initiative, encompassing all requirements starting with the Buyers and Sellers Property Information set ([BASPI v4.0](https://homebuyingandsellinggroup.co.uk/baspi/)).
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@ The Property Data Trust Framework (PDTF) Schemas provide standardized JSON Schem
 
 ## Project Goals & Status
 
-**Current Version:** 3.4.0 (Schema v3 - Stable)
+**Current Version:** 3.5.0 (3.6.0-41 available as a pre-release on branch/package-tag `next`)
 
 This schema framework aims to support the [Home Buying and Selling Group](https://homebuyingandsellinggroup.co.uk) 'Property Pack' initiative, encompassing all requirements starting with the Buyers and Sellers Property Information set ([BASPI v4.0](https://homebuyingandsellinggroup.co.uk/baspi/)).
 
 **Key Objectives:**
+
 - 🏠 **Standardize** residential property data exchange across England and Wales
-- 🔗 **Enable** frictionless data sharing between software products and services  
+- 🔗 **Enable** frictionless data sharing between software products and services
 - 🛡️ **Maintain** trusted information about data provenance and verification
 - 📋 **Support** industry-standard forms (BASPI, NTS, Law Society TA forms)
 - 🧩 **Provide** modular components for flexible implementation
 
 **Related Projects:**
+
 - [API Specifications](https://github.com/Property-Data-Trust-Framework/api) - OpenAPI specs for data exchange protocols
 - [PDTF Website](https://trust.propdata.org.uk) - Official framework documentation
 
@@ -35,7 +37,7 @@ npm install @pdtf/schemas
 ### Basic Usage
 
 ```javascript
-const { getTransactionSchema, getValidator } = require('@pdtf/schemas');
+const { getTransactionSchema, getValidator } = require("@pdtf/schemas");
 
 // Get a schema with BASPI v5 overlay
 const schema = getTransactionSchema(
@@ -45,14 +47,14 @@ const schema = getTransactionSchema(
 
 // Create a validator
 const validator = getValidator(
-  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json", 
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json",
   ["baspiV5"]
 );
 
 // Validate data
 const isValid = validator(propertyData);
 if (!isValid) {
-  console.log('Validation errors:', validator.errors);
+  console.log("Validation errors:", validator.errors);
 }
 ```
 
@@ -60,7 +62,7 @@ if (!isValid) {
 
 - **🏗️ Modular Schema System** - Base schemas with flexible overlay composition
 - **📋 Multiple Form Support** - BASPI, NTS, Law Society TA forms, and more
-- **🧩 Extension Overlays** - Granular NTS2 features as individual modules
+- **🧩 Extension Overlays** - Granular NTS2 and SEF25 features as individual modules
 - **✅ JSON Schema Validation** - Full JSON Schema Draft 07 support with AJV
 - **🔗 Verified Claims** - Support for verified data provenance tracking
 - **📚 Comprehensive Documentation** - Detailed usage guides and examples
@@ -80,7 +82,7 @@ if (!isValid) {
 │   │   │   │   └── extensions/        # Modular NTS2 extensions
 │   │   │   │       ├── jk.json        # Japanese Knotweed
 │   │   │   │       ├── tf.json        # Transfer Fees
-│   │   │   │       └── ...            # 16 total extensions
+│   │   │   │       └── ...            # NTS2 + SEF25 extensions
 │   │   │   └── combined.json          # Master schema for generation
 │   │   ├── v2/                        # Legacy schema version
 │   │   ├── verifiedClaims/            # Verified claims schemas
@@ -122,6 +124,7 @@ const schema = getTransactionSchema(
 ```
 
 **Parameters:**
+
 - `schemaId` (string): Schema version URL
 - `overlays` (array): Array of overlay names or objects
 
@@ -146,39 +149,70 @@ const errors = validateVerifiedClaims(verifiedClaims, schemaId, ["nts2023"]);
 
 #### Main Form Overlays
 
-| Overlay | Description | Version |
-|---------|-------------|---------|
-| `baspiV4` | Buyers and Sellers Property Information | v4.0 |
-| `baspiV5` | Buyers and Sellers Property Information | v5.0 |
-| `nts2023` | National Trading Standards | 2023 |
-| `nts2025` | National Trading Standards | 2025 |
-| `ta6ed4` | Law Society Property Information Form | Edition 4 |
-| `ta7ed3` | Law Society Leasehold Information Form | Edition 3 |
-| `ta10ed3` | Law Society Fittings and Contents Form | Edition 3 |
+| Overlay   | Description                             | Version   |
+| --------- | --------------------------------------- | --------- |
+| `baspiV4` | Buyers and Sellers Property Information | v4.0      |
+| `baspiV5` | Buyers and Sellers Property Information | v5.0      |
+| `nts2023` | National Trading Standards              | 2023      |
+| `nts2025` | National Trading Standards              | 2025      |
+| `ta6ed4`  | Law Society Property Information Form   | Edition 4 |
+| `ta7ed3`  | Law Society Leasehold Information Form  | Edition 3 |
+| `ta10ed3` | Law Society Fittings and Contents Form  | Edition 3 |
 
 [View all overlays →](src/schemas/v3/overlays/README.md)
 
 #### Extension Overlays
 
-Modular NTS2 features for selective adoption:
+Modular features for selective adoption. Extensions are merged on top of an NTS base overlay.
 
 ```javascript
-// Individual extensions
-const schema = getTransactionSchema(schemaId, ["nts2023", "jk", "tf"]);
+// NTS2 extensions
+const schema = getTransactionSchema(schemaId, ["nts2023", "jk", "tf", "ma"]);
 
-// Multiple specialist issues
-const schema = getTransactionSchema(schemaId, ["nts2023", "as", "dr", "jk", "sb"]);
+// SEF25 extensions (Seller Enquiry Form)
+const sef25 = ["sc", "pc", "ph", "dk", "rw", "sd", "lc", "wg", "ic", "nd", "mi", "tr"];
+const schema = getTransactionSchema(schemaId, ["nts2023", ...sef25]);
 ```
 
-| Extension | Code | Description |
-|-----------|------|-------------|
-| Japanese Knotweed | `jk` | Knotweed presence and management |
-| Transfer Fees | `tf` | Additional leasehold fees |
-| Managing Agent | `ma` | Leasehold managing agent details |
-| Solar Panels | `sl` | Solar panel ownership details |
-| Asbestos | `as` | Asbestos presence and management |
+**NTS2 Extensions:**
 
-[View all extensions →](src/schemas/v3/overlays/README.md#extension-overlays)
+| Extension | Code | Description |
+| --- | --- | --- |
+| Japanese Knotweed | `jk` | Knotweed presence and management |
+| Asbestos | `as` | Asbestos presence and management |
+| Dry Rot | `dr` | Dry rot treatment |
+| Subsidence | `sb` | Subsidence or structural fault |
+| Health & Safety | `hs` | Ongoing health or safety issues |
+| Outside Areas | `oa` | Outside areas details |
+| Main Construction | `mc` | Construction type if standard form |
+| Loft Access | `la` | Loft access and details |
+| Spray Foam | `sf` | Spray foam insulation |
+| Solar Panels | `sl` | Solar panel ownership details |
+| Heating Installed | `hi` | Central heating installation date |
+| Flood Defences | `fd` | Flood defence information |
+| Estate Rentcharges | `er` | Estate rentcharges for freehold |
+| Managing Agent | `ma` | Leasehold managing agent details |
+| Transfer Fees | `tf` | Additional leasehold fees |
+| Onward Chain | `oc` | Other property in chain |
+
+**SEF25 Extensions (Seller Enquiry Form):**
+
+| Extension | Code | Description |
+| --- | --- | --- |
+| Supply Costs | `sc` | Private water/sewerage costs |
+| Parking Permit Cost | `pc` | Parking permit frequency |
+| Property Hazards | `ph` | 4 hazard Yes/No questions |
+| Dropped Kerb | `dk` | Dropped kerb access to parking |
+| Private Right of Way | `rw` | Private right of way |
+| Storm/Fire/Flood Damage | `sd` | Storm, fire or flood damage |
+| Solar Lease Costs | `lc` | Solar panel lease costs |
+| Warranties & Guarantees | `wg` | 7 warranty categories upfront |
+| Insurance Claims | `ic` | Insurance claims upfront |
+| Neighbour Development | `nd` | Neighbour development |
+| Material Issue | `mi` | Other material issue upfront |
+| Title Restrictions | `tr` | Title restrictions for freehold |
+
+[View full SEF25 UI spec →](docs/sef25-extensions-ui-spec.md) | [View all extensions →](src/schemas/v3/overlays/README.md#extension-overlays)
 
 ## Usage Examples
 
@@ -195,27 +229,26 @@ const legalSchema = getTransactionSchema(schemaId, ["ta6ed4", "ta7ed3"]);
 const ntsSchema = getTransactionSchema(schemaId, ["nts2023"]);
 ```
 
-### Modular NTS2 Features
+### Modular Extension Features
 
 ```javascript
 // Selective NTS2 adoption
 const partialNts2 = getTransactionSchema(schemaId, [
-  "nts2023",        // Base NTS
-  "jk",             // Japanese Knotweed
-  "tf",             // Transfer Fees  
-  "ma"              // Managing Agent
+  "nts2023", // Base NTS
+  "jk", // Japanese Knotweed
+  "tf", // Transfer Fees
+  "ma", // Managing Agent
 ]);
 
-// Full specialist issues
-const specialistIssues = getTransactionSchema(schemaId, [
-  "nts2023", "as", "dr", "jk", "sb", "hs"
-]);
+// SEF25 Seller Enquiry Form extensions
+const sef25 = ["sc", "pc", "ph", "dk", "rw", "sd", "lc", "wg", "ic", "nd", "mi", "tr"];
+const sellerEnquiry = getTransactionSchema(schemaId, ["nts2023", ...sef25]);
 ```
 
 ### Data Validation
 
 ```javascript
-const { getValidator } = require('@pdtf/schemas');
+const { getValidator } = require("@pdtf/schemas");
 
 const validator = getValidator(schemaId, ["baspiV5"]);
 
@@ -223,16 +256,16 @@ const propertyData = {
   propertyPack: {
     priceInformation: {
       price: 350000,
-      priceQualifier: "Freehold"
+      priceQualifier: "Freehold",
     },
     // ... more property data
-  }
+  },
 };
 
 if (validator(propertyData)) {
-  console.log('✅ Data is valid');
+  console.log("✅ Data is valid");
 } else {
-  console.log('❌ Validation errors:', validator.errors);
+  console.log("❌ Validation errors:", validator.errors);
 }
 ```
 
@@ -241,46 +274,110 @@ if (validator(propertyData)) {
 PDTF supports verified claims to maintain data provenance and trust throughout property transactions. Claims package specific property data with verification evidence, enabling traceability back to authoritative sources.
 
 ```javascript
-const { validateVerifiedClaims } = require('@pdtf/schemas');
+const { validateVerifiedClaims } = require("@pdtf/schemas");
 
 // Current verified claims format
-const verifiedClaims = [{
-  id: "claim-12345",
-  transactionId: "txn-67890", 
-  schemaVersion: "3.4.0",
-  verification: {
-    trust_framework: "uk_pdtf",
-    time: "2024-07-01T10:30:00Z",
-    evidence: [{
-      type: "vouch",
-      attestation: {
-        type: "digital_attestation",
-        voucher: { name: "Estate Agent Ltd" }
-      },
-      verification_method: { type: "auth" }
-    }]
+const verifiedClaims = [
+  {
+    id: "claim-12345",
+    transactionId: "txn-67890",
+    schemaVersion: "3.4.0",
+    verification: {
+      trust_framework: "uk_pdtf",
+      time: "2024-07-01T10:30:00Z",
+      evidence: [
+        {
+          type: "vouch",
+          attestation: {
+            type: "digital_attestation",
+            voucher: { name: "Estate Agent Ltd" },
+          },
+          verification_method: { type: "auth" },
+        },
+      ],
+    },
+    terms_of_use: {
+      confidentiality_level: "public",
+    },
+    claims: {
+      "/propertyPack/priceInformation/price": 350000,
+      "/propertyPack/energyEfficiency/epcRating": "C",
+    },
   },
-  claims: {
-    "/propertyPack/priceInformation/price": 350000,
-    "/propertyPack/energyEfficiency/epcRating": "C"
-  }
-}];
+];
 
 // Validate claims against schema
 const errors = validateVerifiedClaims(verifiedClaims, schemaId, ["baspiV5"]);
 if (errors.length === 0) {
-  console.log('✅ Verified claims are valid');
+  console.log("✅ Verified claims are valid");
 }
 ```
 
 **Key Features:**
+
 - **Schema Path Validation** - Claims reference specific schema paths (e.g., `/propertyPack/priceInformation/price`)
 - **Provenance Tracking** - Each claim includes verification evidence and source attribution
 - **Trust Framework Integration** - Claims operate within the UK PDTF trust framework
 - **Attachment Support** - Supporting documents can be cryptographically linked to claims
+- **Confidentiality Controls** - Terms of use define access levels and permitted recipients
+
+#### Confidentiality Levels
+
+Verified claims support three confidentiality levels through a pdtf-specific extension: a `terms_of_use` field, enabling fine-grained access control:
+
+**Public Data** - Freely accessible data from official sources or public listing information:
+
+```javascript
+{
+  terms_of_use: {
+    confidentiality_level: "public";
+  }
+}
+```
+
+Examples: Land Registry data, Energy Performance Certificates, planning records, council tax information
+
+**Restricted Data** - Limited to transaction participants:
+
+```javascript
+{
+  terms_of_use: {
+    confidentiality_level: "restricted";
+  }
+}
+```
+
+Examples: Commercial property reports, contents of legal forms
+
+**Confidential Data** - Role-based access with explicit authorization:
+
+```javascript
+{
+  terms_of_use: {
+    confidentiality_level: "confidential",
+    allowed_roles: [
+      "Estate Agent",
+      "Seller's Conveyancer",
+      "Buyer's Conveyancer",
+      "Mortgage Broker",
+      "Lender"
+    ]
+  }
+}
+```
+
+Examples: Identity verification reports, anti-money laundering checks, sensitive personal information
+
+**Guidelines:**
+
+- Use **public** for government/official data sources
+- Use **restricted** for commercial data providers and processed information
+- Use **confidential** for sensitive personal data requiring explicit role authorization
+- Always consider data source and sensitivity when assigning levels
 
 **Roadmap - W3C Verifiable Credentials:**
 The next version of the PDTF framework will migrate to [W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) to provide:
+
 - **Enhanced Security** - Cryptographically signed claims with tamper detection
 - **Granular Permissions** - Fine-grained access control over claim data
 - **Interoperability** - Standards-based approach for broader ecosystem compatibility
@@ -311,17 +408,17 @@ npm test -- --testPathPattern=extensionOverlays
 npm test -- --testPathPattern=transactionSchema
 ```
 
-
 ## Versioning
 
 The schema follows semantic versioning:
+
 - **Patch** (3.4.x): Bug fixes, no breaking changes
 - **Minor** (3.x.0): New fields, backward compatible
 - **Major** (x.0.0): Breaking changes, migration required
 
 ## Licensing
 
-Licensed under the [MIT License](https://opensource.org/licenses/MIT). 
+Licensed under the [MIT License](https://opensource.org/licenses/MIT).
 
 **Important:** Overlays contain fields from licensed forms ([BASPI](https://homebuyingsellingcouncil.co.uk/wp-content/uploads/2021/03/Terms-of-Licence-mandatory-download-for-use-of-BASPI.pdf), [PIQ](https://www.propertymark.co.uk/static/14e7c154-98de-4230-957f09bd8d5ddeec/f542b10a-7710-4c37-b3958ccaeec25d4b/property-information-questionnaire-residential-sales.pdf), [Law Society TA](https://www.lawsociety.org.uk/topics/property/transaction-forms)). When rendering data into these forms, ensure compliance with their respective license terms.
 
@@ -331,4 +428,3 @@ Licensed under the [MIT License](https://opensource.org/licenses/MIT).
 - 📁 [Example Files](src/examples/)
 - 🐛 [Issue Tracker](https://github.com/Property-Data-Trust-Framework/schemas/issues)
 - 🌐 [PDTF Website](https://trust.propdata.org.uk)
-

--- a/docs/sef25-extensions-ui-spec.md
+++ b/docs/sef25-extensions-ui-spec.md
@@ -1,0 +1,355 @@
+# SEF25 Extension Overlays — Front-End UI Spec
+
+## Overview
+
+Extension overlays add follow-up questions to existing form sections. Each overlay is loaded by passing its key to `getTransactionSchema(schemaId, overlays)`.
+
+### Pre-existing overlays
+
+These were added before this PR and are already in production.
+
+| Overlay Key | Name | Section | Fields Added |
+|-------------|------|---------|-------------|
+| `sc` | Supply Costs | Water & Drainage | Cost fields for private water and sewerage (restructured to hasCost Yes/No gate) |
+| `pc` | Parking Permit Cost | Parking | 1 frequency field |
+| `ph` | Property Hazards | Specialist Issues | 4 Yes/No + details fields |
+
+### New overlays (this PR)
+
+| Overlay Key | Name | Section | Fields Added |
+|-------------|------|---------|-------------|
+| `dk` | Dropped Kerb | Parking | 1 Yes/No field |
+| `rw` | Private Right of Way | Rights & Informal Arrangements | 1 Yes/No + details field |
+| `sd` | Storm/Fire/Flood Damage | Environmental Issues | 1 Yes/No + details field |
+| `lc` | Solar Lease Costs | Utilities (Solar Panels) | 1 cost field (hasCost + amount + frequency) |
+| `wg` | Warranties & Guarantees | Guarantees & Warranties | Marks 7 warranty categories as required |
+| `ic` | Insurance Claims | Insurance | Marks insuranceClaims required (isInsured=Yes branch) |
+| `nd` | Neighbour Development | Notices | Adds sef25Ref to neighbourDevelopment (already required via NTS) |
+| `mi` | Material Issue | Additional Information | Marks otherMaterialIssue required |
+| `tr` | Title Restrictions | Ownership (Freehold) | Adds titleRestrictions field to freehold branch |
+
+### Existing fields with sef25Ref only (no separate overlay needed)
+
+| Field | Path | sef25Ref | Notes |
+|-------|------|----------|-------|
+| `hasBeenFlooded` | `environmentalIssues.flooding.historicalFlooding.hasBeenFlooded` | E1.2 | Already required and rendered via NTS flooding section |
+
+All fields use `sef25Ref` for reference codes.
+
+---
+
+## Pre-existing overlays (detail)
+
+### 1. Supply Costs (`sc`)
+
+#### 1a. Private Water Cost
+
+**Trigger:** Show when `propertyPack.waterAndDrainage.water.mainsWater.yesNo` = `"No"`
+
+**Path:** `propertyPack.waterAndDrainage.water.mainsWater.associatedCost`
+
+**UI:** Render alongside the existing "How is water supplied?" details field. First ask if there are costs, then show amount and frequency if Yes.
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Has costs? | `associatedCost.hasCost` | `string` | Required, enum | Yes/No radio |
+| Cost (£) | `associatedCost.amount` | `number` | Required when Yes | Numeric input |
+| Payment frequency | `associatedCost.frequency` | `string` | Required when Yes, enum | Dropdown |
+
+**Frequency enum values:** `"Per month"`, `"Per year"`
+
+**Ref:** `U1.1` (hasCost: `U1.1.1`, amount: `U1.1.2`, frequency: `U1.1.3`)
+
+#### 1b. Private Sewerage Cost
+
+**Trigger:** Show when `propertyPack.waterAndDrainage.drainage.mainsFoulDrainage.yesNo` = `"No"` or `"Not known"`
+
+**Path:** `propertyPack.waterAndDrainage.drainage.mainsFoulDrainage.associatedCost`
+
+**UI:** Same hasCost pattern as water cost above.
+
+**Ref:** `U1.2` (hasCost: `U1.2.1`, amount: `U1.2.2`, frequency: `U1.2.3`)
+
+### 2. Parking Permit Cost (`pc`)
+
+**Trigger:** Show when `propertyPack.parking.controlledParking.yesNo` = `"Yes"`
+
+**Path:** `propertyPack.parking.controlledParking.costOfPermitFrequency`
+
+**UI:** Render alongside the existing cost of permit field. The frequency dropdown clarifies whether the cost amount is monthly or annual.
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Payment frequency | `costOfPermitFrequency` | `string` | Enum | Dropdown |
+
+**Frequency enum values:** `"Per month"`, `"Per year"`
+
+**Ref:** `P1.1`
+
+### 3. Property Hazards (`ph`)
+
+**Trigger:** Always shown (standalone questions within Specialist Issues).
+
+**Path prefix:** `propertyPack.specialistIssues`
+
+All 4 fields follow the same pattern: Yes/No, if Yes show required details.
+
+| Property | Title | sef25Ref |
+|----------|-------|----------|
+| `wellsDitchesShaft` | Are there any wells, ditches, or shafts at the property? | H1.1 |
+| `damagedOrExposedElectrics` | Are there any damaged or exposed electrics at the property? | H1.2 |
+| `damageToFlooringOrStaircases` | Is there any damage to flooring and/or staircases? | H1.3 |
+| `knownAreasInPoorCondition` | Are there any known areas in poor condition (internal or external)? | H1.4 |
+
+---
+
+## New overlays (detail)
+
+### 4. Dropped Kerb (`dk`)
+
+**Trigger:** Always shown within Parking section.
+
+**Path:** `propertyPack.parking.droppedKerbAccess`
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Dropped kerb? | `droppedKerbAccess.yesNo` | `string` | Required, enum | Yes/No radio |
+
+**Ref:** `K1.1` (yesNo: `K1.1.1`)
+
+---
+
+### 5. Private Right of Way (`rw`)
+
+**Trigger:** Always shown within Rights & Informal Arrangements, alongside the existing public right of way question.
+
+**Path:** `propertyPack.rightsAndInformalArrangements.rightsOrArrangements.privateRightOfWay`
+
+**UI:** Same pattern as `publicRightOfWay` — Yes/No, if Yes show details.
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Private ROW? | `privateRightOfWay.yesNo` | `string` | Required, enum | Yes/No radio |
+| Details | `privateRightOfWay.details` | `string` | Required when Yes, minLength 1 | Text input |
+
+**Ref:** `R1.1` (yesNo: `R1.1.1`, details: `R1.1.2`)
+
+---
+
+### 6. Storm, Fire or Flood Damage (`sd`)
+
+**Trigger:** Always shown within Environmental Issues section.
+
+**Path:** `propertyPack.environmentalIssues.stormFireFloodDamage`
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Damage? | `stormFireFloodDamage.yesNo` | `string` | Required, enum | Yes/No radio |
+| Details | `stormFireFloodDamage.details` | `string` | Required when Yes, minLength 1 | Text area |
+
+**Ref:** `E1.1` (yesNo: `E1.1.1`, details: `E1.1.2`)
+
+---
+
+### 7. Solar Panel Lease Costs (`lc`)
+
+**Trigger:** Show when `propertyPack.electricity.solarPanels.panelsOwnedOutright.yesNo` = `"No"` (panels are leased).
+
+**Path:** `propertyPack.electricity.solarPanels.panelsOwnedOutright.associatedCost`
+
+**UI:** Render alongside existing lease details. First ask if there are costs, then show amount and frequency if Yes.
+
+| Field | Path (relative) | Type | Validation | UI Element |
+|-------|-----------------|------|------------|------------|
+| Has costs? | `associatedCost.hasCost` | `string` | Required, enum | Yes/No radio |
+| Amount (£) | `associatedCost.amount` | `number` | Required when Yes | Numeric input |
+| Frequency | `associatedCost.frequency` | `string` | Required when Yes, enum | Dropdown |
+
+**Frequency enum values:** `"Per month"`, `"Per year"`
+
+**Ref:** `S1.1` (hasCost: `S1.1.1`, amount: `S1.1.2`, frequency: `S1.1.3`)
+
+---
+
+### 8. Warranties & Guarantees Upfront (`wg`)
+
+**Trigger:** Always shown when overlay is loaded. Displayed upfront regardless of `hasValidGuaranteesOrWarranties` value.
+
+**Path prefix:** `propertyPack.guaranteesWarrantiesAndIndemnityInsurances`
+
+**UI:** For SEF25 upfront, show all 7 warranty categories as simple Yes/No questions. No details or "Years Remaining" needed at this stage — the law firm picks up details later.
+
+| Property | Title | sef25Ref |
+|----------|-------|----------|
+| `newHomeWarranty` | New Home Warranty (NHBC or similar) | W1.1 |
+| `roofingWork` | Roofing work | W1.2 |
+| `dampProofingTreatment` | Damp proofing treatment | W1.3 |
+| `centralHeatingAndorPlumbing` | Central heating and/or plumbing | W1.4 |
+| `electricalRepairOrInstallation` | Electrical repair or installation | W1.5 |
+| `subsidenceWork` | Underpinning or other preventative work / remedial action relating to subsidence | W1.6 |
+| `otherGuarantees` | Other Guarantees or warranties | W1.7 |
+
+**Note:** These fields already exist in the base schema under the `hasValidGuaranteesOrWarranties = "Yes"` branch. The `wg` overlay marks them as required within that branch. The Moverly app shows them upfront for SEF25 users without requiring the parent gate question first.
+
+---
+
+### 9. Insurance Claims (`ic`)
+
+**Path:** `propertyPack.insurance.insuranceClaims` (inside `isInsured = "Yes"` branch)
+
+**Ref:** `I1.1` (yesNo: `I1.1.1`) — "Have you made any buildings insurance claims?"
+
+**Note:** The overlay marks insuranceClaims required within the `isInsured = "Yes"` oneOf branch.
+
+---
+
+### 10. Neighbour Development (`nd`)
+
+**Path:** `propertyPack.notices.neighbourDevelopment`
+
+**Ref:** `N1.1` — "Is the seller aware of any proposals to develop property or land nearby?"
+
+**Note:** `neighbourDevelopment` is already required via `ntsRequired` at the notices level. The `nd` overlay adds `sef25Ref` and `ntsRef` annotations so the field is identifiable as SEF25-relevant.
+
+---
+
+### 11. Material Issue (`mi`)
+
+**Path:** `propertyPack.additionalInformation.otherMaterialIssue`
+
+**Ref:** `M1.1` (yesNo: `M1.1.1`) — "Are you aware of any other material issue or information which may affect the average person's decision to proceed?"
+
+---
+
+### 12. Title Restrictions (`tr`)
+
+**Path:** `propertyPack.ownership.ownershipsToBeTransferred[Freehold].titleRestrictions`
+
+**Ref:** `T1.1` (yesNo: `T1.1.1`, details: `T1.1.2`) — "Are there any known restrictions on the title?"
+
+New field on the freehold ownership branch, modelled on `leaseRestrictions` for leasehold. Yes/No + details if Yes.
+
+---
+
+## Loading the Extensions
+
+```js
+import { getTransactionSchema, getValidator } from "@pdtf/schemas";
+
+const schemaId = "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+// Load all SEF25 extensions
+const sef25Extensions = ["sc", "pc", "ph", "dk", "rw", "sd", "lc", "wg", "ic", "nd", "mi", "tr"];
+const schema = getTransactionSchema(schemaId, sef25Extensions);
+
+// Or combine with other overlays
+const schema = getTransactionSchema(schemaId, ["baspiV5", ...sef25Extensions]);
+
+// Validate data against the merged schema
+const validator = getValidator(schemaId, sef25Extensions);
+```
+
+---
+
+## Summary of Trigger Conditions
+
+| Field | Visible when... |
+|-------|----------------|
+| Water cost | `mainsWater.yesNo` = `"No"` |
+| Sewerage cost | `mainsFoulDrainage.yesNo` = `"No"` or `"Not known"` |
+| Parking permit frequency | `controlledParking.yesNo` = `"Yes"` |
+| Wells/ditches/shaft | Always (within Specialist Issues) |
+| Damaged electrics | Always (within Specialist Issues) |
+| Flooring/staircase damage | Always (within Specialist Issues) |
+| Areas in poor condition | Always (within Specialist Issues) |
+| Dropped kerb access | Always (within Parking) |
+| Private right of way | Always (within Rights & Informal Arrangements) |
+| Storm/fire/flood damage | Always (within Environmental Issues) |
+| Solar panel lease costs | `panelsOwnedOutright.yesNo` = `"No"` |
+| Warranty categories (7) | Always when `wg` overlay loaded (within Guarantees & Warranties) |
+| Insurance claims | `isInsured.yesNo` = `"Yes"` (via `ic` overlay) |
+| Neighbour development | Always (via `nd` overlay) |
+| Other material issue | Always (via `mi` overlay) |
+| Title restrictions | Always (via `tr` overlay, freehold only) |
+
+---
+
+## Moverly propertyPackTasks Changes
+
+The following changes are needed in the Moverly app's `propertyPackTasks` configuration to surface the new SEF25 fields in the listing journey.
+
+### Existing tasks to deprecate
+
+The flooding and planning tasks should be stepped up to their parent section level to cover the new sibling fields (`stormFireFloodDamage` and `neighbourDevelopment`).
+
+```js
+// Replace existing flooding task with deprecated version
+{
+  name: "Flooding",
+  path: "/propertyPack/environmentalIssues/flooding",
+  category: "listing",
+  overlay: "nts2023",
+  deprecated: true, // replaced by environmental issues check
+},
+
+// Replace existing planning task with deprecated version
+{
+  name: "Planning and development",
+  path: "/propertyPack/notices/planningApplication",
+  category: "listing",
+  overlay: "nts2023",
+  deprecated: true, // replaced by notices check
+},
+```
+
+### New listing tasks to add
+
+```js
+{
+  name: "Environmental issues",
+  checkName: "sef25-environmentalIssues",
+  path: "/propertyPack/environmentalIssues",
+  category: "listing",
+  overlay: "sd",
+},
+{
+  name: "Notices",
+  checkName: "sef25-notices",
+  path: "/propertyPack/notices",
+  category: "listing",
+  overlay: "nd",
+},
+{
+  name: "Guarantees & warranties",
+  checkName: "sef25-warranties",
+  path: "/propertyPack/guaranteesWarrantiesAndIndemnityInsurances",
+  category: "listing",
+  overlay: "wg",
+},
+{
+  name: "Insurance claims",
+  checkName: "sef25-insurance",
+  path: "/propertyPack/insurance",
+  category: "listing",
+  overlay: "ic",
+},
+{
+  name: "Additional material information",
+  checkName: "sef25-additionalInformation",
+  path: "/propertyPack/additionalInformation",
+  category: "listing",
+  overlay: "mi",
+},
+```
+
+### Fields covered by existing listing tasks (no new task needed)
+
+| Extension | Covered by |
+|-----------|------------|
+| `dk` (dropped kerb) | Parking |
+| `rw` (private right of way) | Rights and easements |
+| `lc` (solar lease costs) | Electricity |
+| `sc` (supply costs) | Water and drainage |
+| `pc` (parking permit cost) | Parking |
+| `ph` (property hazards) | Specialist issues |
+| `tr` (title restrictions) | Ownership |

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const cacheStats = {
   hits: 0,
   misses: 0,
   totalQueries: 0,
-  cacheStartTime: Date.now()
+  cacheStartTime: Date.now(),
 };
 
 const verifiedClaimsSchema = require("./src/schemas/verifiedClaims/pdtf-verified-claims.json");
@@ -52,6 +52,24 @@ const extensionOverlays = {
 
   // Transaction Extensions
   oc: require("./src/schemas/v3/overlays/extensions/oc.json"),
+
+  // SEF25 Extensions
+  sc: require("./src/schemas/v3/overlays/extensions/sc.json"),
+  pc: require("./src/schemas/v3/overlays/extensions/pc.json"),
+  ph: require("./src/schemas/v3/overlays/extensions/ph.json"),
+  dk: require("./src/schemas/v3/overlays/extensions/dk.json"),
+  rw: require("./src/schemas/v3/overlays/extensions/rw.json"),
+  sd: require("./src/schemas/v3/overlays/extensions/sd.json"),
+  lc: require("./src/schemas/v3/overlays/extensions/lc.json"),
+  wg: require("./src/schemas/v3/overlays/extensions/wg.json"),
+  ic: require("./src/schemas/v3/overlays/extensions/ic.json"),
+  nd: require("./src/schemas/v3/overlays/extensions/nd.json"),
+  mi: require("./src/schemas/v3/overlays/extensions/mi.json"),
+  tr: require("./src/schemas/v3/overlays/extensions/tr.json"),
+  ac: require("./src/schemas/v3/overlays/extensions/ac.json"),
+
+  // Compatibility Extensions
+  ta: require("./src/schemas/v3/overlays/extensions/ta.json"),
 };
 
 const overlaysMap = {
@@ -75,7 +93,9 @@ const overlaysMap = {
     baspiV4: require("./src/schemas/v3/overlays/baspi4.json"),
     baspiV5: require("./src/schemas/v3/overlays/baspi5.json"),
     ta6ed4: require("./src/schemas/v3/overlays/ta6.json"),
+    ta6ed6: require("./src/schemas/v3/overlays/ta6ed6.json"),
     ta7ed3: require("./src/schemas/v3/overlays/ta7.json"),
+    ta7ed5: require("./src/schemas/v3/overlays/ta7ed5.json"),
     ta10ed3: require("./src/schemas/v3/overlays/ta10.json"),
     lpe1ed4: require("./src/schemas/v3/overlays/lpe1.json"),
     fme1ed2: require("./src/schemas/v3/overlays/fme1.json"),
@@ -104,7 +124,7 @@ const transactionSchemas = {
 };
 
 // Custom array merge function for oneOf arrays
-const arrayMerge = (target, source) => {
+const arrayMerge = (target, source, options) => {
   // For string arrays (enum, required, etc.)
   if (
     target.length > 0 &&
@@ -114,17 +134,30 @@ const arrayMerge = (target, source) => {
     source[0] &&
     typeof source[0] === "string"
   ) {
-    // For required arrays, combine them (remove duplicates)
-    // Check if this looks like a required array (contains field names, not enum values)
-    const isRequiredArray = target.some(
-      (item) =>
-        typeof item === "string" &&
-        item.length > 0 &&
-        !item.includes("Yes") &&
-        !item.includes("No") &&
-        !item.includes("Not known") &&
-        !item.includes("To be connected")
-    );
+    // Detect if this is a required array by checking the parent key
+    // Required arrays are property names (camelCase, no spaces)
+    // Enum arrays are values (can contain spaces, capitals, etc.)
+    const isRequiredArray =
+      target.every(
+        (item) =>
+          typeof item === "string" &&
+          item.length > 0 &&
+          // Required field names are typically camelCase without spaces
+          !item.includes(" ") &&
+          // First character is usually lowercase for field names
+          (item[0] === item[0].toLowerCase() ||
+            item.startsWith("is") ||
+            item.startsWith("has")),
+      ) &&
+      source.every(
+        (item) =>
+          typeof item === "string" &&
+          item.length > 0 &&
+          !item.includes(" ") &&
+          (item[0] === item[0].toLowerCase() ||
+            item.startsWith("is") ||
+            item.startsWith("has")),
+      );
 
     if (isRequiredArray) {
       // Combine required arrays
@@ -137,7 +170,7 @@ const arrayMerge = (target, source) => {
       return combined;
     }
 
-    // For other string arrays (like enum), use source if it exists, otherwise use target
+    // For other string arrays (like enum), replace with source
     return source.length > 0 ? source : target;
   }
 
@@ -169,7 +202,7 @@ const arrayMerge = (target, source) => {
 
 const getTransactionSchema = (
   schemaId = "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json",
-  overlays
+  overlays,
 ) => {
   const sourceSchema = transactionSchemas[schemaId];
   if (!overlays || overlays.length < 1) return sourceSchema;
@@ -177,7 +210,7 @@ const getTransactionSchema = (
   let mergedSchema = JSON.parse(JSON.stringify(sourceSchema)); // Deep copy
   overlays.forEach((overlay) => {
     const overlaySchema = JSON.parse(
-      JSON.stringify(overlaysMap[schemaId][overlay] || {})
+      JSON.stringify(overlaysMap[schemaId][overlay] || {}),
     ); // Deep copy
     mergedSchema = merge(mergedSchema, overlaySchema, { arrayMerge });
   });
@@ -204,24 +237,77 @@ const getCachedSchemaData = (path, schemaId, overlays) => {
     const sourceSchema = getTransactionSchema(schemaId, overlays);
     const pathArray = path.split("/").slice(1);
     let subSchema = sourceSchema;
-    
+
     if (pathArray.length >= 1) {
       subSchema = pathArray.reduce((schema, pathElement) => {
         if (!schema) return undefined;
-        const { type, items, properties, oneOf } = schema;
+        const { type, items, properties, patternProperties, oneOf } = schema;
+
+        // Check array type
         if (type === "array") return items;
+
+        // Check explicit properties first
         if (properties?.[pathElement]) return properties[pathElement];
-        if (oneOf) {
-          let matchingProperty;
-          oneOf.forEach((aOneOf) => {
-            if (aOneOf.type === "array" && !Number.isNaN(pathElement)) {
-              matchingProperty = aOneOf.items;
-            } else if (aOneOf.properties?.[pathElement]) {
-              matchingProperty = aOneOf.properties?.[pathElement];
+
+        // Check patternProperties
+        if (patternProperties) {
+          for (const pattern in patternProperties) {
+            try {
+              const regex = new RegExp(pattern);
+              if (regex.test(pathElement)) {
+                return patternProperties[pattern];
+              }
+            } catch (e) {
+              // Invalid regex pattern in schema - skip it
+              console.warn(
+                `Invalid regex pattern in patternProperties: ${pattern}`,
+                e,
+              );
             }
-          });
+          }
+        }
+
+        // Check oneOf discriminators (recursively for nested oneOf)
+        if (oneOf) {
+          const findInOneOf = (branches) => {
+            let arrayFallback;
+            for (const branch of branches) {
+              if (!branch) continue;
+              // Track array matches as fallback (prefer property matches)
+              if (
+                branch.type === "array" &&
+                !Number.isNaN(pathElement) &&
+                !arrayFallback
+              ) {
+                arrayFallback = branch.items;
+              }
+              if (branch.properties?.[pathElement]) {
+                return branch.properties[pathElement];
+              }
+              if (branch.patternProperties) {
+                for (const pattern in branch.patternProperties) {
+                  try {
+                    const regex = new RegExp(pattern);
+                    if (regex.test(pathElement)) {
+                      return branch.patternProperties[pattern];
+                    }
+                  } catch (e) {
+                    // Invalid regex pattern - skip
+                  }
+                }
+              }
+              // Recurse into nested oneOf branches
+              if (branch.oneOf) {
+                const nested = findInOneOf(branch.oneOf);
+                if (nested) return nested;
+              }
+            }
+            return arrayFallback;
+          };
+          const matchingProperty = findInOneOf(oneOf);
           if (matchingProperty) return matchingProperty;
         }
+
         return undefined;
       }, sourceSchema);
     }
@@ -229,7 +315,7 @@ const getCachedSchemaData = (path, schemaId, overlays) => {
     // Add schema to AJV and get validator
     // Only add valid schemas to AJV
     let validator;
-    if (subSchema && typeof subSchema === 'object') {
+    if (subSchema && typeof subSchema === "object") {
       // Check if schema already exists in AJV to avoid duplicates
       validator = ajv.getSchema(cacheKey);
       if (!validator) {
@@ -246,7 +332,7 @@ const getCachedSchemaData = (path, schemaId, overlays) => {
       subSchema,
       validator,
       cacheKey,
-      createdAt: Date.now()
+      createdAt: Date.now(),
     };
     schemaCache.set(cacheKey, cached);
   } else {
@@ -312,13 +398,13 @@ const getTitleAtPath = (schema, path, rootPath = path) => {
   if (oneOfs) {
     // only single dependency discriminator, oneOf keyword is supported
     const matchingOneOf = oneOfs.find(
-      (oneOf) => oneOf["properties"][propertyName]
+      (oneOf) => oneOf["properties"][propertyName],
     );
     if (matchingOneOf)
       return getTitleAtPath(
         matchingOneOf["properties"][propertyName],
         subPath,
-        rootPath
+        rootPath,
       );
   }
 };
@@ -351,7 +437,7 @@ const validateVerifiedClaims = (verifiedClaims, schemaId, overlays) => {
         }
       } else {
         validationErrorsArr.push(
-          `Path ${path} is not a valid PDTF schema path`
+          `Path ${path} is not a valid PDTF schema path`,
         );
       }
     }
@@ -363,8 +449,11 @@ const validateVerifiedClaims = (verifiedClaims, schemaId, overlays) => {
 // Cache management functions
 const getCacheStats = () => {
   const runtime = Date.now() - cacheStats.cacheStartTime;
-  const hitRate = cacheStats.totalQueries > 0 ? (cacheStats.hits / cacheStats.totalQueries * 100) : 0;
-  
+  const hitRate =
+    cacheStats.totalQueries > 0
+      ? (cacheStats.hits / cacheStats.totalQueries) * 100
+      : 0;
+
   return {
     totalEntries: schemaCache.size,
     hits: cacheStats.hits,
@@ -376,8 +465,8 @@ const getCacheStats = () => {
     memoryUsage: {
       entriesCount: schemaCache.size,
       // Rough estimate of memory usage per entry
-      estimatedSizeKB: Math.round((schemaCache.size * 2) / 1024 * 100) / 100 // Rough estimate
-    }
+      estimatedSizeKB: Math.round(((schemaCache.size * 2) / 1024) * 100) / 100, // Rough estimate
+    },
   };
 };
 
@@ -387,15 +476,17 @@ const getDetailedCacheStats = () => {
     key,
     createdAt: value.createdAt,
     age: Date.now() - value.createdAt,
-    hasValidator: typeof value.validator === 'function',
-    hasSubSchema: value.subSchema !== undefined
+    hasValidator: typeof value.validator === "function",
+    hasSubSchema: value.subSchema !== undefined,
   }));
 
   return {
     ...baseStats,
     entries: entries.sort((a, b) => b.createdAt - a.createdAt), // Most recent first
-    oldestEntry: entries.length > 0 ? Math.max(...entries.map(e => e.age)) : 0,
-    newestEntry: entries.length > 0 ? Math.min(...entries.map(e => e.age)) : 0
+    oldestEntry:
+      entries.length > 0 ? Math.max(...entries.map((e) => e.age)) : 0,
+    newestEntry:
+      entries.length > 0 ? Math.min(...entries.map((e) => e.age)) : 0,
   };
 };
 
@@ -408,17 +499,17 @@ const clearSchemaCache = (pattern) => {
         keysToDelete.push(key);
       }
     });
-    keysToDelete.forEach(key => schemaCache.delete(key));
-    
+    keysToDelete.forEach((key) => schemaCache.delete(key));
+
     // Also remove matching schemas from AJV
-    keysToDelete.forEach(key => {
+    keysToDelete.forEach((key) => {
       try {
         ajv.removeSchema(key);
       } catch (e) {
         // Schema might not exist in AJV, ignore
       }
     });
-    
+
     return keysToDelete.length;
   } else {
     // Clear all cache
@@ -429,20 +520,24 @@ const clearSchemaCache = (pattern) => {
     cacheStats.misses = 0;
     cacheStats.totalQueries = 0;
     cacheStats.cacheStartTime = Date.now();
-    
+
     // Also clear AJV's internal cache to prevent duplicates
     ajv.removeSchema();
-    
+
     return entriesCleared;
   }
 };
 
-const warmupCache = (paths, schemaId = "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json", overlaysList = []) => {
+const warmupCache = (
+  paths,
+  schemaId = "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json",
+  overlaysList = [],
+) => {
   const warmupStats = {
     totalAttempted: 0,
     successful: 0,
     failed: 0,
-    errors: []
+    errors: [],
   };
 
   // Default common paths if none provided
@@ -454,7 +549,7 @@ const warmupCache = (paths, schemaId = "https://trust.propdata.org.uk/schemas/v3
     "/propertyPack/valuations",
     "/propertyPack/waterAndDrainage",
     "/propertyPack/ownership",
-    "/propertyPack/notices"
+    "/propertyPack/notices",
   ];
 
   // Default common overlays if none provided
@@ -463,14 +558,15 @@ const warmupCache = (paths, schemaId = "https://trust.propdata.org.uk/schemas/v3
     ["baspiV5"],
     ["ta6ed4"],
     ["nts2023"],
-    ["baspiV5", "ta6ed4"]
+    ["baspiV5", "ta6ed4"],
   ];
 
   const pathsToWarm = paths || defaultPaths;
-  const overlaysToWarm = overlaysList.length > 0 ? overlaysList : defaultOverlays;
+  const overlaysToWarm =
+    overlaysList.length > 0 ? overlaysList : defaultOverlays;
 
-  pathsToWarm.forEach(path => {
-    overlaysToWarm.forEach(overlays => {
+  pathsToWarm.forEach((path) => {
+    overlaysToWarm.forEach((overlays) => {
       warmupStats.totalAttempted++;
       try {
         // This will populate the cache
@@ -482,7 +578,7 @@ const warmupCache = (paths, schemaId = "https://trust.propdata.org.uk/schemas/v3
         warmupStats.errors.push({
           path,
           overlays,
-          error: error.message
+          error: error.message,
         });
       }
     });
@@ -494,14 +590,14 @@ const warmupCache = (paths, schemaId = "https://trust.propdata.org.uk/schemas/v3
 const pruneCacheByAge = (maxAgeMs) => {
   const now = Date.now();
   const keysToDelete = [];
-  
+
   schemaCache.forEach((value, key) => {
     if (now - value.createdAt > maxAgeMs) {
       keysToDelete.push(key);
     }
   });
-  
-  keysToDelete.forEach(key => {
+
+  keysToDelete.forEach((key) => {
     schemaCache.delete(key);
     try {
       ajv.removeSchema(key);
@@ -509,21 +605,22 @@ const pruneCacheByAge = (maxAgeMs) => {
       // Schema might not exist in AJV, ignore
     }
   });
-  
+
   return keysToDelete.length;
 };
 
 const setCacheMaxSize = (maxSize) => {
   if (schemaCache.size <= maxSize) return 0;
-  
+
   // Get entries sorted by creation time (oldest first)
-  const entries = Array.from(schemaCache.entries())
-    .sort((a, b) => a[1].createdAt - b[1].createdAt);
-  
+  const entries = Array.from(schemaCache.entries()).sort(
+    (a, b) => a[1].createdAt - b[1].createdAt,
+  );
+
   const toRemove = schemaCache.size - maxSize;
   const keysToDelete = entries.slice(0, toRemove).map(([key]) => key);
-  
-  keysToDelete.forEach(key => {
+
+  keysToDelete.forEach((key) => {
     schemaCache.delete(key);
     try {
       ajv.removeSchema(key);
@@ -531,7 +628,7 @@ const setCacheMaxSize = (maxSize) => {
       // Schema might not exist in AJV, ignore
     }
   });
-  
+
   return keysToDelete.length;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.4.1-6",
+  "version": "3.6.0-45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pdtf/schemas",
-      "version": "3.4.1-6",
+      "version": "3.6.0-45",
       "license": "MIT",
       "dependencies": {
         "@jdw/jst": "^2.0.0-beta.15",
@@ -1356,9 +1356,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001565",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
       "dev": true,
       "funding": [
         {
@@ -1373,7 +1373,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1687,7 +1688,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -2431,6 +2433,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^27.5.1",
         "jest-serializer": "^27.5.1",
@@ -5180,9 +5183,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001565",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+      "version": "1.0.30001755",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001755.tgz",
+      "integrity": "sha512-44V+Jm6ctPj7R52Na4TLi3Zri4dWUljJd+RDm+j8LtNCc/ihLCT+X1TzoOAkRETEWqjuLnh9581Tl80FvK7jVA==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdtf/schemas",
-  "version": "3.5.0",
+  "version": "3.6.0-45",
   "description": "Property Data Trust Framework Schemas and Utilities",
   "main": "index.js",
   "directories": {
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "extract-overlays": "cd src/utils && node extractOverlay.js",
+    "extract-extension-overlays": "cd src/utils && node extractExtensionOverlays.js"
   },
   "repository": {
     "type": "git",

--- a/src/examples/v3/exampleAddParticipantVouch.json
+++ b/src/examples/v3/exampleAddParticipantVouch.json
@@ -20,6 +20,9 @@
       }
     ]
   },
+  "terms_of_use": {
+    "confidentiality_level": "restricted"
+  },
   "claims": {
     "/participants/-": {
       "name": {

--- a/src/examples/v3/exampleDocumentedVouch.json
+++ b/src/examples/v3/exampleDocumentedVouch.json
@@ -32,6 +32,9 @@
       }
     ]
   },
+  "terms_of_use": {
+    "confidentiality_level": "public"
+  },
   "claims": {
     "/propertyPack/councilTax": {
       "councilTaxBand": "D",

--- a/src/examples/v3/exampleElectronicRecord.json
+++ b/src/examples/v3/exampleElectronicRecord.json
@@ -21,6 +21,9 @@
       }
     ]
   },
+  "terms_of_use": {
+    "confidentiality_level": "public"
+  },
   "claims": {
     "/propertyPack/address": {
       "line1": "3 The Hollys",

--- a/src/examples/v3/exampleTransaction.json
+++ b/src/examples/v3/exampleTransaction.json
@@ -19,7 +19,7 @@
       },
       "role": "Seller",
       "sellersCapacity": { "capacity": "Legal Owner" },
-      "externalIds": { "Moverly": "123434" }
+      "externalIds": { "Platform": "123434" }
     },
     {
       "role": "Seller's Conveyancer",
@@ -525,6 +525,10 @@
     },
     "environmentalIssues": {
       "flooding": {
+        "floodRiskReport": {
+          "hasReportBeenPrepared": "Yes",
+          "attachments": "Attached"
+        },
         "floodRisk": {
           "riskIndicator": "Yes",
           "summary": "Likely to flood from surface water"
@@ -984,7 +988,7 @@
           "name": "Example Agency Agreement",
           "url": "https://example.com/example-agency-agreement",
           "externalIds": {
-            "Moverly": "file123"
+            "Platform": "file123"
           },
           "requiredSignatories": [
             {
@@ -1023,7 +1027,7 @@
           "name": "Peter Ronald Hetherington-Smythe",
           "signedOn": "2024-11-29T16:15:02.735Z",
           "externalIds": {
-            "Moverly": "123434"
+            "Platform": "123434"
           },
           "role": "Seller",
           "contractHash": "IYnBjUI8TauXFop6WCvnPA=="

--- a/src/examples/v3/exampleVouch.json
+++ b/src/examples/v3/exampleVouch.json
@@ -21,6 +21,9 @@
       }
     ]
   },
+  "terms_of_use": {
+    "confidentiality_level": "restricted"
+  },
   "claims": {
     "/propertyPack/delayFactors/hasDelayFactors": {
       "yesNo": "No"

--- a/src/schemas/v3/combined.json
+++ b/src/schemas/v3/combined.json
@@ -7,6 +7,7 @@
   "baspi4Required": ["participants", "propertyPack"],
   "baspi5Required": ["participants", "propertyPack"],
   "ta6Required": ["participants", "propertyPack"],
+  "ta6ed6Required": ["participants", "propertyPack"],
   "ntsRequired": ["propertyPack"],
   "nts2Required": ["propertyPack"],
   "ntslRequired": ["propertyPack"],
@@ -20,7 +21,28 @@
       "type": "string"
     },
     "externalIds": {
-      "type": "object"
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                ".*": {}
+              }
+            }
+          ]
+        }
+      }
     },
     "status": {
       "type": "string",
@@ -40,6 +62,7 @@
       "baspi4Ref": "B1",
       "baspi5Ref": "B1",
       "piqRef": "B1",
+      "ta6ed6Ref": "1",
       "title": "Transaction participants",
       "type": "array",
       "minItems": 1,
@@ -48,6 +71,7 @@
         "title": "Participant Details",
         "baspi4Required": ["name", "email", "role"],
         "baspi5Required": ["name", "email", "role"],
+        "ta6ed6Required": ["role"],
         "properties": {
           "name": {
             "title": "Name",
@@ -129,7 +153,7 @@
                 "title": "Address 2",
                 "type": "string"
               },
-              "line 3": {
+              "line3": {
                 "title": "Address 3",
                 "type": "string"
               },
@@ -167,6 +191,7 @@
             "type": "string"
           },
           "role": {
+            "ta6ed6Ref": "1",
             "title": "Role",
             "type": "string",
             "enum": [
@@ -185,7 +210,28 @@
             ]
           },
           "externalIds": {
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {}
+                    }
+                  }
+                ]
+              }
+            }
           },
           "participantStatus": {
             "type": "string",
@@ -197,6 +243,17 @@
               "identity": {
                 "type": "object",
                 "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
                   "result": {
                     "type": "string",
                     "enum": ["pass", "fail", "consider"]
@@ -224,6 +281,55 @@
               "antiMoneyLaundering": {
                 "type": "object",
                 "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
+                  "result": {
+                    "type": "string",
+                    "enum": ["pass", "fail", "consider"]
+                  },
+                  "reports": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "reportName": {
+                          "type": "string"
+                        },
+                        "result": {
+                          "type": "string",
+                          "enum": ["pass", "fail", "consider"]
+                        },
+                        "details": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceOfFunds": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
                   "result": {
                     "type": "string",
                     "enum": ["pass", "fail", "consider"]
@@ -259,7 +365,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -277,6 +382,18 @@
           {
             "properties": {
               "role": {
+                "enum": ["Buyer"]
+              },
+              "offerId": {
+                "title": "Reference to an offer in the offers object",
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
                 "enum": ["Seller"]
               },
               "sellersCapacity": {
@@ -284,14 +401,17 @@
                 "baspi5Ref": "B1.3",
                 "rdsRef": "Participants/description=?,Participants/ActingFor/Participants/Role",
                 "piqRef": "B1.3.1",
+                "ta6ed6Ref": "1.4",
                 "title": "Capacity in which the Seller sells",
                 "type": "object",
                 "baspi4Required": ["capacity"],
                 "baspi5Required": ["capacity"],
+                "ta6ed6Required": ["capacity"],
                 "properties": {
                   "capacity": {
                     "baspi4Ref": "B1.3.1",
                     "baspi5Ref": "B1.3.1",
+                    "ta6ed6Ref": "1.4",
                     "type": "string",
                     "title": "",
                     "enum": [
@@ -299,6 +419,9 @@
                       "Personal Representative for a Deceased Owner",
                       "Under Power of Attorney",
                       "Mortgagee in Possession",
+                      "Company Director",
+                      "Company Secretary",
+                      "Trustee",
                       "Assistant",
                       "Other"
                     ]
@@ -336,6 +459,7 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
                         ]
@@ -357,12 +481,57 @@
                     },
                     "baspi4Required": ["sellersCapacityDetails", "attachments"],
                     "baspi5Required": ["sellersCapacityDetails", "attachments"]
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": ["Company Director", "Company Secretary"]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2",
+                        "baspi5Ref": "B1.3.2",
+                        "rdsRef": "Participants/OtherDocumentation",
+                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3",
+                        "baspi5Ref": "B1.3.3",
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": ["Attached", "To follow"]
+                      },
+                      "companyName": {
+                        "ta6ed6Ref": "1.6.1",
+                        "title": "Company name",
+                        "type": "string"
+                      },
+                      "companyNumber": {
+                        "ta6ed6Ref": "1.6.2",
+                        "title": "Company number",
+                        "type": "string"
+                      },
+                      "countryOfIncorporation": {
+                        "ta6ed6Ref": "1.6.3",
+                        "title": "Country of incorporation",
+                        "type": "string"
+                      }
+                    },
+                    "baspi4Required": ["sellersCapacityDetails", "attachments"],
+                    "baspi5Required": ["sellersCapacityDetails", "attachments"]
                   }
                 ]
+              },
+              "dateBecameOwnerOrAuthority": {
+                "ta6ed6Ref": "1.5",
+                "title": "Date the seller became owner or was authorised to sell",
+                "type": "string",
+                "format": "date"
               }
             },
             "baspi4Required": ["sellersCapacity"],
-            "baspi5Required": ["sellersCapacity"]
+            "baspi5Required": ["sellersCapacity"],
+            "ta6ed6Required": ["sellersCapacity", "dateBecameOwnerOrAuthority"]
           }
         ]
       }
@@ -471,6 +640,30 @@
         "completionAndMoving",
         "confirmationOfAccuracyByOwners"
       ],
+      "ta6ed6Required": [
+        "address",
+        "parking",
+        "disputesAndComplaints",
+        "alterationsAndChanges",
+        "listingAndConservation",
+        "notices",
+        "specialistIssues",
+        "waterAndDrainage",
+        "electricity",
+        "heating",
+        "connectivity",
+        "insurance",
+        "rightsAndInformalArrangements",
+        "environmentalIssues",
+        "legalBoundaries",
+        "servicesCrossing",
+        "electricalWorks",
+        "guaranteesWarrantiesAndIndemnityInsurances",
+        "occupiers",
+        "completionAndMoving",
+        "confirmationOfAccuracyByOwners",
+        "additionalInformation"
+      ],
       "ntsRequired": [
         "priceInformation",
         "ownership",
@@ -540,12 +733,15 @@
         "specialistIssues"
       ],
       "ta7Required": ["ownership"],
+      "ta7ed5Required": ["address", "ownership"],
       "properties": {
         "address": {
           "baspi4Ref": "A1.1",
           "baspi5Ref": "A1.1",
           "ta6Ref": "0.1",
+          "ta6ed6Ref": "1.1",
           "ta7Ref": "0.1",
+          "ta7ed5Ref": "1.1",
           "ta10Ref": "0.1",
           "rdsRef": "Property/Address/xal:AddressDetails",
           "piqRef": "A1.1",
@@ -572,7 +768,9 @@
             },
             "line1": {
               "ta6Ref": "0.1.1",
+              "ta6ed6Ref": "1.1.1",
               "ta7Ref": "0.1.1",
+              "ta7ed5Ref": "1.1.1",
               "ta10Ref": "0.1.1",
               "baspi4Ref": "A1.1.1",
               "baspi5Ref": "A1.1.1",
@@ -583,7 +781,9 @@
             },
             "line2": {
               "ta6Ref": "0.1.2",
+              "ta6ed6Ref": "1.1.2",
               "ta7Ref": "0.1.2",
+              "ta7ed5Ref": "1.1.1",
               "ta10Ref": "0.1.2",
               "baspi4Ref": "A1.1.2",
               "baspi5Ref": "A1.1.2",
@@ -593,7 +793,9 @@
             },
             "line3": {
               "ta6Ref": "0.1.3",
+              "ta6ed6Ref": "1.1.3",
               "ta7Ref": "0.1.3",
+              "ta7ed5Ref": "1.1.1",
               "ta10Ref": "0.1.3",
               "baspi4Ref": "A1.1.3",
               "baspi5Ref": "A1.1.3",
@@ -602,7 +804,9 @@
             },
             "town": {
               "ta6Ref": "0.1.4",
+              "ta6ed6Ref": "1.1.4",
               "ta7Ref": "0.1.4",
+              "ta7ed5Ref": "1.1.1",
               "ta10Ref": "0.1.4",
               "baspi4Ref": "A1.1.4",
               "baspi5Ref": "A1.1.4",
@@ -612,7 +816,9 @@
             },
             "postcode": {
               "ta6Ref": "0.1.5",
+              "ta6ed6Ref": "1.1.5",
               "ta7Ref": "0.1.5",
+              "ta7ed5Ref": "1.1.2",
               "ta10Ref": "0.1.5",
               "baspi4Ref": "A1.1.5",
               "baspi5Ref": "A1.1.5",
@@ -636,12 +842,16 @@
           },
           "baspi4Required": ["line1", "postcode"],
           "baspi5Required": ["line1", "postcode"],
-          "ta6Required": ["line1", "postcode"]
+          "ta6Required": ["line1", "postcode"],
+          "ta6ed6Required": ["line1", "postcode"]
         },
         "uprn": {
           "baspi4Ref": "A1.1.5",
           "baspi5Ref": "A1.1.5",
+          "ta7ed5Ref": "1.1.3",
           "rdsRef": "Property/GUID/{name='UPRN',id=?}",
+          "ta6ed6Ref": "1.2",
+          "ta6ed6Description": "Unique Property Reference Number (digits)",
           "title": "Unique Property Reference Number",
           "type": "integer"
         },
@@ -1726,8 +1936,10 @@
           "baspi4Ref": "A1.3",
           "baspi5Ref": "A1.3",
           "ta7Ref": "1",
+          "ta7ed5Ref": "2",
           "ntsRef": "A3",
           "nts2Ref": "A3",
+          "sef25Ref": "T1",
           "title": "Ownership",
           "type": "object",
           "baspi4Required": ["ownershipsToBeTransferred"],
@@ -1735,6 +1947,7 @@
           "ntsRequired": ["ownershipsToBeTransferred"],
           "nts2Required": ["ownershipsToBeTransferred"],
           "ta7Required": ["ownershipsToBeTransferred"],
+          "ta7ed5Required": ["ownershipsToBeTransferred"],
           "properties": {
             "numberOfSellers": {
               "title": "How many sellers are involved in the transaction?",
@@ -1745,6 +1958,15 @@
               "title": "How many sellers are involved in the transaction who are resident outside the UK?",
               "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
               "type": "integer"
+            },
+            "outstandingMortgage": {
+              "title": "Are there any outstanding mortgages on the property?",
+              "type": "string",
+              "enum": ["Yes", "No"]
+            },
+            "existingLender": {
+              "title": "What is the name of the existing lender?",
+              "type": "string"
             },
             "hasHelpToBuyEquityLoan": {
               "title": "Is the property being sold with a Help to Buy equity loan outstanding?",
@@ -1765,6 +1987,7 @@
               "baspi4Ref": "A1.3",
               "baspi5Ref": "A1.3",
               "ta7Ref": "1",
+              "ta7ed5Ref": "2",
               "ntsRef": "A3",
               "nts2Ref": "A3",
               "title": "Ownerships to be transferred on sale",
@@ -1776,11 +1999,13 @@
                 "ntsRef": "A3.1",
                 "nts2Ref": "A3.1",
                 "ta7Ref": "1",
+                "ta7ed5Ref": "2",
                 "title": "Ownership to be transferred",
                 "type": "object",
                 "baspi4Required": ["ownershipType"],
                 "baspi5Required": ["ownershipType"],
                 "ta7Required": ["ownershipType"],
+                "ta7ed5Required": ["ownershipType"],
                 "ntsRequired": ["ownershipType"],
                 "nts2Required": ["ownershipType"],
                 "properties": {
@@ -1803,8 +2028,8 @@
                     "nts2Ref": "A3.1",
                     "baspi4Ref": "A1.3.0.2",
                     "baspi5Ref": "A1.3.0.2",
+                    "ta7ed5Ref": "2",
                     "rdsRef": "Tenure/Tenure",
-                    "ta7Ref": "1.1",
                     "piqRef": "A1.2",
                     "title": "What type of ownership is the property?",
                     "description": "A Managed Freehold is any freehold where there are shared amenities, the maintenance of which you pay for through an estate rentcharge, service charge, informal or formal contribution. Choose Leasehold if your property is under a Shared Ownership arrangement.",
@@ -1874,6 +2099,46 @@
                           }
                         ]
                       },
+                      "titleRestrictions": {
+                        "sef25Ref": "T1.1",
+                        "title": "Are there any known restrictions on the title?",
+                        "type": "object",
+                        "sef25Required": ["yesNo"],
+                        "properties": {
+                          "yesNo": {
+                            "sef25Ref": "T1.1.1",
+                            "type": "string",
+                            "title": "",
+                            "enum": ["Yes", "No"]
+                          }
+                        },
+                        "discriminator": {
+                          "propertyName": "yesNo"
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": ["No"]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": ["Yes"]
+                              },
+                              "details": {
+                                "sef25Ref": "T1.1.2",
+                                "title": "Details",
+                                "type": "string",
+                                "minLength": 1
+                              }
+                            },
+                            "sef25Required": ["details"]
+                          }
+                        ]
+                      },
                       "wholeFreeholdForSale": {
                         "baspi4Ref": "A1.3.0.2.1",
                         "baspi5Ref": "A1.3.0.2.1",
@@ -1922,7 +2187,8 @@
                     },
                     "baspi4Required": ["wholeFreeholdForSale"],
                     "baspi5Required": ["wholeFreeholdForSale"],
-                    "nts2Required": ["estateRentcharges"]
+                    "nts2Required": ["estateRentcharges"],
+                    "sef25Required": ["titleRestrictions"]
                   },
                   {
                     "properties": {
@@ -2621,71 +2887,71 @@
                                           "noticeViaEmail": {
                                             "type": "string",
                                             "enum": ["true", "false"]
-                                          }
-                                        },
-                                        "contact": {
-                                          "type": "object",
-                                          "properties": {
-                                            "nameOrOrganisation": {
-                                              "title": "Name or organisation",
-                                              "type": "string",
-                                              "minLength": 1
-                                            },
-                                            "address": {
-                                              "title": "Address",
-                                              "type": "object",
-                                              "properties": {
-                                                "line1": {
-                                                  "title": "Address line 1",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "line2": {
-                                                  "title": "Address line 2",
-                                                  "type": "string"
-                                                },
-                                                "line3": {
-                                                  "title": "Address line 3",
-                                                  "type": "string"
-                                                },
-                                                "town": {
-                                                  "title": "Town",
-                                                  "type": "string"
-                                                },
-                                                "postcode": {
-                                                  "title": "Postcode",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                }
-                                              },
-                                              "fme1Required": [
-                                                "line1",
-                                                "postcode"
-                                              ]
-                                            },
-                                            "telephone": {
-                                              "title": "Telephone",
-                                              "type": "string",
-                                              "minLength": 1
-                                            },
-                                            "emailAddress": {
-                                              "title": "Email address",
-                                              "type": "string",
-                                              "format": "email"
-                                            }
                                           },
-                                          "fme1Required": [
-                                            "nameOrOrganisation",
-                                            "line1",
-                                            "postcode",
-                                            "telephone",
-                                            "emailAddress"
-                                          ]
-                                        },
-                                        "capacity": {
-                                          "title": "Capacity (e.g. Management Company's lawyer)",
-                                          "type": "string",
-                                          "minLength": 1
+                                          "contact": {
+                                            "type": "object",
+                                            "properties": {
+                                              "nameOrOrganisation": {
+                                                "title": "Name or organisation",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "address": {
+                                                "title": "Address",
+                                                "type": "object",
+                                                "properties": {
+                                                  "line1": {
+                                                    "title": "Address line 1",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "line2": {
+                                                    "title": "Address line 2",
+                                                    "type": "string"
+                                                  },
+                                                  "line3": {
+                                                    "title": "Address line 3",
+                                                    "type": "string"
+                                                  },
+                                                  "town": {
+                                                    "title": "Town",
+                                                    "type": "string"
+                                                  },
+                                                  "postcode": {
+                                                    "title": "Postcode",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  }
+                                                },
+                                                "fme1Required": [
+                                                  "line1",
+                                                  "postcode"
+                                                ]
+                                              },
+                                              "telephone": {
+                                                "title": "Telephone",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "emailAddress": {
+                                                "title": "Email address",
+                                                "type": "string",
+                                                "format": "email"
+                                              }
+                                            },
+                                            "fme1Required": [
+                                              "nameOrOrganisation",
+                                              "line1",
+                                              "postcode",
+                                              "telephone",
+                                              "emailAddress"
+                                            ]
+                                          },
+                                          "capacity": {
+                                            "title": "Capacity (e.g. Management Company's lawyer)",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
                                         },
                                         "fme1Required": [
                                           "feeIncludingVAT",
@@ -2971,7 +3237,7 @@
                               "hasFixedRentcharge": {
                                 "type": "string",
                                 "fme1Ref": "3.1.1",
-                                "title": "If there is also a ‘fixed’ Rentcharge, please confirm the amount and explain why."
+                                "title": "If there is also a 'fixed' Rentcharge, please confirm the amount and explain why."
                               },
                               "largeAdditionalExpense": {
                                 "baspi4Ref": "A1.5.2.1",
@@ -3130,7 +3396,7 @@
                                       },
                                       "details": {
                                         "fme1Ref": "3.4.1.1",
-                                        "title": "If No, provide details as to why not",
+                                        "title": "Provide details as to why not",
                                         "type": "string"
                                       }
                                     }
@@ -4125,17 +4391,14 @@
                           },
                           "confirmation": {
                             "title": "Confirmation",
-                            "description": "By checking the box you are .",
                             "type": "object",
                             "fme1Required": ["response"],
                             "properties": {
                               "response": {
                                 "title": "Declaration",
+                                "type": "object",
                                 "description": "I/we confirm that I am the person authorised to provide the information which I have completed in it on behalf of those parties which I have selected from the list, and that a buyer may rely on the information which I have supplied without applying to any other party except where I have left a section blank because I do not have the authority to provide the information",
-                                "confirmation": {
-                                  "type": "string",
-                                  "enum": ["true", "false"]
-                                }
+                                "type": "boolean"
                               },
                               "capacity": {
                                 "title": "Please tick as applicable below, to confirm the capacity in which the answers are given.",
@@ -4169,6 +4432,7 @@
                         "baspi5Ref": "A1.5",
                         "ntsRef": "A3.2",
                         "nts2Ref": "A3.2",
+                        "ta7ed5Ref": "2",
                         "title": "Leasehold information",
                         "type": "object",
                         "lpe1Required": [
@@ -4217,6 +4481,7 @@
                           "leaseRestrictions"
                         ],
                         "ta7Required": [
+                          "typeOfLeasehold",
                           "sharedOwnership",
                           "leaseTerm",
                           "contactDetails",
@@ -4232,7 +4497,84 @@
                           "requiredDocuments",
                           "confirmationOfAccuracy"
                         ],
+                        "ta7ed5Required": [
+                          "typeOfLeasehold",
+                          "contactDetails",
+                          "consents",
+                          "groundRent",
+                          "ownershipAndManagement",
+                          "serviceCharge",
+                          "disputes",
+                          "buildingSafetyAct",
+                          "enfranchisement",
+                          "requiredDocuments",
+                          "additionalInformation",
+                          "confirmationOfAccuracy"
+                        ],
                         "properties": {
+                          "typeOfLeasehold": {
+                            "ta7Ref": "1.1",
+                            "ta7ed5Ref": "2.1",
+                            "title": "Type of leasehold property",
+                            "type": "object",
+                            "ta7Required": ["leaseholdType"],
+                            "ta7ed5Required": ["leaseholdType"],
+                            "properties": {
+                              "leaseholdType": {
+                                "ta7Ref": "1.1.1",
+                                "ta7ed5Ref": "2.1.1",
+                                "title": "What type of leasehold property does the seller own?",
+                                "ta7ed5Title": "What is the type of property included in the lease?",
+                                "description": "'Flat'includes maisonette and apartment.",
+                                "type": "string",
+                                "enum": [
+                                  "Flat",
+                                  "Shared ownership",
+                                  "Long leasehold house",
+                                  "Maisonette",
+                                  "Leasehold garage",
+                                  "Other"
+                                ],
+                                "ta7Enum": [
+                                  "Flat",
+                                  "Shared ownership",
+                                  "Long leasehold house"
+                                ]
+                              }
+                            },
+                            "discriminator": {
+                              "propertyName": "leaseholdType"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Flat",
+                                      "Shared ownership",
+                                      "Long leasehold house",
+                                      "Maisonette",
+                                      "Leasehold garage"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": ["Other"]
+                                  },
+                                  "otherLeaseholdType": {
+                                    "ta7ed5Ref": "2.1.2",
+                                    "title": "Please give details",
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "ta7ed5Required": ["otherLeaseholdType"]
+                              }
+                            ]
+                          },
                           "sharedOwnership": {
                             "baspi4Ref": "A1.3.1",
                             "baspi5Ref": "A1.3.1",
@@ -4376,6 +4718,7 @@
                             "baspi4Ref": "A1.5.4",
                             "baspi5Ref": "A1.5.4",
                             "ta7Ref": "4.1",
+                            "ta7ed5Ref": "3",
                             "lpe1Ref": "1",
                             "nts2Ref": "A1.5.4",
                             "title": "Contact Details",
@@ -4391,11 +4734,16 @@
                               "contacts",
                               "serviceContactAssignments"
                             ],
+                            "ta7ed5Required": [
+                              "contacts",
+                              "serviceContactAssignments"
+                            ],
                             "properties": {
                               "contacts": {
                                 "baspi4Ref": "A1.5.4",
                                 "baspi5Ref": "A1.5.4",
                                 "ta7Ref": "4.1",
+                                "ta7ed5Ref": "3",
                                 "lpe1Ref": "1",
                                 "nts2Ref": "A1.5.4",
                                 "type": "object",
@@ -4409,6 +4757,7 @@
                                     "baspi4Ref": "A1.5.4",
                                     "baspi5Ref": "A1.5.5",
                                     "ta7Ref": "4.1a",
+                                    "ta7ed5Ref": "3.1.1",
                                     "lpe1Ref": "1.1",
                                     "piqRef": "A1.4.4",
                                     "title": "Landlord",
@@ -4422,6 +4771,7 @@
                                         "baspi4Ref": "A1.5.4.1",
                                         "baspi5Ref": "A1.5.5.1",
                                         "ta7Ref": "4.1a",
+                                        "ta7ed5Ref": "3.1.1",
                                         "type": "object",
                                         "lpe1Required": [
                                           "nameOrOrganisation",
@@ -4444,6 +4794,7 @@
                                             "baspi4Ref": "A1.5.4.1.1",
                                             "baspi5Ref": "A1.5.5.1.1",
                                             "ta7Ref": "4.1a.1",
+                                            "ta7ed5Ref": "3.1.1.1",
                                             "title": "Name or organisation",
                                             "type": "string",
                                             "minLength": 1
@@ -4452,6 +4803,7 @@
                                             "baspi4Ref": "A1.5.4.1.2",
                                             "baspi5Ref": "A1.5.5.1.2",
                                             "ta7Ref": "4.1a.0",
+                                            "ta7ed5Ref": "3.1.1.2",
                                             "title": "Address",
                                             "type": "object",
                                             "properties": {
@@ -4459,6 +4811,7 @@
                                                 "baspi4Ref": "A1.5.4.1.2.1",
                                                 "baspi5Ref": "A1.5.5.1.2.1",
                                                 "ta7Ref": "4.1a.2",
+                                                "ta7ed5Ref": "3.1.1.2",
                                                 "title": "Address line 1",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4488,6 +4841,7 @@
                                                 "baspi4Ref": "A1.5.4.1.2.5",
                                                 "baspi5Ref": "A1.5.5.1.2.5",
                                                 "ta7Ref": "4.1a.6",
+                                                "ta7ed5Ref": "3.1.1.2",
                                                 "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4516,6 +4870,7 @@
                                             "baspi4Ref": "A1.5.4.3",
                                             "baspi5Ref": "A1.5.5.3",
                                             "ta7Ref": "4.1a.8",
+                                            "ta7ed5Ref": "3.1.1.3",
                                             "title": "Email address",
                                             "type": "string",
                                             "format": "email"
@@ -4661,26 +5016,31 @@
                                   "managementCompany": {
                                     "lpe1Ref": "1.2",
                                     "ta7Ref": "4.1b",
+                                    "ta7ed5Ref": "3.1.2",
                                     "title": "Management Company",
                                     "type": "object",
                                     "properties": {
                                       "contact": {
                                         "ta7Ref": "4.1b",
+                                        "ta7ed5Ref": "3.1.2",
                                         "type": "object",
                                         "properties": {
                                           "nameOrOrganisation": {
                                             "ta7Ref": "4.1b.1",
+                                            "ta7ed5Ref": "3.1.2.1",
                                             "title": "Name or organisation",
                                             "type": "string",
                                             "minLength": 1
                                           },
                                           "address": {
                                             "ta7Ref": "4.1b.0",
+                                            "ta7ed5Ref": "3.1.2.2",
                                             "title": "Address",
                                             "type": "object",
                                             "properties": {
                                               "line1": {
                                                 "ta7Ref": "4.1b.2",
+                                                "ta7ed5Ref": "3.1.2.2",
                                                 "title": "Address line 1",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4702,6 +5062,7 @@
                                               },
                                               "postcode": {
                                                 "ta7Ref": "4.1b.6",
+                                                "ta7ed5Ref": "3.1.2.2",
                                                 "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4720,6 +5081,7 @@
                                           },
                                           "emailAddress": {
                                             "ta7Ref": "4.1b.8",
+                                            "ta7ed5Ref": "3.1.2.3",
                                             "title": "Email address",
                                             "type": "string",
                                             "format": "email"
@@ -4768,22 +5130,208 @@
                                       }
                                     }
                                   },
+                                  "rightToManageCompany": {
+                                    "ta7ed5Ref": "3.1.3",
+                                    "title": "Right to manage company",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.3",
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.3.1",
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.3.2",
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.3.2",
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.3.2",
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.3.3",
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "freeholder": {
+                                    "ta7ed5Ref": "3.1.4",
+                                    "title": "Freeholder where different from the landlord",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.4",
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.4.1",
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.4.2",
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.4.2",
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.4.2",
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.4.3",
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "headLeaseHolder": {
+                                    "ta7ed5Ref": "3.1.5",
+                                    "title": "Head leaseholder (if applicable)",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.5",
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.5.1",
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.5.2",
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.5.2",
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.5.2",
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.5.3",
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   "managingAgent": {
                                     "baspi4Ref": "A1.5.5",
                                     "baspi5Ref": "A1.5.6",
                                     "ta7Ref": "4.1c",
+                                    "ta7ed5Ref": "4.1",
                                     "lpe1Ref": "1.3",
                                     "nts2Ref": "A1.5.6",
                                     "title": "Managing Agent",
-                                    "description": "A managing agent may be employed by the landlord or by the tenants’ management company to collect the rent and/or manage the building.",
+                                    "description": "A managing agent may be employed by the landlord or by the tenants' management company to collect the rent and/or manage the building.",
                                     "type": "object",
                                     "baspi4Required": ["contact"],
                                     "baspi5Required": ["contact"],
+                                    "ta7ed5Required": ["contact"],
                                     "properties": {
                                       "contact": {
                                         "baspi4Ref": "A1.5.5.1",
                                         "baspi5Ref": "A1.5.6.1",
                                         "ta7Ref": "4.1c",
+                                        "ta7ed5Ref": "4.1.2",
                                         "nts2Ref": "A1.5.6.1",
                                         "type": "object",
                                         "lpe1Required": [
@@ -4802,6 +5350,11 @@
                                           "address",
                                           "emailAddress"
                                         ],
+                                        "ta7ed5Required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
                                         "nts2Required": [
                                           "nameOrOrganisation",
                                           "emailAddress"
@@ -4811,6 +5364,7 @@
                                             "baspi4Ref": "A1.5.5.1.1",
                                             "baspi5Ref": "A1.5.6.1.1",
                                             "ta7Ref": "4.1c.1",
+                                            "ta7ed5Ref": "4.1.2.1",
                                             "nts2Ref": "A1.5.6.1.1",
                                             "title": "Name or organisation",
                                             "type": "string",
@@ -4820,6 +5374,7 @@
                                             "baspi4Ref": "A1.5.5.1.2",
                                             "baspi5Ref": "A1.5.6.1.2",
                                             "ta7Ref": "4.1c.0",
+                                            "ta7ed5Ref": "4.1.2.2",
                                             "title": "Address",
                                             "type": "object",
                                             "properties": {
@@ -4827,6 +5382,7 @@
                                                 "baspi4Ref": "A1.5.5.1.2.1",
                                                 "baspi5Ref": "A1.5.6.1.2.1",
                                                 "ta7Ref": "4.1c.2",
+                                                "ta7ed5Ref": "4.1.2.2",
                                                 "title": "Address line 1",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4856,6 +5412,7 @@
                                                 "baspi4Ref": "A1.5.5.1.2.5",
                                                 "baspi5Ref": "A1.5.6.1.2.5",
                                                 "ta7Ref": "4.1c.6",
+                                                "ta7ed5Ref": "4.1.2.2",
                                                 "title": "Postcode",
                                                 "type": "string",
                                                 "minLength": 1
@@ -4884,6 +5441,7 @@
                                             "baspi4Ref": "A1.5.5.1.3",
                                             "baspi5Ref": "A1.5.6.1.3",
                                             "ta7Ref": "4.1c.8",
+                                            "ta7ed5Ref": "4.1.2.3",
                                             "nts2Ref": "A1.5.6.1.2",
                                             "title": "Email address",
                                             "type": "string",
@@ -5127,6 +5685,7 @@
                               },
                               "serviceContactAssignments": {
                                 "ta7Ref": "5.1",
+                                "ta7ed5Ref": "4",
                                 "lpe1Ref": "1.6",
                                 "type": "object",
                                 "lpe1Required": [
@@ -5139,6 +5698,10 @@
                                   "dealsWithDayToDayMaintenanceOfBuilding"
                                 ],
                                 "ta7Required": ["organisesBuildingInsurance"],
+                                "ta7ed5Required": [
+                                  "collectsGroundRent",
+                                  "collectsbuildingInsurancePremiums"
+                                ],
                                 "properties": {
                                   "noticeOfAssignmentAndCharge": {
                                     "lpe1Ref": "1.6",
@@ -5305,71 +5868,71 @@
                                               "noticeViaEmail": {
                                                 "type": "string",
                                                 "enum": ["true", "false"]
-                                              }
-                                            },
-                                            "contact": {
-                                              "type": "object",
-                                              "properties": {
-                                                "nameOrOrganisation": {
-                                                  "title": "Name or organisation",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "address": {
-                                                  "title": "Address",
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "line1": {
-                                                      "title": "Address line 1",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    },
-                                                    "line2": {
-                                                      "title": "Address line 2",
-                                                      "type": "string"
-                                                    },
-                                                    "line3": {
-                                                      "title": "Address line 3",
-                                                      "type": "string"
-                                                    },
-                                                    "town": {
-                                                      "title": "Town",
-                                                      "type": "string"
-                                                    },
-                                                    "postcode": {
-                                                      "title": "Postcode",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    }
-                                                  },
-                                                  "lpe1Required": [
-                                                    "line1",
-                                                    "postcode"
-                                                  ]
-                                                },
-                                                "telephone": {
-                                                  "title": "Telephone",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "emailAddress": {
-                                                  "title": "Email address",
-                                                  "type": "string",
-                                                  "format": "email"
-                                                }
                                               },
-                                              "lpe1Required": [
-                                                "nameOrOrganisation",
-                                                "line1",
-                                                "postcode",
-                                                "telephone",
-                                                "emailAddress"
-                                              ]
-                                            },
-                                            "capacity": {
-                                              "title": "Capacity (e.g. Landlord's lawyer)",
-                                              "type": "string",
-                                              "minLength": 1
+                                              "contact": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "nameOrOrganisation": {
+                                                    "title": "Name or organisation",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "address": {
+                                                    "title": "Address",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "line1": {
+                                                        "title": "Address line 1",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "line2": {
+                                                        "title": "Address line 2",
+                                                        "type": "string"
+                                                      },
+                                                      "line3": {
+                                                        "title": "Address line 3",
+                                                        "type": "string"
+                                                      },
+                                                      "town": {
+                                                        "title": "Town",
+                                                        "type": "string"
+                                                      },
+                                                      "postcode": {
+                                                        "title": "Postcode",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
+                                                    },
+                                                    "lpe1Required": [
+                                                      "line1",
+                                                      "postcode"
+                                                    ]
+                                                  },
+                                                  "telephone": {
+                                                    "title": "Telephone",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "emailAddress": {
+                                                    "title": "Email address",
+                                                    "type": "string",
+                                                    "format": "email"
+                                                  }
+                                                },
+                                                "lpe1Required": [
+                                                  "nameOrOrganisation",
+                                                  "line1",
+                                                  "postcode",
+                                                  "telephone",
+                                                  "emailAddress"
+                                                ]
+                                              },
+                                              "capacity": {
+                                                "title": "Capacity (e.g. Landlord's lawyer)",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
                                             },
                                             "lpe1Required": [
                                               "feeIncludingVAT",
@@ -5589,71 +6152,71 @@
                                               "noticeViaEmail": {
                                                 "type": "string",
                                                 "enum": ["true", "false"]
-                                              }
-                                            },
-                                            "contact": {
-                                              "type": "object",
-                                              "properties": {
-                                                "nameOrOrganisation": {
-                                                  "title": "Name or organisation",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "address": {
-                                                  "title": "Address",
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "line1": {
-                                                      "title": "Address line 1",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    },
-                                                    "line2": {
-                                                      "title": "Address line 2",
-                                                      "type": "string"
-                                                    },
-                                                    "line3": {
-                                                      "title": "Address line 3",
-                                                      "type": "string"
-                                                    },
-                                                    "town": {
-                                                      "title": "Town",
-                                                      "type": "string"
-                                                    },
-                                                    "postcode": {
-                                                      "title": "Postcode",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    }
-                                                  },
-                                                  "lpe1Required": [
-                                                    "line1",
-                                                    "postcode"
-                                                  ]
-                                                },
-                                                "telephone": {
-                                                  "title": "Telephone",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "emailAddress": {
-                                                  "title": "Email address",
-                                                  "type": "string",
-                                                  "format": "email"
-                                                }
                                               },
-                                              "lpe1Required": [
-                                                "nameOrOrganisation",
-                                                "line1",
-                                                "postcode",
-                                                "telephone",
-                                                "emailAddress"
-                                              ]
-                                            },
-                                            "capacity": {
-                                              "title": "Capacity (e.g. Management Company's lawyer)",
-                                              "type": "string",
-                                              "minLength": 1
+                                              "contact": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "nameOrOrganisation": {
+                                                    "title": "Name or organisation",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "address": {
+                                                    "title": "Address",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "line1": {
+                                                        "title": "Address line 1",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "line2": {
+                                                        "title": "Address line 2",
+                                                        "type": "string"
+                                                      },
+                                                      "line3": {
+                                                        "title": "Address line 3",
+                                                        "type": "string"
+                                                      },
+                                                      "town": {
+                                                        "title": "Town",
+                                                        "type": "string"
+                                                      },
+                                                      "postcode": {
+                                                        "title": "Postcode",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
+                                                    },
+                                                    "lpe1Required": [
+                                                      "line1",
+                                                      "postcode"
+                                                    ]
+                                                  },
+                                                  "telephone": {
+                                                    "title": "Telephone",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "emailAddress": {
+                                                    "title": "Email address",
+                                                    "type": "string",
+                                                    "format": "email"
+                                                  }
+                                                },
+                                                "lpe1Required": [
+                                                  "nameOrOrganisation",
+                                                  "line1",
+                                                  "postcode",
+                                                  "telephone",
+                                                  "emailAddress"
+                                                ]
+                                              },
+                                              "capacity": {
+                                                "title": "Capacity (e.g. Management Company's lawyer)",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
                                             },
                                             "lpe1Required": [
                                               "feeIncludingVAT",
@@ -5707,14 +6270,68 @@
                                     }
                                   },
                                   "collectsGroundRent": {
-                                    "lpe1Ref": "1.7",
+                                    "ta7ed5Ref": "4.3",
                                     "title": "Who collects the Ground Rent?",
-                                    "type": "string",
-                                    "enum": [
-                                      "Landlord",
-                                      "Management Company",
-                                      "Managing Agent",
-                                      "Not applicable"
+                                    "type": "object",
+                                    "lpe1Required": ["collector"],
+                                    "ta7ed5Required": ["collector"],
+                                    "properties": {
+                                      "collector": {
+                                        "lpe1Ref": "1.7",
+                                        "ta7ed5Ref": "4.3.2",
+                                        "title": "Who collects the Ground Rent?",
+                                        "ta7ed5Title": "Who collects the ground rent?",
+                                        "type": "string",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable",
+                                          "Other"
+                                        ],
+                                        "lpe1Enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable"
+                                        ],
+                                        "ta7ed5Enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Other"
+                                        ]
+                                      }
+                                    },
+                                    "discriminator": {
+                                      "propertyName": "collector"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": ["Other"]
+                                          },
+                                          "otherCollector": {
+                                            "ta7ed5Ref": "4.3.3",
+                                            "title": "Please specify who",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        },
+                                        "ta7ed5Required": ["otherCollector"]
+                                      }
                                     ]
                                   },
                                   "collectsServiceCharges": {
@@ -5730,14 +6347,76 @@
                                     ]
                                   },
                                   "collectsbuildingInsurancePremiums": {
-                                    "lpe1Ref": "1.9",
+                                    "ta7ed5Ref": "4.2",
                                     "title": "Who collects the building insurance premiums?",
-                                    "type": "string",
-                                    "enum": [
-                                      "Landlord",
-                                      "Management Company",
-                                      "Managing Agent",
-                                      "Not applicable"
+                                    "type": "object",
+                                    "lpe1Required": ["collector"],
+                                    "ta7ed5Required": ["collector"],
+                                    "properties": {
+                                      "collector": {
+                                        "lpe1Ref": "1.9",
+                                        "ta7ed5Ref": "4.2.2",
+                                        "title": "Who collects the building insurance premiums?",
+                                        "type": "string",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable",
+                                          "Freeholder",
+                                          "Head Leaseholder",
+                                          "Seller",
+                                          "Other"
+                                        ],
+                                        "lpe1Enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable"
+                                        ],
+                                        "ta7ed5Enum": [
+                                          "Freeholder",
+                                          "Landlord",
+                                          "Management Company",
+                                          "Head Leaseholder",
+                                          "Seller",
+                                          "Other"
+                                        ]
+                                      }
+                                    },
+                                    "discriminator": {
+                                      "propertyName": "collector"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable",
+                                              "Freeholder",
+                                              "Head Leaseholder",
+                                              "Seller"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": ["Other"]
+                                          },
+                                          "otherCollector": {
+                                            "ta7ed5Ref": "4.2.3",
+                                            "title": "Please specify who",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        },
+                                        "ta7ed5Required": ["otherCollector"]
+                                      }
                                     ]
                                   },
                                   "dealsWithDayToDayMaintenanceOfManagedArea": {
@@ -5882,19 +6561,27 @@
                           },
                           "consents": {
                             "ta7Ref": "7",
+                            "ta7ed5Ref": "8",
                             "title": "Consents",
                             "type": "object",
                             "ta7Required": ["changesInTermOfLease"],
+                            "ta7ed5Required": [
+                              "changesInTermOfLease",
+                              "landlordConsents"
+                            ],
                             "properties": {
                               "changesInTermOfLease": {
                                 "ta7Ref": "7.1",
+                                "ta7ed5Ref": "8.1",
                                 "title": "Is the seller aware of any changes in the terms of the lease or of the landlord giving any consents under the lease?",
                                 "type": "object",
                                 "lpe1Required": ["isSellerAwareOfChanges"],
                                 "ta7Required": ["isSellerAwareOfChanges"],
+                                "ta7ed5Required": ["isSellerAwareOfChanges"],
                                 "properties": {
                                   "isSellerAwareOfChanges": {
                                     "ta7Ref": "7.1.1",
+                                    "ta7ed5Ref": "8.1.1",
                                     "title": "",
                                     "type": "string",
                                     "enum": ["Yes", "No"]
@@ -5918,12 +6605,15 @@
                                       },
                                       "details": {
                                         "ta7Ref": "7.1.2",
+                                        "ta7ed5Ref": "8.1.2",
                                         "title": "Please supply a copy or, if not in writing, please give details:",
+                                        "ta7ed5Title": "Please supply further details and any documents relating to the variation:",
                                         "type": "string",
                                         "minLength": 1
                                       },
                                       "attachments": {
                                         "ta7Ref": "7.1.3",
+                                        "ta7ed5Ref": "8.1.3",
                                         "type": "string",
                                         "enum": [
                                           "Attached",
@@ -5932,7 +6622,55 @@
                                         ]
                                       }
                                     },
-                                    "lpe1Required": ["details"]
+                                    "lpe1Required": ["details"],
+                                    "ta7ed5Required": ["details"]
+                                  }
+                                ]
+                              },
+                              "landlordConsents": {
+                                "ta7ed5Ref": "8.2",
+                                "title": "Are you aware of the landlord giving any formal or informal consents required by the lease?",
+                                "type": "object",
+                                "ta7ed5Required": [
+                                  "isSellerAwareOfLandlordConsents"
+                                ],
+                                "properties": {
+                                  "isSellerAwareOfLandlordConsents": {
+                                    "ta7ed5Ref": "8.2.1",
+                                    "title": "",
+                                    "type": "string",
+                                    "enum": ["Yes", "No"]
+                                  }
+                                },
+                                "discriminator": {
+                                  "propertyName": "isSellerAwareOfLandlordConsents"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": ["No"]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": ["Yes"]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "8.2.2",
+                                        "title": "Please supply the consent or if the consent was not in writing, please give details:",
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "8.2.3",
+                                        "type": "string",
+                                        "enum": ["Attached", "To follow"]
+                                      }
+                                    },
+                                    "ta7ed5Required": ["details", "attachments"]
                                   }
                                 ]
                               }
@@ -6081,7 +6819,6 @@
                                   }
                                 ]
                               },
-
                               "requirementsToBeMemberOfManagementCompany": {
                                 "baspi4Ref": "A1.5.6",
                                 "baspi5Ref": "A1.5.7",
@@ -6139,6 +6876,7 @@
                             "baspi4Ref": "A1.4.2",
                             "baspi5Ref": "A1.4.2",
                             "ta7Ref": "1.2",
+                            "ta7ed5Ref": "2.2",
                             "lpe1Ref": "3",
                             "piqRef": "A1.3.3",
                             "ntsRef": "A3.4",
@@ -6149,6 +6887,7 @@
                             "baspi4Required": ["isGroundRentPayable"],
                             "baspi5Required": ["isGroundRentPayable"],
                             "ta7Required": ["isGroundRentPayable"],
+                            "ta7ed5Required": ["isGroundRentPayable"],
                             "ntsRequired": ["isGroundRentPayable"],
                             "nts2Required": ["isGroundRentPayable"],
                             "properties": {
@@ -6156,6 +6895,7 @@
                                 "baspi4Ref": "A1.4.2.1",
                                 "baspi5Ref": "A1.4.2.1",
                                 "ta7Ref": "1.2.1",
+                                "ta7ed5Ref": "2.2",
                                 "ntsRef": "A3.4.1",
                                 "nts2Ref": "A3.4.1",
                                 "title": "Does the seller pay ground rent for the property?",
@@ -6195,6 +6935,16 @@
                                     "ta7Ref": "1.2b",
                                     "title": "How regularly is the rent paid? (e.g. annually)",
                                     "type": "string"
+                                  },
+                                  "mostRecentGroundRentDemandStatus": {
+                                    "title": "Please provide the most recent payment demands payable under the lease for ground rent",
+                                    "ta7ed5Ref": "2.2a",
+                                    "type": "string",
+                                    "enum": [
+                                      "Attached",
+                                      "To follow",
+                                      "Not applicable"
+                                    ]
                                   },
                                   "rentSubjectToIncrease": {
                                     "baspi4Ref": "A1.4.2.3",
@@ -6355,6 +7105,9 @@
                                   "groundRentFrequency",
                                   "rentSubjectToIncrease"
                                 ],
+                                "ta7ed5Required": [
+                                  "mostRecentGroundRentDemandStatus"
+                                ],
                                 "baspi4Required": [
                                   "annualGroundRent",
                                   "rentSubjectToIncrease"
@@ -6376,6 +7129,7 @@
                           },
                           "ownershipAndManagement": {
                             "ta7Ref": "2",
+                            "ta7ed5Ref": "4",
                             "title": "Ownership and management",
                             "type": "object",
                             "ta7Required": [
@@ -6384,6 +7138,11 @@
                               "buildingManager",
                               "hasTenantCompanyDissolved",
                               "isManagingAgentEmployed"
+                            ],
+                            "ta7ed5Required": [
+                              "isManagingAgentEmployed",
+                              "sellerOwnership",
+                              "hasTenantCompanyDissolved"
                             ],
                             "properties": {
                               "freeholdOwner": {
@@ -6488,25 +7247,99 @@
                                   }
                                 ]
                               },
-                              "hasTenantCompanyDissolved": {
-                                "ta7Ref": "2.4",
-                                "title": "Has any tenants’ management company been dissolved or struck off the register at Companies House?",
-                                "type": "string",
-                                "enum": ["Yes", "No"]
-                              },
                               "isManagingAgentEmployed": {
                                 "ta7Ref": "2.5",
+                                "ta7ed5Ref": "4.1.1",
                                 "title": "Does the landlord, tenants’ management company or Right to Manage company employ a managing agent to collect rent or manage the building?",
+                                "ta7ed5Title": "Is a managing agent appointed to manage the building and collect service charges?",
                                 "type": "string",
-                                "enum": ["Yes", "No"]
+                                "enum": ["Yes", "No", "Not applicable"],
+                                "ta7ed5Enum": ["Yes", "No", "Not applicable"]
+                              },
+                              "sellerOwnership": {
+                                "ta7ed5Ref": "4.4",
+                                "title": "Seller Ownership Details",
+                                "type": "object",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "4.4.1",
+                                    "title": "Does the seller alone, or jointly with others, own the freehold, any headlease or a management company named in the lease?",
+                                    "type": "string",
+                                    "enum": ["Yes", "No", "Not known"]
+                                  }
+                                },
+                                "ta7ed5Required": ["yesNo"],
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": { "enum": ["No", "Not known"] }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": { "enum": ["Yes"] },
+                                      "attachments": {
+                                        "ta7ed5Ref": "4.4.2",
+                                        "title": "If yes, supply evidence of your ownership or share certificate for membership of the organisation that is responsible for the management of the building.",
+                                        "type": "string",
+                                        "enum": [
+                                          "Attached",
+                                          "To follow",
+                                          "Not available"
+                                        ]
+                                      }
+                                    },
+                                    "ta7ed5Required": ["attachments"]
+                                  }
+                                ]
+                              },
+                              "hasTenantCompanyDissolved": {
+                                "ta7Ref": "2.4",
+                                "ta7ed5Ref": "4.5.1",
+                                "title": "Has any tenants' management company been dissolved or struck off the register at Companies House?",
+                                "ta7ed5Title": "Are you aware of any company responsible for managing the building having been dissolved or struck off the register at Companies House?",
+                                "type": "string",
+                                "enum": ["Yes", "No", "Not applicable"],
+                                "ta7ed5Enum": ["Yes", "No", "Not applicable"]
                               }
-                            }
+                            },
+                            "discriminator": {
+                              "propertyName": "hasTenantCompanyDissolved"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": ["No", "Not applicable"]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": ["Yes"]
+                                  },
+                                  "hasTenantCompanyDissolvedDetails": {
+                                    "ta7ed5Ref": "4.5.2",
+                                    "title": "Please provide details",
+                                    "type": "string"
+                                  }
+                                },
+                                "ta7ed5Required": [
+                                  "hasTenantCompanyDissolvedDetails"
+                                ]
+                              }
+                            ]
                           },
                           "serviceCharge": {
                             "baspi4Ref": "A1.5.1",
                             "baspi5Ref": "A1.5.1",
                             "lpe1Ref": "4",
                             "ta7Ref": "5.4",
+                            "ta7ed5Ref": "2.2",
                             "ntsRef": "A3.5",
                             "nts2Ref": "A3.5",
                             "title": "Service Charge",
@@ -6525,11 +7358,15 @@
                               "sellerContributesToServiceCharge"
                             ],
                             "ta7Required": ["sellerContributesToServiceCharge"],
+                            "ta7ed5Required": [
+                              "sellerContributesToServiceCharge"
+                            ],
                             "properties": {
                               "sellerContributesToServiceCharge": {
                                 "baspi4Ref": "A1.5.1.1",
                                 "baspi5Ref": "A1.5.1.1",
                                 "ta7Ref": "5.4",
+                                "ta7ed5Ref": "5.3",
                                 "ntsRef": "A3.5.1",
                                 "nts2Ref": "A3.5.1",
                                 "title": "Does the seller contribute to the cost of maintaining the building (a service charge)?",
@@ -6562,10 +7399,21 @@
                                     "title": "Amount of current annual service charge (£)",
                                     "type": "number"
                                   },
+                                  "mostRecentServiceChargeDemandStatus": {
+                                    "ta7ed5Ref": "2.2b",
+                                    "title": "Please provide the most recent payment demands payable under the lease for service charge",
+                                    "type": "string",
+                                    "enum": [
+                                      "Attached",
+                                      "To follow",
+                                      "Not applicable"
+                                    ]
+                                  },
                                   "largeAdditionalExpense": {
                                     "baspi4Ref": "A1.5.2.1",
                                     "baspi5Ref": "A1.5.2.1",
                                     "ta7Ref": "5.5",
+                                    "ta7ed5Ref": "5.4",
                                     "title": "Does the seller know of any expense (e.g. the cost of redecoration of outside or communal areas not usually incurred annually) likely to be shown in the service charge accounts within the next three years?",
                                     "type": "object",
                                     "properties": {
@@ -6573,6 +7421,7 @@
                                         "baspi4Ref": "A1.5.2.2",
                                         "baspi5Ref": "A1.5.2.2",
                                         "ta7Ref": "5.5.1",
+                                        "ta7ed5Ref": "5.4.1",
                                         "type": "string",
                                         "title": "",
                                         "enum": ["Yes", "No"]
@@ -6580,6 +7429,7 @@
                                     },
                                     "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
+                                    "ta7ed5Required": ["yesNo"],
                                     "baspi4Required": ["yesNo"],
                                     "baspi5Required": ["yesNo"],
                                     "discriminator": {
@@ -6602,6 +7452,7 @@
                                             "baspi4Ref": "A1.5.2.3",
                                             "baspi5Ref": "A1.5.2.3",
                                             "ta7Ref": "5.5.2",
+                                            "ta7ed5Ref": "5.4.2",
                                             "title": "Details",
                                             "type": "string"
                                           }
@@ -6609,24 +7460,27 @@
                                         "lpe1Required": ["details"],
                                         "baspi4Required": ["details"],
                                         "baspi5Required": ["details"],
-                                        "ta7Required": ["details"]
+                                        "ta7Required": ["details"],
+                                        "ta7ed5Required": ["details"]
                                       }
                                     ]
                                   },
                                   "problemInServiceChargeLevel": {
                                     "ta7Ref": "5.6",
+                                    "ta7ed5Ref": "5.6",
                                     "title": "Does the seller know of any problems in the last three years regarding the level of service charges or with the management?",
                                     "type": "object",
                                     "properties": {
                                       "yesNo": {
                                         "ta7Ref": "5.6.1",
+                                        "ta7ed5Ref": "5.6.1",
                                         "type": "string",
                                         "title": "",
                                         "enum": ["Yes", "No"]
                                       }
                                     },
-                                    "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
+                                    "ta7ed5Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -6645,29 +7499,32 @@
                                           },
                                           "details": {
                                             "ta7Ref": "5.6.2",
+                                            "ta7ed5Ref": "5.6.2",
                                             "title": "Please give details:",
                                             "type": "string"
                                           }
                                         },
-                                        "lpe1Required": ["details"],
-                                        "ta7Required": ["details"]
+                                        "ta7Required": ["details"],
+                                        "ta7ed5Required": ["details"]
                                       }
                                     ]
                                   },
                                   "serviceChargeChallenged": {
                                     "ta7Ref": "5.7",
+                                    "ta7ed5Ref": "5.5",
                                     "title": "Has the seller challenged the service charge or any expense in the last three years?",
                                     "type": "object",
                                     "properties": {
                                       "yesNo": {
                                         "ta7Ref": "5.7.1",
+                                        "ta7ed5Ref": "5.5.1",
                                         "type": "string",
                                         "title": "",
                                         "enum": ["Yes", "No"]
                                       }
                                     },
-                                    "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
+                                    "ta7ed5Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
                                     },
@@ -6686,19 +7543,60 @@
                                           },
                                           "details": {
                                             "ta7Ref": "5.7.2",
+                                            "ta7ed5Ref": "5.5.2",
                                             "title": "Please give details",
                                             "type": "string"
                                           }
                                         },
-                                        "lpe1Required": ["details"]
+                                        "ta7Required": ["details"],
+                                        "ta7ed5Required": ["details"]
                                       }
                                     ]
                                   },
                                   "dangerousCladdingOrDefects": {
                                     "ta7Ref": "5.8",
+                                    "ta7ed5Ref": "11.1",
                                     "title": "Does the seller know of the existence or suspected existence in the building of dangerous cladding or any other defects that create a building safety risk?",
-                                    "type": "string",
-                                    "enum": ["Yes", "No"]
+                                    "ta7ed5Title": "Are you aware of the existence or suspected existence in the building of cladding or any defects that may create a building safety risk?",
+                                    "type": "object",
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7Ref": "5.8.1",
+                                        "ta7ed5Ref": "11.1.1",
+                                        "type": "string",
+                                        "title": "",
+                                        "enum": ["Yes", "No"]
+                                      }
+                                    },
+                                    "ta7Required": ["yesNo"],
+                                    "ta7ed5Required": ["yesNo"],
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": ["No"]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": ["Yes"]
+                                          },
+                                          "details": {
+                                            "ta7Ref": "5.8.2",
+                                            "ta7ed5Ref": "11.1.2",
+                                            "title": "Please give details:",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "ta7Required": ["details"],
+                                        "ta7ed5Required": ["details"]
+                                      }
+                                    ]
                                   },
                                   "difficultyInCollectingServiceCharge": {
                                     "ta7Ref": "5.9",
@@ -6712,7 +7610,6 @@
                                         "enum": ["Yes", "No"]
                                       }
                                     },
-                                    "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
@@ -6736,7 +7633,6 @@
                                             "type": "string"
                                           }
                                         },
-                                        "lpe1Required": ["details"],
                                         "ta7Required": ["details"]
                                       }
                                     ]
@@ -6753,7 +7649,6 @@
                                         "enum": ["Yes", "No"]
                                       }
                                     },
-                                    "lpe1Required": ["yesNo"],
                                     "ta7Required": ["yesNo"],
                                     "discriminator": {
                                       "propertyName": "yesNo"
@@ -6777,7 +7672,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "lpe1Required": ["details"]
+                                        "ta7Required": ["details"]
                                       }
                                     ]
                                   },
@@ -7020,17 +7915,20 @@
                                   "lastDecoratedPeriod": {
                                     "lpe1Ref": "4.7",
                                     "ta7Ref": "5",
+                                    "ta7ed5Ref": "5",
                                     "title": "Confirm the date when the Managed Areas were last decorated, internally and externally.",
                                     "ta7itle": "In what year was the building last decorated:",
                                     "type": "object",
                                     "properties": {
                                       "externally": {
                                         "ta7Ref": "5.2",
+                                        "ta7ed5Ref": "5.1",
                                         "title": "The outside of the building (if known)",
                                         "type": "object",
                                         "properties": {
                                           "year": {
                                             "ta7Ref": "5.2.1",
+                                            "ta7ed5Ref": "5.1.1",
                                             "title": "Year",
                                             "type": "integer"
                                           },
@@ -7048,12 +7946,14 @@
                                       },
                                       "internally": {
                                         "ta7Ref": "5.3",
+                                        "ta7ed5Ref": "5.2",
                                         "title": "Internally",
                                         "ta7Title": "The internal communal parts (if known)",
                                         "type": "object",
                                         "properties": {
                                           "year": {
                                             "ta7Ref": "5.3.1",
+                                            "ta7ed5Ref": "5.2.1",
                                             "title": "Year",
                                             "type": "integer"
                                           },
@@ -7337,11 +8237,6 @@
                                 "lpe1Required": [
                                   "annualServiceCharge",
                                   "largeAdditionalExpense",
-                                  "problemInServiceChargeLevel",
-                                  "serviceChargeChallenged",
-                                  "dangerousCladdingOrDefects",
-                                  "difficultyInCollectingServiceCharge",
-                                  "serviceChargeOwed",
                                   "propertiesContributingToMaintenanceOfManagedArea",
                                   "adHocExpenses",
                                   "serviceChargePaidUpToDate",
@@ -7363,6 +8258,14 @@
                                   "dangerousCladdingOrDefects",
                                   "difficultyInCollectingServiceCharge",
                                   "serviceChargeOwed",
+                                  "lastDecoratedPeriod"
+                                ],
+                                "ta7ed5Required": [
+                                  "mostRecentServiceChargeDemandStatus",
+                                  "largeAdditionalExpense",
+                                  "problemInServiceChargeLevel",
+                                  "serviceChargeChallenged",
+                                  "dangerousCladdingOrDefects",
                                   "lastDecoratedPeriod"
                                 ],
                                 "baspi4Required": [
@@ -7429,6 +8332,7 @@
                           },
                           "buildingsInsurance": {
                             "lpe1Ref": "5",
+                            "ta7ed5Ref": "2.2",
                             "title": "Buildings Insurance",
                             "type": "object",
                             "lpe1Required": [
@@ -7442,6 +8346,9 @@
                               "nonComplianceWithConditions",
                               "buildingsReinstatementCostAssessment",
                               "premiumIncludedInServiceCharge"
+                            ],
+                            "ta7ed5Required": [
+                              "mostRecentBuildingsInsuranceDemandStatus"
                             ],
                             "properties": {
                               "premiumsPaidUpToDate": {
@@ -7481,6 +8388,16 @@
                                     },
                                     "lpe1Required": ["details"]
                                   }
+                                ]
+                              },
+                              "mostRecentBuildingsInsuranceDemandStatus": {
+                                "ta7ed5Ref": "2.2c",
+                                "title": "Most recent buildings insurance payment demand",
+                                "type": "string",
+                                "enum": [
+                                  "Attached",
+                                  "To follow",
+                                  "Not applicable"
                                 ]
                               },
                               "lastDemandPeriod": {
@@ -7677,7 +8594,7 @@
                                               "assessmentsCarriedOut": {
                                                 "enum": [
                                                   "Fire risk assessment",
-                                                  "External Wall fire risk assessment",
+                                                  "External wall fire risk assessment",
                                                   "Both"
                                                 ]
                                               },
@@ -7890,6 +8807,7 @@
                           "disputes": {
                             "lpe1Ref": "6",
                             "ta7Ref": "8",
+                            "ta7ed5Ref": "10",
                             "title": "Disputes",
                             "ta7Ttle": "Complaints",
                             "type": "object",
@@ -7904,20 +8822,29 @@
                               "sellerReceivedComplaint",
                               "sellerSentComplaint"
                             ],
+                            "ta7ed5Required": [
+                              "sellerReceivedComplaint",
+                              "sellerSentComplaint"
+                            ],
                             "properties": {
                               "sellerReceivedComplaint": {
                                 "ta7Ref": "8.1",
+                                "ta7ed5Ref": "10.1",
                                 "title": "Has the seller received any complaint from the landlord, the management company or any neighbour about anything the seller has or has not done?",
+                                "ta7ed5Title": "Are you aware of any complaint received from the landlord, the management company or any neighbour about anything you have or have not done?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "8.1.1",
+                                    "ta7ed5Ref": "10.1.1",
                                     "type": "string",
                                     "title": "",
-                                    "enum": ["Yes", "No"]
+                                    "enum": ["Yes", "No", "Not known"],
+                                    "ta7Enum": ["Yes", "No"]
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "lpe1Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
@@ -7926,7 +8853,8 @@
                                   {
                                     "properties": {
                                       "yesNo": {
-                                        "enum": ["No"]
+                                        "enum": ["No", "Not known"],
+                                        "ta7Enum": ["No"]
                                       }
                                     }
                                   },
@@ -7937,30 +8865,37 @@
                                       },
                                       "details": {
                                         "ta7Ref": "8.1.2",
+                                        "ta7ed5Ref": "10.1.2",
                                         "title": "Please give details",
                                         "type": "string",
                                         "minLength": 1
                                       }
                                     },
                                     "lpe1Required": ["details"],
-                                    "ta7Required": ["details"]
+                                    "ta7Required": ["details"],
+                                    "ta7ed5Required": ["details"]
                                   }
                                 ]
                               },
                               "sellerSentComplaint": {
                                 "ta7Ref": "8.2",
+                                "ta7ed5Ref": "10.2",
                                 "title": "Has the seller complained or had cause to complain to or about the landlord, the management company, or any neighbour?",
+                                "ta7ed5Title": "Are you aware of any complaint made to or about the landlord, the management company, or any neighbour?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "8.2.1",
+                                    "ta7ed5Ref": "10.2.1",
                                     "type": "string",
                                     "title": "",
-                                    "enum": ["Yes", "No"]
+                                    "enum": ["Yes", "No", "Not known"],
+                                    "ta7Enum": ["Yes", "No"]
                                   }
                                 },
                                 "lpe1Required": ["yesNo"],
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -7968,7 +8903,8 @@
                                   {
                                     "properties": {
                                       "yesNo": {
-                                        "enum": ["No"]
+                                        "enum": ["No", "Not known"],
+                                        "ta7Enum": ["No"]
                                       }
                                     }
                                   },
@@ -7979,13 +8915,15 @@
                                       },
                                       "details": {
                                         "ta7Ref": "8.2.2",
+                                        "ta7ed5Ref": "10.2.2",
                                         "title": "Please give details",
                                         "type": "string",
                                         "minLength": 1
                                       }
                                     },
                                     "lpe1Required": ["details"],
-                                    "ta7Required": ["details"]
+                                    "ta7Required": ["details"],
+                                    "ta7ed5Required": ["details"]
                                   }
                                 ]
                               },
@@ -8083,6 +9021,7 @@
                           },
                           "buildingSafetyAct": {
                             "ta7Ref": "11",
+                            "ta7ed5Ref": "11",
                             "title": "Building safety",
                             "type": "object",
                             "ta7Required": [
@@ -8091,22 +9030,34 @@
                               "deedOfCertificateServed",
                               "landlordsCertificateServed"
                             ],
+                            "ta7ed5Required": [
+                              "isLeaseQualifying",
+                              "landlordNotifiedOfSale",
+                              "deedOfCertificateServed",
+                              "landlordsCertificateServed"
+                            ],
                             "properties": {
                               "isLeaseQualifying": {
                                 "ta7Ref": "11.2",
+                                "ta7ed5Ref": "11.3",
                                 "title": "Is the lease of the property a qualifying lease?",
+                                "ta7ed5Title": "Is the property within a relevant building (11 metres or more in height or at least 5 storeys and contains at least 2 dwellings) and is not leaseholder-owned?",
                                 "type": "string",
-                                "enum": ["Yes", "No"]
+                                "enum": ["Yes", "No", "Not known"],
+                                "ta7ed5Enum": ["Yes", "No", "Not known"]
                               },
                               "deedOfCertificateServed": {
                                 "lpe1Ref": "4.14",
                                 "ta7Ref": "11.3",
+                                "ta7ed5Ref": "11.4",
                                 "title": "Has a Leaseholder Deed of Certificate been served on the Landlord in relation to the property or remedial works required to the property?",
                                 "ta7Title": "Is there a Leaseholder Deed of Certificate for the property?",
+                                "ta7ed5Title": "Is there a leaseholder deed of certificate for the property?",
                                 "type": "object",
                                 "properties": {
                                   "yesNoNotApplicable": {
                                     "ta7Ref": "11.3.1",
+                                    "ta7ed5Ref": "11.4.1",
                                     "lpe1Ref": "4.14",
                                     "type": "string",
                                     "title": "",
@@ -8141,8 +9092,10 @@
                                       "attachments": {
                                         "lpe1Ref": "8.19",
                                         "ta7Ref": "11.3b",
+                                        "ta7ed5Ref": "11.4.2",
                                         "title": "Leaseholder Deed of Certificate.",
                                         "ta7Title": "Please supply a copy of the leaseholder deed of certificate and the accompanying evidence",
+                                        "ta7ed5Title": "Please supply a copy of the leaseholder deed of certificate and the accompanying evidence.",
                                         "type": "string",
                                         "enum": ["Attached", "To follow"]
                                       }
@@ -8154,33 +9107,43 @@
                                     "ta7Required": [
                                       "sellerCompletedDeedOfCertificate",
                                       "attachments"
-                                    ]
+                                    ],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ],
                                 "lpe1Required": ["yesNoNotApplicable"],
-                                "ta7Required": ["yesNoNotApplicable"]
+                                "ta7Required": ["yesNoNotApplicable"],
+                                "ta7ed5Required": ["yesNoNotApplicable"]
                               },
                               "landlordNotifiedOfSale": {
                                 "ta7Ref": "11.4",
+                                "ta7ed5Ref": "11.5",
                                 "title": "Has the freeholder / landlord been notified of the intention to sell?",
+                                "ta7ed5Title": "Has the landlord been notified of your intention to sell the property?",
                                 "type": "string",
-                                "enum": ["Yes", "No"]
+                                "enum": ["Yes", "No", "Not known"],
+                                "ta7ed5Enum": ["Yes", "No", "Not known"]
                               },
                               "landlordsCertificateServed": {
                                 "lpe1Ref": "4.14",
                                 "ta7Ref": "11.5",
+                                "ta7ed5Ref": "11.6",
                                 "title": "Has a Landlord's Certificate been served?",
                                 "ta7Title": "Has the seller received a Landlord’s Certificate and the accompanying evidence?",
+                                "ta7ed5Title": "Have you received a landlord’s certificate and the accompanying evidence?",
                                 "type": "object",
                                 "lpe1Required": ["yesNoNotApplicable"],
                                 "ta7Required": ["yesNoNotApplicable"],
+                                "ta7ed5Required": ["yesNoNotApplicable"],
                                 "properties": {
                                   "yesNoNotApplicable": {
                                     "ta7Ref": "11.5.1",
+                                    "ta7ed5Ref": "11.6.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No", "Not applicable"],
-                                    "ta7Enum": ["Yes", "No"]
+                                    "ta7Enum": ["Yes", "No"],
+                                    "ta7ed5Enum": ["Yes", "No"]
                                   }
                                 },
                                 "discriminator": {
@@ -8202,14 +9165,17 @@
                                       "attachments": {
                                         "lpe1Ref": "8.20",
                                         "ta7Ref": "11.5.2",
+                                        "ta7ed5Ref": "11.6.2",
                                         "title": "Landlord's Certificate.",
                                         "ta7Title": "Please supply a copy and the accompanying evidence.",
+                                        "ta7ed5Title": "Please supply a copy of the landlord’s certificate and the accompanying evidence.",
                                         "type": "string",
                                         "enum": ["Attached", "To follow"]
                                       }
                                     },
                                     "lpe1Required": ["attachments"],
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               }
@@ -8217,17 +9183,21 @@
                           },
                           "alterations": {
                             "ta7Ref": "9",
+                            "ta7ed5Ref": "9",
                             "title": "Alterations",
                             "type": "object",
                             "ta7Required": ["sellerAwareOfAlterations"],
+                            "ta7ed5Required": ["sellerAwareOfAlterations"],
                             "properties": {
                               "sellerAwareOfAlterations": {
                                 "ta7Ref": "9.1",
+                                "ta7ed5Ref": "9.1",
                                 "title": "Is the seller aware of any alterations having been made to the property since the lease was originally granted?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "9.1.1",
+                                    "ta7ed5Ref": "9.1.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
@@ -8235,6 +9205,7 @@
                                 },
                                 "lpe1Required": ["yesNo"],
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8253,17 +9224,20 @@
                                       },
                                       "details": {
                                         "ta7Ref": "9.2",
+                                        "ta7ed5Ref": "9.2",
                                         "title": "Please give details of these alterations",
                                         "type": "string",
                                         "minLength": 1
                                       },
                                       "landlordConsentObtained": {
                                         "ta7Ref": "9.3",
+                                        "ta7ed5Ref": "9.3",
                                         "title": "Was the landlord’s consent for the alterations obtained?",
                                         "type": "object",
                                         "properties": {
                                           "yesNo": {
                                             "ta7Ref": "9.3.1",
+                                            "ta7ed5Ref": "9.3.1",
                                             "type": "string",
                                             "title": "",
                                             "enum": [
@@ -8275,6 +9249,7 @@
                                           }
                                         },
                                         "ta7Required": ["yesNo"],
+                                        "ta7ed5Required": ["yesNo"],
                                         "discriminator": {
                                           "propertyName": "yesNo"
                                         },
@@ -8297,6 +9272,7 @@
                                               },
                                               "attachments": {
                                                 "ta7Ref": "9.3.2",
+                                                "ta7ed5Ref": "9.3.2",
                                                 "title": "Please supply a copy.",
                                                 "type": "string",
                                                 "enum": [
@@ -8305,13 +9281,18 @@
                                                 ]
                                               }
                                             },
-                                            "ta7Required": ["attachments"]
+                                            "ta7Required": ["attachments"],
+                                            "ta7ed5Required": ["attachments"]
                                           }
                                         ]
                                       }
                                     },
                                     "lpe1Required": ["details"],
                                     "ta7Required": [
+                                      "details",
+                                      "landlordConsentObtained"
+                                    ],
+                                    "ta7ed5Required": [
                                       "details",
                                       "landlordConsentObtained"
                                     ]
@@ -8323,10 +9304,16 @@
                           "enfranchisement": {
                             "lpe1Ref": "6",
                             "ta7Ref": "10",
+                            "ta7ed5Ref": "7",
                             "title": "Enfranchisement",
                             "type": "object",
                             "ta7Required": [
                               "sellerOwnedProperty",
+                              "sellerServedNoticeOnLandlord",
+                              "sellerAwareOfNoticeOfCollectivePurchase",
+                              "sellerAwareOfResponse"
+                            ],
+                            "ta7ed5Required": [
                               "sellerServedNoticeOnLandlord",
                               "sellerAwareOfNoticeOfCollectivePurchase",
                               "sellerAwareOfResponse"
@@ -8341,11 +9328,14 @@
                               },
                               "sellerServedNoticeOnLandlord": {
                                 "ta7Ref": "10.2",
+                                "ta7ed5Ref": "7.1",
                                 "title": "Has the seller served on the landlord a formal notice stating the seller’s wish to buy the freehold or be granted an extended lease?",
+                                "ta7ed5Title": "Have you served on the landlord a notice stating your wish to buy the freehold or be granted an extended lease?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "10.2.1",
+                                    "ta7ed5Ref": "7.1.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": [
@@ -8357,6 +9347,7 @@
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8379,22 +9370,27 @@
                                       },
                                       "attachments": {
                                         "ta7Ref": "10.2.2",
+                                        "ta7ed5Ref": "7.1.2",
                                         "title": "Please supply a copy.",
                                         "type": "string",
                                         "enum": ["Attached", "To follow"]
                                       }
                                     },
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               },
                               "sellerAwareOfNoticeOfCollectivePurchase": {
                                 "ta7Ref": "10.3",
+                                "ta7ed5Ref": "7.2",
                                 "title": "Is the seller aware of the service of any notice relating to the possible collective purchase of the freehold of the building or part of it by a group of tenants?",
+                                "ta7ed5Title": "Are you aware of the service of any notice relating to the possible collective purchase of the freehold of the building or part of it by a group of tenants?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "10.3.1",
+                                    "ta7ed5Ref": "7.2.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": [
@@ -8406,6 +9402,7 @@
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8428,22 +9425,26 @@
                                       },
                                       "attachments": {
                                         "ta7Ref": "10.3.2",
+                                        "ta7ed5Ref": "7.2.2",
                                         "title": "Please supply a copy.",
                                         "type": "string",
                                         "enum": ["Attached", "To follow"]
                                       }
                                     },
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               },
                               "sellerAwareOfResponse": {
                                 "ta7Ref": "10.4",
+                                "ta7ed5Ref": "7.3",
                                 "title": "Is the seller aware of any response to a notice disclosed in replies above?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "10.4.1",
+                                    "ta7ed5Ref": "7.3.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": [
@@ -8455,6 +9456,7 @@
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8477,12 +9479,14 @@
                                       },
                                       "attachments": {
                                         "ta7Ref": "10.4.2",
+                                        "ta7ed5Ref": "7.3.2",
                                         "title": "Please supply a copy.",
                                         "type": "string",
                                         "enum": ["Attached", "To follow"]
                                       }
                                     },
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               },
@@ -8705,6 +9709,7 @@
                           "requiredDocuments": {
                             "lpe1Ref": "8",
                             "ta7Ref": "3",
+                            "ta7ed5Ref": "6",
                             "title": "Required documents",
                             "ta7Title": "Relevant documents",
                             "type": "object",
@@ -8744,6 +9749,10 @@
                               "additionalRegulationsNotInLease",
                               "deedsOfVariation",
                               "managementCompanyDocuments"
+                            ],
+                            "ta7ed5Required": [
+                              "noticeOfSale",
+                              "noticeOfBuildingCondition"
                             ],
                             "properties": {
                               "lease": {
@@ -8837,17 +9846,21 @@
                               },
                               "noticeOfSale": {
                                 "ta7Ref": "6.1",
+                                "ta7ed5Ref": "6.1",
                                 "title": "Has the seller received a notice that the landlord wants to sell the building?",
+                                "ta7ed5Title": "Have you received a notice that the landlord wants to sell the building?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "6.1.1",
+                                    "ta7ed5Ref": "6.1.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8866,6 +9879,7 @@
                                       },
                                       "attachments": {
                                         "ta7Ref": "6.1.2",
+                                        "ta7ed5Ref": "6.1.2",
                                         "title": "Please supply a copy.",
                                         "type": "string",
                                         "enum": [
@@ -8875,23 +9889,28 @@
                                         ]
                                       }
                                     },
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               },
                               "noticeOfBuildingCondition": {
                                 "ta7Ref": "6.2",
+                                "ta7ed5Ref": "6.2",
                                 "title": "Has the seller received any other notice about the building, its use, its condition or its repair and maintenance?",
+                                "ta7ed5Title": "Have you received any other notice about the building, its use, its condition or its repair and maintenance?",
                                 "type": "object",
                                 "properties": {
                                   "yesNo": {
                                     "ta7Ref": "6.2.1",
+                                    "ta7ed5Ref": "6.2.1",
                                     "type": "string",
                                     "title": "",
                                     "enum": ["Yes", "No"]
                                   }
                                 },
                                 "ta7Required": ["yesNo"],
+                                "ta7ed5Required": ["yesNo"],
                                 "discriminator": {
                                   "propertyName": "yesNo"
                                 },
@@ -8910,6 +9929,7 @@
                                       },
                                       "attachments": {
                                         "ta7Ref": "6.2.2",
+                                        "ta7ed5Ref": "6.2.2",
                                         "title": "Please supply a copy.",
                                         "type": "string",
                                         "enum": [
@@ -8919,7 +9939,8 @@
                                         ]
                                       }
                                     },
-                                    "ta7Required": ["attachments"]
+                                    "ta7Required": ["attachments"],
+                                    "ta7ed5Required": ["attachments"]
                                   }
                                 ]
                               },
@@ -9064,7 +10085,7 @@
                               "managementCompanyDocuments": {
                                 "ta7Ref": "3.5",
                                 "lpe1Ref": "8.17",
-                                "title": "If a landlord is a company controlled by the tenants and/or if a tenants’ management company or Right to Manage company is managing the building, please supply a copy of:",
+                                "title": "If a landlord is a company controlled by the tenants and/or if a tenants' management company or Right to Manage company is managing the building, please supply a copy of:",
                                 "type": "object",
                                 "required": [
                                   "memorandumAndArticles",
@@ -9127,16 +10148,44 @@
                               }
                             }
                           },
+                          "additionalInformation": {
+                            "ta7ed5Ref": "12",
+                            "title": "Additional information about any of your answers",
+                            "description": "If there is any further information about any of your answers on this form, provide details below and/or supply additional documents.",
+                            "type": "object",
+                            "properties": {
+                              "details": {
+                                "ta7ed5Ref": "12.1",
+                                "title": "Details",
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "attachments": {
+                                "ta7ed5Ref": "12.2",
+                                "title": "Attachments",
+                                "type": "string",
+                                "enum": [
+                                  "Attached",
+                                  "To follow",
+                                  "Not applicable"
+                                ]
+                              }
+                            },
+                            "ta7ed5Required": ["attachments"]
+                          },
                           "confirmationOfAccuracy": {
                             "ta7Ref": "12",
+                            "ta7ed5Ref": "13",
                             "lpe1Ref": "9",
                             "title": "Confirmation of accuracy",
                             "type": "object",
                             "lpe1Required": ["confirmation", "capacity"],
                             "ta7Required": ["confirmation"],
+                            "ta7ed5Required": ["confirmation"],
                             "properties": {
                               "confirmation": {
                                 "ta7Ref": "12.1",
+                                "ta7ed5Ref": "13.1",
                                 "title": "Declaration",
                                 "description": "I/we confirm that I am the person authorised to provide the information which I have completed in it on behalf of those parties which I have selected from the list, and that a buyer may rely on the information which I have supplied without applying to any other party except where I have left a section blank because I do not have the authority to provide the information",
                                 "ta7Title": "I/we confirm that all information provided is accurate to the best of our knowledge and if we become aware of any change to/changes which alter the information supplied/provided prior to exchange of contracts for the sale of the property, I/we will update immediately notify the person marketing the property as well as my/our property lawyer",
@@ -9162,7 +10211,8 @@
                     "lpe1Required": ["leaseholdInformation"],
                     "baspi4Required": ["leaseholdInformation"],
                     "baspi5Required": ["leaseholdInformation"],
-                    "ta7Required": ["leaseholdInformation"]
+                    "ta7Required": ["leaseholdInformation"],
+                    "ta7ed5Required": ["leaseholdInformation"]
                   },
                   {
                     "properties": {
@@ -9198,6 +10248,9 @@
           "baspi5Ref": "A1.6",
           "rdsRef": "Services/Parking",
           "ta6Ref": "9",
+          "ta6ed6Ref": "10",
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.10",
+          "sef25Ref": "K1",
           "title": "Parking",
           "type": "object",
           "baspi4Required": [
@@ -9235,6 +10288,12 @@
             "electricVehicleChargingPoint"
           ],
           "ta6Required": ["parkingArrangements", "controlledParking"],
+          "ta6ed6Required": [
+            "parkingArrangements",
+            "controlledParking",
+            "electricVehicleChargingPoint"
+          ],
+          "sef25Required": ["droppedKerbAccess"],
           "properties": {
             "parkingArrangements": {
               "ntsRef": "B4.1",
@@ -9244,6 +10303,7 @@
               "baspi4Ref": "A1.6.0",
               "baspi5Ref": "A1.6.0",
               "ta6Ref": "9.1",
+              "ta6ed6Ref": "10.1",
               "piqRef": "A1.5",
               "type": "array",
               "title": "Parking arrangements",
@@ -9300,7 +10360,10 @@
               "baspi4Ref": "A1.6.0.2",
               "baspi5Ref": "A1.6.0.2",
               "ta6Ref": "9.2",
+              "ta6ed6Ref": "10.2",
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.10.2",
               "title": "Is the property in a controlled parking zone or within a local authority parking scheme?",
+              "ta6ed6Title": "Is a permit required for on-road parking?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -9311,6 +10374,10 @@
                   "baspi4Ref": "A1.6.0.2.1",
                   "baspi5Ref": "A1.6.0.2.1",
                   "ta6Ref": "9.2.1",
+                  "ta6ed6Ref": "10.2.1",
+                  "ta6ed6CompatRef": "TA6ED6-COMPAT.10.2.1",
+                  "ta6ed6Enum": ["Yes", "No"],
+                  "ta6ed6CompatEnum": ["Yes", "No"],
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not known"]
@@ -9323,6 +10390,9 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6CompatRequired": ["yesNo"],
+
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -9330,7 +10400,10 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No", "Not known"]
+                      "ta6ed6CompatRef": "TA6ED6-COMPAT.10.2.1.no",
+                      "enum": ["No", "Not known"],
+                      "ta6ed6Enum": ["No"],
+                      "ta6ed6CompatEnum": ["No"]
                     }
                   }
                 },
@@ -9340,12 +10413,24 @@
                       "enum": ["Yes"]
                     },
                     "annualCostOfPermit": {
-                      "baspi5Ref": "A1.6.0.2.2",
-                      "title": "Annual cost of permit (£)",
+                      "title": "Annual cost of permit (£) (deprecated, retained for backwards compatibility — use costOfPermit + costOfPermitFrequency)",
                       "type": "number"
+                    },
+                    "costOfPermit": {
+                      "baspi5Ref": "A1.6.0.2.2",
+                      "sef25Ref": "P1.1",
+                      "title": "Cost of permit (£)",
+                      "type": "number"
+                    },
+                    "costOfPermitFrequency": {
+                      "sef25Ref": "P1.2",
+                      "title": "Payment frequency",
+                      "type": "string",
+                      "enum": ["Per month", "Per year", "Not applicable"]
                     }
                   },
-                  "baspi5Required": ["annualCostOfPermit"]
+                  "baspi5Required": ["costOfPermit"],
+                  "sef25Required": ["costOfPermit", "costOfPermitFrequency"]
                 }
               ]
             },
@@ -9389,6 +10474,20 @@
                 }
               ]
             },
+            "droppedKerbAccess": {
+              "sef25Ref": "K1.1",
+              "title": "Is there a dropped kerb access to parking?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "K1.1.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              }
+            },
             "electricVehicleChargingPoint": {
               "ntsRef": "B4.4",
               "nts2Ref": "B4.4",
@@ -9396,6 +10495,7 @@
               "ntsl2Ref": "B4.4",
               "baspi4Ref": "A1.6.1",
               "baspi5Ref": "A1.6.1",
+              "ta6ed6Ref": "10.3",
               "title": "Is there an electric vehicle charging point belonging to the property?",
               "type": "object",
               "properties": {
@@ -9406,6 +10506,7 @@
                   "ntsl2Ref": "B4.4.1",
                   "baspi4Ref": "A1.6.1.1",
                   "baspi5Ref": "A1.6.1.1",
+                  "ta6ed6Ref": "10.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -9416,7 +10517,79 @@
               "ntsRequired": ["yesNo"],
               "nts2Required": ["yesNo"],
               "ntslRequired": ["yesNo"],
-              "ntsl2Required": ["yesNo"]
+              "ntsl2Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "chargerDetails": {
+                      "ta6ed6Ref": "10.3a",
+                      "title": "Specify the type of EV charger, connector and its location and provide building regulation approvals:",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "chargerDetailsAttachments": {
+                      "ta6ed6Ref": "10.3a1",
+                      "title": "Attachments",
+                      "type": "string",
+                      "enum": ["Attached", "To follow"]
+                    },
+                    "cableCrossesPavement": {
+                      "ta6ed6Ref": "10.3b",
+                      "title": "Does an EV charging cable have to cross the public pavement?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "10.3b1",
+                          "type": "string",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "10.3b2",
+                              "title": "Specify any relevant local authority licence or terms and conditions",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["chargerDetails", "cableCrossesPavement"]
+                }
+              ]
             },
             "locatedInUlez": {
               "baspi4Ref": "A1.6.2",
@@ -9445,6 +10618,7 @@
           "baspi4Ref": "A1.7",
           "baspi5Ref": "A1.7",
           "ta6Ref": "4.7",
+          "ta6ed6Ref": "5.7",
           "title": "Listing and Conservation",
           "type": "object",
           "ntsRequired": [
@@ -9482,6 +10656,12 @@
             "isConservationArea",
             "hasTreePreservationOrder"
           ],
+          "ta6ed6Required": [
+            "isListed",
+            "isConservationArea",
+            "hasTreePreservationOrder"
+          ],
+          "ta6ed6Title": "Listed buildings and conservation area",
           "properties": {
             "isListed": {
               "ntsRef": "C2.1.1",
@@ -9492,6 +10672,7 @@
               "baspi5Ref": "A1.7.1",
               "rdsRef": "Protections",
               "ta6Ref": "4.7a",
+              "ta6ed6Ref": "5.7",
               "piqRef": "A1.6.1",
               "title": "Is the property a listed building in England or Wales?",
               "type": "object",
@@ -9504,6 +10685,7 @@
                   "baspi4Ref": "A1.7.1.1",
                   "baspi5Ref": "A1.7.1.1",
                   "ta6Ref": "4.7a1",
+                  "ta6ed6Ref": "5.7.1",
                   "piqRef": "A1.6.1.1",
                   "type": "string",
                   "title": "",
@@ -9521,6 +10703,8 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Title": "Is the property (or any part of it) listed?",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -9544,7 +10728,6 @@
                       "ntsl2Ref": "C2.1.1.2",
                       "baspi4Ref": "A1.7.1.2",
                       "baspi5Ref": "A1.7.1.2",
-                      "ta6Ref": "4.7a2",
                       "title": "Please provide details of the listing",
                       "type": "string",
                       "minLength": 1
@@ -9552,7 +10735,7 @@
                     "attachments": {
                       "baspi4Ref": "A1.7.1.3",
                       "baspi5Ref": "A1.7.1.3",
-                      "ta6Ref": "4.7a3",
+                      "ta6Ref": "4.7a2",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
@@ -9564,7 +10747,7 @@
                   "ntsl2Required": ["details"],
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details", "attachments"]
+                  "ta6Required": ["attachments"]
                 }
               ]
             },
@@ -9577,6 +10760,7 @@
               "baspi5Ref": "A1.7.2",
               "rdsRef": "Protections",
               "ta6Ref": "4.7b",
+              "ta6ed6Ref": "5.8",
               "piqRef": "A1.6.2",
               "title": "Is the property in a designated conservation area?",
               "type": "object",
@@ -9590,6 +10774,7 @@
                   "baspi5Ref": "A1.7.2.1",
                   "piqRef": "A1.6.2.1",
                   "ta6Ref": "4.7b1",
+                  "ta6ed6Ref": "5.8.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not known"],
@@ -9606,6 +10791,8 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Title": "Is the property (or any part of it) in a conservation area?",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -9629,7 +10816,6 @@
                       "ntsl2Ref": "C2.1.2.2",
                       "baspi4Ref": "A1.7.2.2",
                       "baspi5Ref": "A1.7.2.2",
-                      "ta6Ref": "4.7b2",
                       "title": "Please provide details of the listing",
                       "type": "string",
                       "minLength": 1
@@ -9637,7 +10823,7 @@
                     "attachments": {
                       "baspi4Ref": "A1.7.2.3",
                       "baspi5Ref": "A1.7.2.3",
-                      "ta6Ref": "4.7b3",
+                      "ta6Ref": "4.7b2",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
@@ -9649,7 +10835,7 @@
                   "ntsl2Required": ["details"],
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details", "attachments"]
+                  "ta6Required": ["attachments"]
                 }
               ]
             },
@@ -9662,8 +10848,10 @@
               "baspi5Ref": "A1.7.3",
               "rdsRef": "Property/Flags",
               "ta6Ref": "4.8",
+              "ta6ed6Ref": "5.9",
               "piqRef": "A1.6.3",
               "title": "To your knowledge, does a tree preservation order apply to any trees within the boundaries of the property?",
+              "ta6ed6Title": "Are any trees on or overhanging the property subject to a tree preservation order (TPO)?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -9674,6 +10862,7 @@
                   "baspi4Ref": "A1.7.3.1",
                   "baspi5Ref": "A1.7.3.1",
                   "ta6Ref": "4.8.1",
+                  "ta6ed6Ref": "5.9.1",
                   "piqRef": "A1.6.3.1",
                   "type": "string",
                   "title": "",
@@ -9691,6 +10880,7 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -9715,14 +10905,17 @@
                       "baspi4Ref": "A1.7.3.2",
                       "baspi5Ref": "A1.7.3.2",
                       "rdsRef": "WorksAlterationsChanges",
+                      "ta6ed6Ref": "5.9a",
                       "ta6Ref": "4.8a",
                       "piqRef": "A1.6.4",
                       "title": "Has work been carried out to any trees which are protected by the order?",
+                      "ta6ed6Title": "Are you aware of any works carried out on those trees?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
                           "baspi4Ref": "A1.7.3.2.1",
                           "baspi5Ref": "A1.7.3.2.1",
+                          "ta6ed6Ref": "5.9a1",
                           "ta6Ref": "4.8a1",
                           "piqRef": "A1.6.4.1",
                           "type": "string",
@@ -9737,6 +10930,7 @@
                       "ntslRequired": ["yesNo"],
                       "ntsl2Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -9752,6 +10946,12 @@
                           "properties": {
                             "yesNo": {
                               "enum": ["Yes"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.9a2",
+                              "title": "Give details",
+                              "type": "string",
+                              "minLength": 1
                             },
                             "consentsObtained": {
                               "ntsRef": "C2.1.3.3",
@@ -9769,8 +10969,10 @@
                             "attachments": {
                               "baspi4Ref": "A1.7.3.4",
                               "baspi5Ref": "A1.7.3.4",
+                              "ta6ed6Ref": "5.9a3",
                               "ta6Ref": "4.8a3",
                               "title": "Provide any relevant documentation",
+                              "ta6ed6Title": "Provide a copy of the TPO along with any relevant documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
                             }
@@ -9781,14 +10983,16 @@
                           "ntsl2Required": ["consentsObtained"],
                           "baspi4Required": ["consentsObtained"],
                           "baspi5Required": ["consentsObtained"],
-                          "ta6Required": ["consentsObtained"]
+                          "ta6Required": ["consentsObtained"],
+                          "ta6ed6Required": ["details", "attachments"]
                         }
                       ]
                     }
                   },
                   "baspi4Required": ["workCarriedOut"],
                   "baspi5Required": ["workCarriedOut"],
-                  "ta6Required": ["workCarriedOut"]
+                  "ta6Required": ["workCarriedOut"],
+                  "ta6ed6Required": ["workCarriedOut"]
                 }
               ]
             }
@@ -9801,6 +11005,7 @@
           "nts2Ref": "A1.2",
           "ntslRef": "A1.2",
           "ntsl2Ref": "A1.2",
+          "ta7ed5Ref": "11",
           "title": "Type of Construction",
           "type": "object",
           "baspi4Required": [
@@ -9827,6 +11032,7 @@
             "loft",
             "sprayFoamInsulation"
           ],
+          "ta7ed5Required": ["buildingSafety"],
           "properties": {
             "isStandardForm": {
               "baspi4Ref": "A1.8.1",
@@ -9920,10 +11126,10 @@
               "baspi4Ref": "A1.8.2",
               "baspi5Ref": "A1.8.2",
               "ta7Ref": "11.1",
-              "title": "Are you aware of any building safety issues?",
-              "baspi4Title": "Are you aware of any remediation required to the property due to building safety?",
-              "baspi5Title": "Are you aware of any remediation required to the property due to building safety?",
+              "ta7ed5Ref": "11.2",
+              "title": "Are you aware of any remediation required to the property due to building safety?",
               "ta7Title": "Have any remediation works on the building been proposed or carried out?",
+              "ta7ed5Title": "Have any remediation works on the building been proposed or carried out?",
               "description": "For example issues related to unsafe cladding, integrity of building materials used in construction (e.g. asbestos), risk of collapse (e.g. damaged roofs or structural failures), at-risk wooden decking for external structures (including balconies), lack of emergency lighting where required or insufficient fire/smoke alarm systems",
               "type": "object",
               "properties": {
@@ -9935,10 +11141,12 @@
                   "baspi4Ref": "A1.8.2.1",
                   "baspi5Ref": "A1.8.2.1",
                   "ta7Ref": "11.1.1",
+                  "ta7ed5Ref": "11.2.1",
                   "type": "string",
                   "title": "",
-                  "enum": ["Yes", "No", "Not applicable"],
+                  "enum": ["Yes", "No", "Not applicable", "Not known"],
                   "ta7Enum": ["Yes", "No", "Not applicable"],
+                  "ta7ed5Enum": ["Yes", "No", "Not known"],
                   "baspi4Enum": ["Yes", "No"],
                   "baspi5Enum": ["Yes", "No"],
                   "ntsEnum": ["Yes", "No"],
@@ -9954,6 +11162,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta7Required": ["yesNo"],
+              "ta7ed5Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -9961,8 +11170,9 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No"],
-                      "ta7Enum": ["No", "Not applicable"]
+                      "enum": ["No", "Not applicable", "Not known"],
+                      "ta7Enum": ["No", "Not applicable"],
+                      "ta7ed5Enum": ["No", "Not known"]
                     }
                   }
                 },
@@ -9978,9 +11188,7 @@
                       "ntsl2Ref": "C1.2",
                       "baspi4Ref": "A1.8.2.2",
                       "baspi5Ref": "A1.8.2.2",
-                      "ta7Ref": "11.1.2",
                       "title": "What are the defects or hazards?",
-                      "ta7Title": "Please provide details of the remediation works proposed and evidence of any carried out.",
                       "type": "string",
                       "minLength": 1
                     },
@@ -9991,7 +11199,6 @@
                       "ntsl2Ref": "C1.3",
                       "baspi4Ref": "A1.8.2.2",
                       "baspi5Ref": "A1.8.2.2",
-                      "ta7Ref": "11.1.2",
                       "title": "What work has already been done?",
                       "type": "string",
                       "minLength": 1
@@ -10003,7 +11210,6 @@
                       "ntsl2Ref": "C1.4",
                       "baspi4Ref": "A1.8.2.2",
                       "baspi5Ref": "A1.8.2.2",
-                      "ta7Ref": "11.1.2",
                       "title": "What work is required to be done?",
                       "type": "string",
                       "minLength": 1
@@ -10015,7 +11221,6 @@
                       "ntsl2Ref": "C1.5",
                       "baspi4Ref": "A1.8.2.2",
                       "baspi5Ref": "A1.8.2.2",
-                      "ta7Ref": "11.1.2",
                       "title": "What will the potential cost be?",
                       "type": "string",
                       "minLength": 1
@@ -10027,7 +11232,6 @@
                       "ntsl2Ref": "C1.6",
                       "baspi4Ref": "A1.8.2.2",
                       "baspi5Ref": "A1.8.2.2",
-                      "ta7Ref": "11.1.2",
                       "title": "Will the work impact the ability to reside at the property?",
                       "type": "string",
                       "minLength": 1
@@ -10036,8 +11240,10 @@
                       "baspi4Ref": "A1.8.2.3",
                       "baspi5Ref": "A1.8.2.3",
                       "ta7Ref": "11.1.3",
+                      "ta7ed5Ref": "11.2.2",
                       "title": "Attachments",
-                      "description": "Please attach evidence in support of the above",
+                      "ta7Title": "Please attach details of the remediation works proposed and evidence of any carried out.",
+                      "ta7ed5Title": "Please provide details of the remediation works proposed and evidence of any carried out.",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
                     }
@@ -10064,7 +11270,9 @@
                     "workToBeDone",
                     "potentialCost",
                     "abilityToResideAtProperty"
-                  ]
+                  ],
+                  "ta7Required": ["attachments"],
+                  "ta7ed5Required": ["attachments"]
                 }
               ]
             },
@@ -10221,6 +11429,7 @@
           "baspi4Ref": "A1.8.3",
           "baspi5Ref": "A1.8.3",
           "ta6Ref": "7.6",
+          "ta6ed6Ref": "8",
           "ntsRef": "A4",
           "nts2Ref": "A4",
           "ntslRef": "A4",
@@ -10593,6 +11802,7 @@
             "greenDealLoan": {
               "baspi4Ref": "A7.3",
               "baspi5Ref": "A7.3",
+              "ta6ed6Ref": "8.5",
               "ta6Ref": "7.7",
               "piqRef": "A11.4",
               "rdsRef": "RightsHolders/Loans,RightsHolders/OtherDocumentation",
@@ -10601,10 +11811,12 @@
               "baspi4Required": ["hasGreenDealLoan"],
               "baspi5Required": ["hasGreenDealLoan"],
               "ta6Required": ["hasGreenDealLoan"],
+              "ta6ed6Required": ["hasGreenDealLoan"],
               "properties": {
                 "hasGreenDealLoan": {
                   "baspi4Ref": "A7.3",
                   "baspi5Ref": "A7.3",
+                  "ta6ed6Ref": "8.5.1",
                   "ta6Ref": "7.7.0",
                   "title": "Is this property subject to a Green Deal loan or other financed home improvement scheme?",
                   "type": "object",
@@ -10612,6 +11824,7 @@
                     "yesNo": {
                       "baspi4Ref": "A7.3.1",
                       "baspi5Ref": "A7.3.1",
+                      "ta6ed6Ref": "8.5.1a",
                       "ta6Ref": "7.7.1",
                       "piqRef": "A11.4.1",
                       "type": "string",
@@ -10622,6 +11835,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -10641,6 +11855,7 @@
                         "details": {
                           "baspi4Ref": "A7.3.2",
                           "baspi5Ref": "A7.3.2",
+                          "ta6ed6Ref": "8.5.1b",
                           "ta6Ref": "7.7.2",
                           "title": "Please provide details below including any outstanding payments for the renewable devices and any feed-in tariffs and a copy of your last electricity bill",
                           "type": "string",
@@ -10649,6 +11864,7 @@
                         "attachments": {
                           "baspi4Ref": "A7.3.3",
                           "baspi5Ref": "A7.3.3",
+                          "ta6ed6Ref": "8.5.1c",
                           "ta6Ref": "7.7.3",
                           "title": "Attachments",
                           "type": "string",
@@ -10657,7 +11873,8 @@
                       },
                       "baspi4Required": ["details", "attachments"],
                       "baspi5Required": ["details", "attachments"],
-                      "ta6Required": ["details", "attachments"]
+                      "ta6Required": ["details", "attachments"],
+                      "ta6ed6Required": ["details", "attachments"]
                     }
                   ]
                 }
@@ -10800,6 +12017,7 @@
           "baspi4Ref": "A2",
           "baspi5Ref": "A2",
           "ta6Ref": "2",
+          "ta6ed6Ref": "3",
           "title": "Disputes and Complaints",
           "type": "object",
           "baspi4Required": [
@@ -10814,23 +12032,31 @@
             "hasDisputesAndComplaints",
             "leadingToDisputesAndComplaints"
           ],
+          "ta6ed6Required": [
+            "hasDisputesAndComplaints",
+            "leadingToDisputesAndComplaints"
+          ],
           "properties": {
             "hasDisputesAndComplaints": {
               "baspi4Ref": "A2.1.1",
               "baspi5Ref": "A2.1.1",
               "rdsRef": "Tenure/DisputesComplaints,Tenure/LegalClaims",
               "ta6Ref": "2.1",
+              "ta6ed6Ref": "3.1",
               "piqRef": "A2.1",
               "title": "Have any disputes or complaints occurred, regarding this property, a property nearby, or their use?",
               "ta6Title": "Have there been any disputes or complaints regarding this property or a property nearby?",
+              "ta6ed6Title": "Are you aware of any disputes or complaints about the property or a property nearby?",
               "description": "E.g boundary disagreement, noise, trespass etc",
               "ta6Description": "",
+              "ta6ed6Description": "If yes, give details such as when this took place and who was involved:",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "A2.1.1.1",
                   "baspi5Ref": "A2.1.1.1",
                   "ta6Ref": "2.1.1",
+                  "ta6ed6Ref": "3.1.1",
                   "piqRef": "A2.1.1",
                   "type": "string",
                   "title": "",
@@ -10840,6 +12066,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -10860,6 +12087,7 @@
                       "baspi4Ref": "A2.1.1.2",
                       "baspi5Ref": "A2.1.1.2",
                       "ta6Ref": "2.1.2",
+                      "ta6ed6Ref": "3.1.2",
                       "piqRef": "A2.1.1.2",
                       "title": "Please give details",
                       "type": "string",
@@ -10868,7 +12096,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -10877,6 +12106,7 @@
               "baspi5Ref": "A2.1.2",
               "rdsRef": "Tenure/DisputesComplaints,Tenure/LegalClaims",
               "ta6Ref": "2.2",
+              "ta6ed6Ref": "3.2",
               "title": "Is the seller aware of anything which might lead to a dispute about the property or a property nearby?",
               "type": "object",
               "properties": {
@@ -10884,6 +12114,7 @@
                   "baspi4Ref": "A2.1.2.1",
                   "baspi5Ref": "A2.1.2.1",
                   "ta6Ref": "2.2.1",
+                  "ta6ed6Ref": "3.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -10892,6 +12123,9 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Title": "Are you aware of anything that might lead to a dispute about the property or a property nearby?",
+              "ta6ed6Description": "If yes, please give details:",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -10912,6 +12146,7 @@
                       "baspi4Ref": "A2.1.2.2",
                       "baspi5Ref": "A2.1.2.2",
                       "ta6Ref": "2.2.2",
+                      "ta6ed6Ref": "3.2.2",
                       "title": "Please give details",
                       "type": "string",
                       "minLength": 1
@@ -10919,7 +12154,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             }
@@ -10929,6 +12165,8 @@
           "baspi4Ref": "A3",
           "baspi5Ref": "A3",
           "ta6Ref": "4.1",
+          "ta6ed6Ref": "5",
+          "sef25Ref": "A1",
           "title": "Alterations and Changes to the Property",
           "description": "Have any of the following changes been made to the whole or any part of the property (including the garden)?",
           "type": "object",
@@ -10958,6 +12196,27 @@
             "worksUnfinished",
             "planningPermissionBreaches",
             "unresolvedPlanningIssues"
+          ],
+          "ta6ed6Required": [
+            "windowReplacementsSince2002",
+            "hasAddedConservatory",
+            "extension",
+            "loftConversion",
+            "garageConversion",
+            "removalOfInternalWalls",
+            "removalOfChimneyBreast",
+            "insulation",
+            "otherBuildingWorksOrChangesToTheProperty",
+            "nonResidentialPurposes",
+            "planningPermissionBreaches",
+            "unresolvedPlanningIssues"
+          ],
+          "sef25Required": [
+            "extension",
+            "loftConversion",
+            "garageConversion",
+            "removalOfInternalWalls",
+            "changeOfUse"
           ],
           "properties": {
             "hasStructuralAlterations": {
@@ -11268,6 +12527,7 @@
               "baspi5Ref": "A3.2",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1b",
+              "sef25Ref": "A1.5",
               "title": "Has there been any change of use (e.g. from an office to a residence)?",
               "type": "object",
               "properties": {
@@ -11275,6 +12535,7 @@
                   "baspi4Ref": "A3.2.1",
                   "baspi5Ref": "A3.2.1",
                   "ta6Ref": "4.1b1",
+                  "sef25Ref": "A1.5.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -11283,6 +12544,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11302,6 +12564,7 @@
                     "details": {
                       "baspi4Ref": "A3.2.2",
                       "baspi5Ref": "A3.2.2",
+                      "sef25Ref": "A1.5.2",
                       "title": "Please outline the nature of the work",
                       "type": "string",
                       "minLength": 1
@@ -11318,6 +12581,7 @@
                       "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "sef25Ref": "A1.5.4",
                       "title": "Was building regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
                       "properties": {
@@ -11325,6 +12589,7 @@
                           "baspi4Ref": "A3.5.1.1",
                           "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
+                          "sef25Ref": "A1.5.4.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11333,6 +12598,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11381,6 +12647,7 @@
                       "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "sef25Ref": "A1.5.3",
                       "title": "Was planning permission obtained?",
                       "type": "object",
                       "properties": {
@@ -11388,6 +12655,7 @@
                           "baspi4Ref": "A3.5.2.1",
                           "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
+                          "sef25Ref": "A1.5.3.1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11396,6 +12664,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11566,7 +12835,59 @@
                     "listedBuildingConsent",
                     "deedRestrictionConsent"
                   ],
-                  "ta6Required": ["yearCompleted"]
+                  "ta6Required": ["yearCompleted"],
+                  "sef25Required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ]
+            },
+            "nonResidentialPurposes": {
+              "ta6ed6Ref": "5.3",
+              "title": "Is any part of the property used exclusively for non-residential purposes?",
+              "description": "If yes, give details and supply a copy of any relevant planning permission:",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.3.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "ta6ed6Required": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.3.2",
+                      "title": "Please give details",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "attachments": {
+                      "ta6ed6Ref": "5.3.3",
+                      "title": "Please supply a copy of any relevant planning permission",
+                      "type": "string",
+                      "enum": ["Attached", "To follow"]
+                    }
+                  },
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -11575,6 +12896,7 @@
               "baspi5Ref": "A3.3",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1c",
+              "ta6ed6Ref": "5.1a",
               "piqRef": "A3.2",
               "title": "Since 1st April 2002 has replacement of any windows, roof windows, roof lights, glazed doors taken place?",
               "type": "object",
@@ -11583,6 +12905,7 @@
                   "baspi4Ref": "A3.3.1",
                   "baspi5Ref": "A3.3.1",
                   "ta6Ref": "4.1c1",
+                  "ta6ed6Ref": "5.1a",
                   "piqRef": "A3.2.1",
                   "type": "string",
                   "title": "",
@@ -11592,6 +12915,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11612,6 +12936,7 @@
                       "baspi4Ref": "A3.3.2",
                       "baspi5Ref": "A3.3.2",
                       "piqRef": "A3.2.2",
+                      "ta6ed6Ref": "5.1a(a)",
                       "title": "For each installation, please outline the nature of the work.",
                       "type": "string",
                       "minLength": 1
@@ -11621,6 +12946,7 @@
                       "baspi5Ref": "A3.3.3",
                       "piqRef": "A3.2.3",
                       "ta6Ref": "4.1c2",
+                      "ta6ed6Ref": "5.1a",
                       "title": "What year was the installation completed?",
                       "type": "integer"
                     },
@@ -11629,6 +12955,7 @@
                       "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "ta6ed6Ref": "5.1a(e)",
                       "title": "Was building regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
                       "properties": {
@@ -11636,6 +12963,7 @@
                           "baspi4Ref": "A3.5.1.1",
                           "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
+                          "ta6ed6Ref": "5.1a(e)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11644,6 +12972,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11657,6 +12986,7 @@
                               "baspi4Ref": "A3.5.1.3",
                               "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
+                              "ta6ed6Ref": "5.1a(e)",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
@@ -11664,7 +12994,8 @@
                           },
                           "baspi4Required": ["attachments"],
                           "baspi5Required": ["attachments"],
-                          "ta6Required": ["attachments"]
+                          "ta6Required": ["attachments"],
+                          "ta6ed6Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -11675,6 +13006,7 @@
                               "baspi4Ref": "A3.5.1.2",
                               "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
+                              "ta6ed6Ref": "5.1a(e)",
                               "title": "Please outline the reasons why",
                               "description": "e.g. the work was exempt from Building Regulations",
                               "type": "string",
@@ -11683,7 +13015,8 @@
                           },
                           "baspi4Required": ["details"],
                           "baspi5Required": ["details"],
-                          "ta6Required": ["details"]
+                          "ta6Required": ["details"],
+                          "ta6ed6Required": ["details"]
                         }
                       ]
                     },
@@ -11692,6 +13025,7 @@
                       "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "ta6ed6Ref": "5.1a(d)",
                       "title": "Was planning permission obtained?",
                       "type": "object",
                       "properties": {
@@ -11699,6 +13033,7 @@
                           "baspi4Ref": "A3.5.2.1",
                           "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
+                          "ta6ed6Ref": "5.1a(d)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11707,6 +13042,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11720,6 +13056,7 @@
                               "baspi4Ref": "A3.5.2.3",
                               "baspi5Ref": "A3.5.2.3",
                               "ta6Ref": "4.2a",
+                              "ta6ed6Ref": "5.1a(d)",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
@@ -11727,7 +13064,8 @@
                           },
                           "baspi4Required": ["attachments"],
                           "baspi5Required": ["attachments"],
-                          "ta6Required": ["attachments"]
+                          "ta6Required": ["attachments"],
+                          "ta6ed6Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -11738,6 +13076,7 @@
                               "baspi4Ref": "A3.5.2.2",
                               "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
+                              "ta6ed6Ref": "5.1a(d)",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
                               "type": "string",
@@ -11746,7 +13085,8 @@
                           },
                           "baspi4Required": ["details"],
                           "baspi5Required": ["details"],
-                          "ta6Required": ["details"]
+                          "ta6Required": ["details"],
+                          "ta6ed6Required": ["details"]
                         }
                       ]
                     },
@@ -11754,12 +13094,14 @@
                       "baspi4Ref": "A3.5.3",
                       "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
+                      "ta6ed6Ref": "5.1a(f)",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
                           "baspi4Ref": "A3.5.3.1",
                           "baspi5Ref": "A3.5.3.1",
+                          "ta6ed6Ref": "5.1a(f)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11767,6 +13109,7 @@
                       },
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11809,12 +13152,14 @@
                       "baspi4Ref": "A3.5.4",
                       "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
+                      "ta6ed6Ref": "5.1a(g)",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
                         "yesNo": {
                           "baspi4Ref": "A3.5.4.1",
                           "baspi5Ref": "A3.5.4.1",
+                          "ta6ed6Ref": "5.1a(g)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -11822,6 +13167,7 @@
                       },
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11859,6 +13205,52 @@
                           "baspi5Required": ["details"]
                         }
                       ]
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1a(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1a(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1a(c)",
+                      "title": "Supply copies of documents",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
                     }
                   },
                   "baspi4Required": [
@@ -11877,7 +13269,203 @@
                     "listedBuildingConsent",
                     "deedRestrictionConsent"
                   ],
-                  "ta6Required": ["yearCompleted"]
+                  "ta6Required": ["yearCompleted"],
+                  "ta6ed6Required": ["details"]
+                }
+              ]
+            },
+            "extension": {
+              "ta6ed6Ref": "5.1b",
+              "sef25Ref": "A1.1",
+              "title": "Extension",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1b",
+                  "sef25Ref": "A1.1.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1b(a)",
+                      "sef25Ref": "A1.1.2",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1b(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1b(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1b(d)",
+                      "sef25Ref": "A1.1.3",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(d)",
+                          "sef25Ref": "A1.1.3.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1b(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1b(e)",
+                      "sef25Ref": "A1.1.4",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(e)",
+                          "sef25Ref": "A1.1.4.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1b(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"],
+                  "sef25Required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
                 }
               ]
             },
@@ -11886,6 +13474,7 @@
               "baspi5Ref": "A3.4",
               "rdsRef": "WorksAlterationsChanges",
               "ta6Ref": "4.1d",
+              "ta6ed6Ref": "5.1c",
               "piqRef": "A3.4",
               "title": "Has a conservatory been added?",
               "type": "object",
@@ -11894,6 +13483,7 @@
                   "baspi4Ref": "A3.4.1",
                   "baspi5Ref": "A3.4.1",
                   "ta6Ref": "4.1d1",
+                  "ta6ed6Ref": "5.1c",
                   "piqRef": "A3.4.1",
                   "type": "string",
                   "title": "",
@@ -11903,6 +13493,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -11923,6 +13514,7 @@
                       "baspi4Ref": "A3.4.2",
                       "baspi5Ref": "A3.4.2",
                       "piqRef": "A3.4.2",
+                      "ta6ed6Ref": "5.1c(a)",
                       "title": "Confirm whether any walls were removed, an exterior quality door separates the conservatory from the main building and, since the conservatory was added, has any replacement or refurbishment of the roof been undertaken that reduces the glazed area of the roof?",
                       "type": "string",
                       "minLength": 1
@@ -11932,6 +13524,7 @@
                       "baspi5Ref": "A3.4.3",
                       "piqRef": "A3.4.3",
                       "ta6Ref": "4.1d2",
+                      "ta6ed6Ref": "5.1c",
                       "title": "What year was the installation completed?",
                       "type": "integer"
                     },
@@ -11940,6 +13533,7 @@
                       "baspi5Ref": "A3.5.1",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "ta6ed6Ref": "5.1c(e)",
                       "piqRef": "A3.5.1",
                       "title": "Was building regulation approval and a completion certificate obtained or an equivalent Competent Person Scheme Certificate?",
                       "type": "object",
@@ -11948,6 +13542,7 @@
                           "baspi4Ref": "A3.5.1.1",
                           "baspi5Ref": "A3.5.1.1",
                           "ta6Ref": "4.2.1",
+                          "ta6ed6Ref": "5.1c(e)",
                           "piqRef": "A3.5.1.1",
                           "type": "string",
                           "title": "",
@@ -11957,6 +13552,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -11970,6 +13566,7 @@
                               "baspi4Ref": "A3.5.1.3",
                               "baspi5Ref": "A3.5.1.3",
                               "ta6Ref": "4.2a",
+                              "ta6ed6Ref": "5.1c(e)",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
@@ -11977,7 +13574,8 @@
                           },
                           "baspi4Required": ["attachments"],
                           "baspi5Required": ["attachments"],
-                          "ta6Required": ["attachments"]
+                          "ta6Required": ["attachments"],
+                          "ta6ed6Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -11988,6 +13586,7 @@
                               "baspi4Ref": "A3.5.1.2",
                               "baspi5Ref": "A3.5.1.2",
                               "ta6Ref": "4.2b",
+                              "ta6ed6Ref": "5.1c(e)",
                               "piqRef": "A3.5.1.2",
                               "title": "Please outline the reasons why",
                               "description": "e.g. the work was exempt from Building Regulations",
@@ -11997,7 +13596,8 @@
                           },
                           "baspi4Required": ["details"],
                           "baspi5Required": ["details"],
-                          "ta6Required": ["details"]
+                          "ta6Required": ["details"],
+                          "ta6ed6Required": ["details"]
                         }
                       ]
                     },
@@ -12006,6 +13606,7 @@
                       "baspi5Ref": "A3.5.2",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "ta6Ref": "4.2",
+                      "ta6ed6Ref": "5.1c(d)",
                       "piqRef": "A3.5.2",
                       "title": "Was planning permission obtained?",
                       "type": "object",
@@ -12014,6 +13615,7 @@
                           "baspi4Ref": "A3.5.2.1",
                           "baspi5Ref": "A3.5.2.1",
                           "ta6Ref": "4.2.1",
+                          "ta6ed6Ref": "5.1c(d)",
                           "piqRef": "A3.5.2.1",
                           "type": "string",
                           "title": "",
@@ -12023,6 +13625,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -12036,6 +13639,7 @@
                               "baspi4Ref": "A3.5.2.3",
                               "baspi5Ref": "A3.5.2.3",
                               "ta6Ref": "4.2a",
+                              "ta6ed6Ref": "5.1c(d)",
                               "title": "Please provide a copy of the documents",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
@@ -12043,7 +13647,8 @@
                           },
                           "baspi4Required": ["attachments"],
                           "baspi5Required": ["attachments"],
-                          "ta6Required": ["attachments"]
+                          "ta6Required": ["attachments"],
+                          "ta6ed6Required": ["attachments"]
                         },
                         {
                           "properties": {
@@ -12054,6 +13659,7 @@
                               "baspi4Ref": "A3.5.2.2",
                               "baspi5Ref": "A3.5.2.2",
                               "ta6Ref": "4.2b",
+                              "ta6ed6Ref": "5.1c(d)",
                               "title": "Please outline the reasons why",
                               "description": "e.g. permitted development rights applied",
                               "type": "string",
@@ -12062,7 +13668,8 @@
                           },
                           "baspi4Required": ["details"],
                           "baspi5Required": ["details"],
-                          "ta6Required": ["details"]
+                          "ta6Required": ["details"],
+                          "ta6ed6Required": ["details"]
                         }
                       ]
                     },
@@ -12071,6 +13678,7 @@
                       "baspi5Ref": "A3.5.3",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "piqRef": "A3.5.3",
+                      "ta6ed6Ref": "5.1c(f)",
                       "title": "Was listed building consent obtained?",
                       "type": "object",
                       "properties": {
@@ -12078,6 +13686,7 @@
                           "baspi4Ref": "A3.5.3.1",
                           "baspi5Ref": "A3.5.3.1",
                           "piqRef": "A3.5.3.1",
+                          "ta6ed6Ref": "5.1c(f)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -12085,6 +13694,7 @@
                       },
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -12128,6 +13738,7 @@
                       "baspi5Ref": "A3.5.4",
                       "rdsRef": "WorksAlterationsChanges/ConsentApproval",
                       "piqRef": "A3.5.4",
+                      "ta6ed6Ref": "5.1c(g)",
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
                       "type": "object",
                       "properties": {
@@ -12135,6 +13746,7 @@
                           "baspi4Ref": "A3.5.4.1",
                           "baspi5Ref": "A3.5.4.1",
                           "piqRef": "A3.5.4.1",
+                          "ta6ed6Ref": "5.1c(g)",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No", "Not required"]
@@ -12142,6 +13754,7 @@
                       },
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -12180,6 +13793,52 @@
                           "baspi5Required": ["details"]
                         }
                       ]
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1c(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1c(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1c(c)",
+                      "title": "Supply copies of documents",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
                     }
                   },
                   "baspi4Required": [
@@ -12198,7 +13857,1133 @@
                     "listedBuildingConsent",
                     "deedRestrictionConsent"
                   ],
-                  "ta6Required": ["yearCompleted"]
+                  "ta6Required": ["yearCompleted"],
+                  "ta6ed6Required": ["details"]
+                }
+              ]
+            },
+            "loftConversion": {
+              "ta6ed6Ref": "5.1d",
+              "sef25Ref": "A1.2",
+              "title": "Loft conversion",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1d",
+                  "sef25Ref": "A1.2.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1d(a)",
+                      "sef25Ref": "A1.2.2",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1d(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1d(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1d(d)",
+                      "sef25Ref": "A1.2.3",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(d)",
+                          "sef25Ref": "A1.2.3.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1d(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1d(e)",
+                      "sef25Ref": "A1.2.4",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(e)",
+                          "sef25Ref": "A1.2.4.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1d(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"],
+                  "sef25Required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ]
+            },
+            "garageConversion": {
+              "ta6ed6Ref": "5.1e",
+              "sef25Ref": "A1.3",
+              "title": "Garage conversion",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1e",
+                  "sef25Ref": "A1.3.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1e(a)",
+                      "sef25Ref": "A1.3.2",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1e(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1e(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1e(d)",
+                      "sef25Ref": "A1.3.3",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(d)",
+                          "sef25Ref": "A1.3.3.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1e(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1e(e)",
+                      "sef25Ref": "A1.3.4",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(e)",
+                          "sef25Ref": "A1.3.4.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1e(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"],
+                  "sef25Required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ]
+            },
+            "removalOfInternalWalls": {
+              "ta6ed6Ref": "5.1f",
+              "sef25Ref": "A1.4",
+              "title": "Removal of internal walls",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1f",
+                  "sef25Ref": "A1.4.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1f(a)",
+                      "sef25Ref": "A1.4.2",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1f(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1f(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1f(d)",
+                      "sef25Ref": "A1.4.3",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(d)",
+                          "sef25Ref": "A1.4.3.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1f(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1f(e)",
+                      "sef25Ref": "A1.4.4",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "sef25Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(e)",
+                          "sef25Ref": "A1.4.4.1",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1f(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"],
+                  "sef25Required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ]
+            },
+            "removalOfChimneyBreast": {
+              "ta6ed6Ref": "5.1g",
+              "title": "Removal of chimney breast",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1g",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1g(a)",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1g(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1g(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1g(d)",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(d)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1g(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1g(e)",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(e)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1g(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"]
+                }
+              ]
+            },
+            "insulation": {
+              "ta6ed6Ref": "5.1h",
+              "title": "Insulation",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1h",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1h(a)",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1h(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1h(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1h(d)",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(d)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1h(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1h(e)",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(e)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1h(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"]
+                }
+              ]
+            },
+            "otherBuildingWorksOrChangesToTheProperty": {
+              "ta6ed6Ref": "5.1i",
+              "title": "Other building works or changes to the property",
+              "type": "object",
+              "ta6ed6Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1i",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1i(a)",
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1i(b)",
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(b)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(b)",
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1i(c)",
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1i(d)",
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(d)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1i(d)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(d)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1i(e)",
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(e)",
+                          "type": "string",
+                          "title": "",
+                          "enum": ["Yes", "No", "Not required"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1i(e)",
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not required"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(e)",
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -12268,6 +15053,7 @@
               "baspi5Ref": "A3.7",
               "rdsRef": "Property/Flags",
               "ta6Ref": "4.4",
+              "ta6ed6Ref": "5.4",
               "piqRef": "A3.7",
               "title": "Are you aware of any breaches of planning permission conditions or building regulations consent conditions or work not having the necessary consents?",
               "type": "object",
@@ -12276,6 +15062,7 @@
                   "baspi4Ref": "A3.7.1",
                   "baspi5Ref": "A3.7.1",
                   "ta6Ref": "4.4.1",
+                  "ta6ed6Ref": "5.4.1",
                   "piqRef": "A3.7.1",
                   "type": "string",
                   "title": "",
@@ -12284,6 +15071,8 @@
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
+              "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12304,6 +15093,7 @@
                       "baspi4Ref": "A3.7.2",
                       "baspi5Ref": "A3.7.2",
                       "ta6Ref": "4.4.2",
+                      "ta6ed6Ref": "5.4.2",
                       "piqRef": "A3.7.2",
                       "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
                       "title": "Please give details",
@@ -12336,15 +15126,16 @@
                     "attachments",
                     "willingToInsure"
                   ],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
-              ],
-              "ta6Required": ["yesNo"]
+              ]
             },
             "unresolvedPlanningIssues": {
               "baspi4Ref": "A3.8",
               "baspi5Ref": "A3.8",
               "ta6Ref": "4.5",
+              "ta6ed6Ref": "5.5",
               "piqRef": "A3.8",
               "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
               "title": "Are you aware of any unresolved planning or building control issues?",
@@ -12354,6 +15145,7 @@
                   "baspi4Ref": "A3.8.1",
                   "baspi5Ref": "A3.8.1",
                   "ta6Ref": "4.5.1",
+                  "ta6ed6Ref": "5.5.1",
                   "piqRef": "A3.8.1",
                   "type": "string",
                   "title": "",
@@ -12363,6 +15155,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12383,6 +15176,7 @@
                       "baspi4Ref": "A3.8.2",
                       "baspi5Ref": "A3.8.2",
                       "ta6Ref": "4.5.2",
+                      "ta6ed6Ref": "5.5.2",
                       "piqRef": "A3.8.2",
                       "rdsRef": "Buildings,BuildingsSections/StructureAuthorised,BuildingsSections/StructureUnauthorised",
                       "title": "Please give details",
@@ -12415,7 +15209,8 @@
                     "attachments",
                     "willingToInsure"
                   ],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             }
@@ -12425,10 +15220,12 @@
           "baspi4Ref": "A4",
           "baspi5Ref": "A4",
           "ta6Ref": "3",
+          "ta6ed6Ref": "4",
           "ntsRef": "C4",
           "nts2Ref": "C4",
           "ntslRef": "C4",
           "ntsl2Ref": "C4",
+          "sef25Ref": "N1",
           "title": "Notices which Affect the Property",
           "description": "Are you aware of, or have you received, any of the following notices?",
           "type": "object",
@@ -12459,6 +15256,12 @@
             "partyWallAct",
             "otherNotices"
           ],
+          "ta6ed6Required": [
+            "otherNotices",
+            "neighbourDevelopment",
+            "planningApplication"
+          ],
+          "ta6ed6Title": "Notices",
           "properties": {
             "neighbourDevelopment": {
               "baspi4Ref": "A4.1",
@@ -12468,8 +15271,10 @@
               "ntslRef": "C4.1",
               "ntsl2Ref": "C4.1",
               "ta6Ref": "3.2",
+              "ta6ed6Ref": "4.2",
               "rdsRef": "Property/Flags,Planning",
               "piqRef": "A4.1",
+              "sef25Ref": "N1.1",
               "title": "The owner of a neighbouring property is proposing to develop property or land nearby, make alterations to nearby buildings or change the use?",
               "ta6Title": "Is the seller aware of any proposals to develop property or land nearby, or of any proposals to make alterations to buildings nearby?",
               "type": "object",
@@ -12483,6 +15288,7 @@
                   "baspi5Ref": "A4.1.1",
                   "piqRef": "A4.1.1",
                   "ta6Ref": "3.2.1",
+                  "ta6ed6Ref": "4.2.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -12495,6 +15301,7 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12519,6 +15326,7 @@
                       "baspi4Ref": "A4.1.2",
                       "baspi5Ref": "A4.1.2",
                       "ta6Ref": "3.2.2",
+                      "ta6ed6Ref": "4.2.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
@@ -12534,6 +15342,7 @@
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"],
                   "ntsRequired": ["details"],
                   "nts2Required": ["details"],
                   "ntslRequired": ["details"],
@@ -12550,6 +15359,7 @@
               "baspi5Ref": "A4.2",
               "rdsRef": "Property/Flags,Planning",
               "ta6Ref": "3.1",
+              "ta6ed6Ref": "4.3",
               "piqRef": "A4.2",
               "title": "Any planning application that could affect the property, the enjoyment of it or the views from it?",
               "type": "object",
@@ -12563,6 +15373,7 @@
                   "baspi5Ref": "A4.2.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.2.1",
+                  "ta6ed6Ref": "4.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -12575,6 +15386,7 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12599,6 +15411,7 @@
                       "baspi4Ref": "A4.2.2",
                       "baspi5Ref": "A4.2.2",
                       "ta6Ref": "3.1.2",
+                      "ta6ed6Ref": "4.3.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
@@ -12614,6 +15427,7 @@
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
                   "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"],
                   "ntsRequired": ["details"],
                   "nts2Required": ["details"],
                   "ntslRequired": ["details"],
@@ -12806,6 +15620,7 @@
               "baspi5Ref": "A4.6",
               "rdsRef": "Property/Flags,Notifications",
               "ta6Ref": "1.6",
+              "ta6ed6Ref": "2.5",
               "title": "Notice under the Party Wall Act 1996 in respect of any shared or party boundaries?",
               "type": "object",
               "properties": {
@@ -12813,6 +15628,7 @@
                   "baspi4Ref": "A4.6.1",
                   "baspi5Ref": "A4.6.1",
                   "ta6Ref": "1.6.1",
+                  "ta6ed6Ref": "2.5.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -12821,6 +15637,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12841,6 +15658,7 @@
                       "baspi4Ref": "A4.6.2",
                       "baspi5Ref": "A4.6.2",
                       "ta6Ref": "1.6.2",
+                      "ta6ed6Ref": "2.5.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
@@ -12856,7 +15674,8 @@
                   },
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -12865,6 +15684,7 @@
               "baspi5Ref": "A4.7",
               "rdsRef": "Property/Flags,Notifications",
               "ta6Ref": "3.1",
+              "ta6ed6Ref": "4.1",
               "piqRef": "A4.6",
               "title": "Any other type of notice?",
               "type": "object",
@@ -12874,6 +15694,7 @@
                   "baspi5Ref": "A4.7.1",
                   "ta6Ref": "3.1.1",
                   "piqRef": "A4.6.1",
+                  "ta6ed6Ref": "4.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -12882,6 +15703,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -12902,6 +15724,7 @@
                       "baspi4Ref": "A4.7.2",
                       "baspi5Ref": "A4.7.2",
                       "ta6Ref": "3.1.2",
+                      "ta6ed6Ref": "4.1.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
@@ -12916,7 +15739,8 @@
                   },
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             }
@@ -12927,6 +15751,8 @@
           "baspi5Ref": "A5",
           "nts2Ref": "A5",
           "ntsl2Ref": "A5",
+          "ta6ed6Ref": "8.6",
+          "ta6Ref": "7.8",
           "title": "Specialist Issues",
           "type": "object",
           "baspi4Required": [
@@ -12944,6 +15770,7 @@
             "ongoingHealthOrSafetyIssue"
           ],
           "ta6Required": ["japaneseKnotweed"],
+          "ta6ed6Required": ["japaneseKnotweed"],
           "nts2Required": [
             "dryRotEtcTreatment",
             "containsAsbestos",
@@ -12957,6 +15784,12 @@
             "japaneseKnotweed",
             "subsidenceOrStructuralFault",
             "ongoingHealthOrSafetyIssue"
+          ],
+          "sef25Required": [
+            "wellsDitchesShaft",
+            "damagedOrExposedElectrics",
+            "damageToFlooringOrStaircases",
+            "knownAreasInPoorCondition"
           ],
           "properties": {
             "dryRotEtcTreatment": {
@@ -13012,8 +15845,6 @@
                     "attachments": {
                       "baspi4Ref": "A5.1.3",
                       "baspi5Ref": "A5.1.3",
-                      "nts2Ref": "A5.1.3",
-                      "ntsl2Ref": "A5.1.3",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
@@ -13097,21 +15928,63 @@
               "nts2Ref": "A5.3",
               "ntsl2Ref": "A5.3",
               "rdsRef": "Property/Flags,BuildingSections/EnvironmentalIssues,Use/EnvironmentalIssues",
+              "ta6ed6Ref": "8.6",
               "ta6Ref": "7.8",
               "piqRef": "A5.3",
-              "title": "To your knowledge, is the property or neighbouring land, affected by Japanese knotweed or other invasive species?",
-              "ta6Title": "Is the property affected by Japanese knotweed?",
+              "title": "Japanese Knotweed",
               "type": "object",
               "properties": {
+                "knotweedSurveyCarriedOut": {
+                  "ta6ed6Ref": "8.7",
+                  "title": "Has a Japanese knotweed survey been carried out in relation to the property?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "8.7.1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No", "Not known"]
+                    }
+                  },
+                  "ta6ed6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No", "Not known"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "8.7.2",
+                          "title": "Provide a copy of the survey.",
+                          "type": "string",
+                          "enum": ["Attached", "To follow"]
+                        }
+                      },
+                      "ta6ed6Required": ["attachments"]
+                    }
+                  ]
+                },
                 "yesNo": {
                   "baspi4Ref": "A5.3.1",
                   "baspi5Ref": "A5.3.1",
                   "nts2Ref": "A5.3.1",
                   "ntsl2Ref": "A5.3.1",
+                  "ta6ed6Ref": "8.6.1",
                   "ta6Ref": "7.8.1",
                   "piqRef": "A5.3.1",
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, is the property or neighbouring land, affected by Japanese knotweed or other invasive species?",
+                  "ta6Title": "Is the property affected by Japanese knotweed?",
                   "enum": ["Yes", "No", "Not known"],
                   "baspi4Enum": ["Yes", "No"],
                   "baspi5Enum": ["Yes", "No"]
@@ -13121,6 +15994,8 @@
               "baspi5Required": ["yesNo"],
               "nts2Required": ["yesNo"],
               "ntsl2Required": ["yesNo"],
+              "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo", "knotweedSurveyCarriedOut"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -13140,30 +16015,53 @@
                     "managementPlanInPlace": {
                       "baspi4Ref": "A5.3.2",
                       "baspi5Ref": "A5.3.2",
+                      "ta6ed6Ref": "8.6.2",
                       "ta6Ref": "7.8.2",
                       "nts2Ref": "A5.3.2",
                       "ntsl2Ref": "A5.3.2",
                       "title": "Is there a Japanese Knotweed management and treatment plan in place?",
                       "type": "string",
                       "enum": ["Yes", "No", "Not known"]
-                    },
-                    "attachments": {
-                      "baspi4Ref": "A5.3.3",
-                      "baspi5Ref": "A5.3.3",
-                      "ta6Ref": "7.8.3",
-                      "title": "Please supply a copy with any insurance cover linked to the plan.",
-                      "type": "string",
-                      "enum": ["Attached", "To follow"]
                     }
                   },
                   "baspi4Required": ["managementPlanInPlace"],
                   "baspi5Required": ["managementPlanInPlace"],
                   "nts2Required": ["managementPlanInPlace"],
                   "ntsl2Required": ["managementPlanInPlace"],
-                  "ta6Required": ["managementPlanInPlace", "attachments"]
+                  "ta6Required": ["managementPlanInPlace"],
+                  "ta6ed6Required": ["managementPlanInPlace"],
+                  "discriminator": {
+                    "propertyName": "managementPlanInPlace"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": ["No", "Not known"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": ["Yes"]
+                        },
+                        "attachments": {
+                          "baspi4Ref": "A5.3.3",
+                          "baspi5Ref": "A5.3.3",
+                          "ta6ed6Ref": "8.6.3",
+                          "ta6Ref": "7.8.3",
+                          "title": "Please supply a copy with any insurance cover linked to the plan.",
+                          "type": "string",
+                          "enum": ["Attached", "To follow"]
+                        }
+                      },
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
+                    }
+                  ]
                 }
-              ],
-              "ta6Required": ["yesNo"]
+              ]
             },
             "subsidenceOrStructuralFault": {
               "baspi4Ref": "A5.4",
@@ -13292,6 +16190,166 @@
                   "ntsl2Required": ["details"]
                 }
               ]
+            },
+            "wellsDitchesShaft": {
+              "sef25Ref": "H1.1",
+              "title": "Are there any wells, ditches, or shafts at the property?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.1.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "sef25Required": ["details"],
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.1.2",
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "damagedOrExposedElectrics": {
+              "sef25Ref": "H1.2",
+              "title": "Are there any damaged or exposed electrics at the property?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.2.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "sef25Required": ["details"],
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.2.2",
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "damageToFlooringOrStaircases": {
+              "sef25Ref": "H1.3",
+              "title": "Is there any damage to flooring and/or staircases?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.3.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "sef25Required": ["details"],
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.3.2",
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "knownAreasInPoorCondition": {
+              "sef25Ref": "H1.4",
+              "title": "Are there any known areas in poor condition (internal or external)?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.4.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "sef25Required": ["details"],
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.4.2",
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
             }
           }
         },
@@ -13300,7 +16358,7 @@
           "baspi5Ref": "A6",
           "ta10Ref": "0",
           "title": "Fixtures and Fittings",
-          "description": "This is so a buyer’s offer can take into account whether you are taking something of value or leaving extra items.  A full list will need to be completed after the sale is agreed.",
+          "description": "This is so a buyer's offer can take into account whether you are taking something of value or leaving extra items.  A full list will need to be completed after the sale is agreed.",
           "type": "object",
           "baspi4Required": ["itemsToRemove", "itemsToInclude"],
           "baspi5Required": ["itemsToRemove", "itemsToInclude"],
@@ -14988,13 +18046,6 @@
                             "ta10Required": ["fittedOrFreestanding"]
                           }
                         }
-                      },
-                      {
-                        "properties": {
-                          "isIncludedOrExcluded": {
-                            "enum": ["None"]
-                          }
-                        }
                       }
                     ]
                   }
@@ -15793,6 +18844,11 @@
                         "properties": {
                           "isIncludedOrExcluded": {
                             "enum": ["Included"]
+                          },
+                          "comments": {
+                            "ta10Ref": "4.8c",
+                            "title": "Comments",
+                            "type": "string"
                           }
                         }
                       },
@@ -15805,6 +18861,11 @@
                             "ta10Ref": "4.8b",
                             "title": "Price",
                             "type": "number"
+                          },
+                          "comments": {
+                            "ta10Ref": "4.8c",
+                            "title": "Comments",
+                            "type": "string"
                           }
                         }
                       }
@@ -16535,6 +19596,11 @@
                             "properties": {
                               "isIncludedOrExcluded": {
                                 "enum": ["Included"]
+                              },
+                              "comments": {
+                                "ta10Ref": "5.19c",
+                                "title": "Comments",
+                                "type": "string"
                               }
                             }
                           },
@@ -16547,6 +19613,11 @@
                                 "ta10Ref": "5.19b",
                                 "title": "Price",
                                 "type": "number"
+                              },
+                              "comments": {
+                                "ta10Ref": "5.19c",
+                                "title": "Comments",
+                                "type": "string"
                               }
                             }
                           }
@@ -18306,8 +21377,10 @@
           "ntslRef": "B3.1",
           "ntsl2Ref": "B3.1",
           "ta6Ref": "13.1",
+          "ta6ed6Ref": "12.1",
           "rdsRef": "Services/Electricity",
           "piqRef": "A7.1.1",
+          "sef25Ref": "S1",
           "title": "Electricity supply",
           "type": "object",
           "ntsRequired": [
@@ -18337,6 +21410,7 @@
           "baspi4Required": ["mainsElectricity", "solarPanels", "otherSources"],
           "baspi5Required": ["mainsElectricity", "solarPanels", "otherSources"],
           "ta6Required": ["mainsElectricity", "solarPanels"],
+          "ta6ed6Required": ["mainsElectricity"],
           "properties": {
             "mainsElectricity": {
               "baspi4Ref": "A7.1.0.1",
@@ -18346,6 +21420,7 @@
               "ntslRef": "B3.1",
               "ntsl2Ref": "B3.1",
               "ta6Ref": "13.1",
+              "ta6ed6Ref": "12.1",
               "rdsRef": "Services/Electricity",
               "piqRef": "A7.1.1",
               "title": "Mains electricity",
@@ -18359,6 +21434,7 @@
                   "baspi4Ref": "A7.1.0.1.1",
                   "baspi5Ref": "A7.1.0.1.1",
                   "ta6Ref": "13.1.1",
+                  "ta6ed6Ref": "12.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "To be connected", "No"],
@@ -18366,7 +21442,8 @@
                   "nts2Enum": ["Yes", "No"],
                   "ntslEnum": ["Yes", "No"],
                   "ntsl2Enum": ["Yes", "No"],
-                  "ta6Enum": ["Yes", "No"]
+                  "ta6Enum": ["Yes", "No"],
+                  "ta6ed6Enum": ["Yes", "No"]
                 }
               },
               "baspi4Required": ["yesNo"],
@@ -18376,6 +21453,7 @@
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -18396,6 +21474,7 @@
                       "baspi4Ref": "A7.1.0.1.2",
                       "baspi5Ref": "A7.1.0.1.2",
                       "ta6Ref": "13.1.2",
+                      "ta6ed6Ref": "12.1.2",
                       "piqRef": "A7.1.2",
                       "title": "Supplier",
                       "type": "string"
@@ -18404,10 +21483,12 @@
                       "baspi4Ref": "B4.4",
                       "baspi5Ref": "B4.4",
                       "ta6Ref": "13.1b",
+                      "ta6ed6Ref": "12.1.3",
                       "rdsRef": "Objects/class='meters|'&access=?&accessLocation=?",
                       "title": "Location of electricity meter",
                       "type": "object",
                       "ta6Required": ["location"],
+                      "ta6ed6Required": ["location", "mpan"],
                       "baspi4Required": ["location"],
                       "baspi5Required": ["location"],
                       "properties": {
@@ -18415,6 +21496,7 @@
                           "baspi4Ref": "4.4.1",
                           "baspi5Ref": "4.4.1",
                           "ta6Ref": "13.1b1",
+                          "ta6ed6Ref": "12.1.3",
                           "title": "Describe the location of the meter",
                           "type": "string",
                           "minLength": 1
@@ -18427,14 +21509,17 @@
                           "enum": ["Attached", "To follow"]
                         },
                         "mpan": {
+                          "ta6ed6Ref": "12.1.4",
                           "title": "Meter Point Administration Number (MPAN)",
-                          "description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked ‘Supply Number’. It’s 21 digits long and begins with ‘S’. You’ll only need the last 12 or 13 digits.",
-                          "type": "integer"
+                          "description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked 'Supply Number'. It's 21 digits long and begins with 'S'. You'll only need the last 12 or 13 digits.",
+                          "ta6ed6Description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked 'Supply Number'. It's 21 digits long and begins with 'S'. You'll only need the last 12 or 13 digits.",
+                          "type": "string"
                         }
                       }
                     }
                   },
                   "ta6Required": ["supplier", "electricityMeter"],
+                  "ta6ed6Required": ["supplier", "electricityMeter"],
                   "baspi4Required": ["electricityMeter"],
                   "baspi5Required": ["electricityMeter"]
                 },
@@ -18473,6 +21558,8 @@
               "baspi5Ref": "A7.1.0.8",
               "piqRef": "A7.1.17",
               "ta6Ref": "4.6",
+              "ta6ed6Ref": "5.6",
+              "sef25Ref": "S1",
               "title": "Solar or photovoltaic panels",
               "type": "object",
               "properties": {
@@ -18484,18 +21571,22 @@
                   "baspi4Ref": "A7.1.0.8.1",
                   "baspi5Ref": "A7.1.0.8.1",
                   "ta6Ref": "4.6",
+                  "ta6ed6Ref": "5.6",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "To be connected", "No"],
                   "ntsEnum": ["Yes", "No"],
                   "nts2Enum": ["Yes", "No"],
                   "ntslEnum": ["Yes", "No"],
-                  "ntsl2Enum": ["Yes", "No"]
+                  "ntsl2Enum": ["Yes", "No"],
+                  "ta6Enum": ["Yes", "No"],
+                  "ta6ed6Enum": ["Yes", "No"]
                 }
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "ntsRequired": ["yesNo"],
               "nts2Required": ["yesNo"],
               "ntslRequired": ["yesNo"],
@@ -18522,10 +21613,17 @@
                       "title": "Supplier",
                       "type": "string"
                     },
+                    "hotWaterOnly": {
+                      "ta6ed6Ref": "5.6a",
+                      "title": "Is the system used only to provide hot water or heating and not to generate electricity?",
+                      "type": "string",
+                      "enum": ["Yes", "No"]
+                    },
                     "yearInstalled": {
                       "baspi4Ref": "B4.3.1",
                       "baspi5Ref": "B4.3.1",
                       "ta6Ref": "4.6a",
+                      "ta6ed6Ref": "5.6b",
                       "rdsRef": "Objects/Installation",
                       "piqRef": "B4.4.2",
                       "title": "What year were they installed?",
@@ -18535,8 +21633,10 @@
                       "baspi4Ref": "B4.3.2",
                       "baspi5Ref": "B4.3.2",
                       "ta6Ref": "4.6b",
+                      "ta6ed6Ref": "5.6c",
                       "nts2Ref": "B3.7.1",
                       "ntsl2Ref": "B3.7.1",
+                      "sef25Ref": "S1.1",
                       "rdsRef": "Objects/Ownership",
                       "piqRef": "B4.4.3",
                       "title": "Do you own the panels, and all equipment related to them, outright?",
@@ -18548,6 +21648,7 @@
                           "nts2Ref": "B3.7.1.1",
                           "ntsl2Ref": "B3.7.1.1",
                           "ta6Ref": "4.6b1",
+                          "ta6ed6Ref": "5.6c",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
@@ -18556,6 +21657,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "nts2Required": ["yesNo"],
                       "ntsl2Required": ["yesNo"],
                       "discriminator": {
@@ -18587,6 +21689,39 @@
                               "title": "Attachments",
                               "type": "string",
                               "enum": ["Attached", "To follow"]
+                            },
+                            "associatedCost": {
+                              "sef25Ref": "S1.1",
+                              "title": "Associated costs of leased solar panels",
+                              "type": "object",
+                              "sef25Required": ["frequency"],
+                              "properties": {
+                                "frequency": {
+                                  "sef25Ref": "S1.1.2",
+                                  "title": "Payment frequency if costs are associated",
+                                  "type": "string",
+                                  "enum": ["Per month", "Per year", "Not applicable"]
+                                }
+                              },
+                              "discriminator": { "propertyName": "frequency" },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "frequency": { "enum": ["Not applicable"] }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "frequency": { "enum": ["Per month", "Per year"] },
+                                    "amount": {
+                                      "sef25Ref": "S1.1.1",
+                                      "title": "Associated costs of leased solar panels if any (£)",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": ["amount"]
+                                }
+                              ]
                             }
                           },
                           "baspi4Required": ["details", "attachments"],
@@ -18598,6 +21733,7 @@
                       "baspi4Ref": "B4.3.3",
                       "baspi5Ref": "B4.3.3",
                       "ta6Ref": "4.6c",
+                      "ta6ed6Ref": "5.6d",
                       "rdsRef": "Objects/Ownership",
                       "piqRef": "B4.4.4",
                       "title": "Is there an existing long lease of the roof/air space granted to a panel provider?",
@@ -18607,6 +21743,7 @@
                           "baspi4Ref": "4.3.3.1",
                           "baspi5Ref": "4.3.3.1",
                           "ta6Ref": "4.6c1",
+                          "ta6ed6Ref": "5.6d1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
@@ -18615,6 +21752,7 @@
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
                       "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
                       "discriminator": {
                         "propertyName": "yesNo"
                       },
@@ -18642,6 +21780,7 @@
                               "baspi4Ref": "4.3.3.3",
                               "baspi5Ref": "4.3.3.3",
                               "ta6Ref": "4.6c2",
+                              "ta6ed6Ref": "5.6d2",
                               "piqRef": "B4.4.5",
                               "title": "Please supply copies of the relevant documents",
                               "type": "string",
@@ -18708,14 +21847,6 @@
                         }
                       ]
                     },
-                    "isConnectedToNationalGrid": {
-                      "baspi4Ref": "B4.3.6",
-                      "baspi5Ref": "B4.3.6",
-                      "rdsRef": "Objects/isExternallyConnected=yes|no|true|false,Connection,Objects/ExternalConnection",
-                      "title": "Is the system connected to the National Grid e.g. for feed-in tariffs (FiT) or Smart Export Guarantee (SEG)",
-                      "type": "string",
-                      "enum": ["Yes (FiT)", "Yes (SEG)", "No"]
-                    },
                     "photovoltaicMeterPanelLocation": {
                       "baspi4Ref": "B4.7",
                       "baspi5Ref": "B4.7",
@@ -18739,28 +21870,204 @@
                         }
                       }
                     },
-                    "photovoltaicBatteriesLocation": {
+                    "maintenanceAgreement": {
+                      "ta6ed6Ref": "5.6e",
+                      "title": "Do you have a maintenance agreement in place for the system?",
+                      "type": "object",
+                      "ta6ed6Required": ["yesNo"],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6e1",
+                          "title": "",
+                          "type": "string",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.6e2",
+                              "title": "Supply a copy of the agreement.",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            }
+                          },
+                          "ta6ed6Required": ["attachments"]
+                        }
+                      ]
+                    },
+                    "photovoltaicBatteries": {
                       "baspi4Ref": "B4.8",
                       "baspi5Ref": "B4.8",
+                      "ta6ed6Ref": "5.6f",
                       "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
-                      "title": "Location of photovoltaic batteries (if any)",
+                      "title": "Photovoltaic batteries",
                       "type": "object",
                       "properties": {
-                        "description": {
-                          "baspi4Ref": "4.8.1",
-                          "baspi5Ref": "4.8.1",
-                          "title": "Describe the location of the batteries",
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6f",
+                          "title": "",
                           "type": "string",
-                          "minLength": 1
-                        },
-                        "attachments": {
-                          "baspi4Ref": "4.8.2",
-                          "baspi5Ref": "4.8.2",
-                          "title": "Photograph of batteries location",
-                          "type": "string",
-                          "enum": ["Attached", "To follow"]
+                          "enum": ["Yes", "No"]
                         }
-                      }
+                      },
+                      "required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "description": {
+                              "baspi4Ref": "4.8.1",
+                              "baspi5Ref": "4.8.1",
+                              "ta6ed6Ref": "5.6f1",
+                              "title": "Describe the location of the batteries",
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "attachments": {
+                              "baspi4Ref": "4.8.2",
+                              "baspi5Ref": "4.8.2",
+                              "title": "Photograph of batteries location",
+                              "type": "string",
+                              "enum": ["Attached", "To follow"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.6f2",
+                              "title": "Provide the make, model and storage capacity in kWh of the battery:",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "baspi4Required": ["description"],
+                          "baspi5Required": ["description"],
+                          "ta6ed6Required": ["description", "details"]
+                        }
+                      ]
+                    },
+                    "nationalGrid": {
+                      "baspi4Ref": "B4.3.6",
+                      "baspi5Ref": "B4.3.6",
+                      "ta6ed6Ref": "5.6g",
+                      "rdsRef": "Objects/isExternallyConnected=yes|no|true|false,Connection,Objects/ExternalConnection",
+                      "title": "Is the system connected to the National Grid?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "B4.3.6",
+                          "baspi5Ref": "B4.3.6",
+                          "ta6ed6Ref": "5.6g",
+                          "title": "",
+                          "type": "string",
+                          "enum": ["Yes", "No"]
+                        }
+                      },
+                      "baspi4Required": ["yesNo"],
+                      "baspi5Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"],
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "fitOrSegInPlace": {
+                              "ta6ed6Ref": "5.6g1",
+                              "title": "Is there a Feed-in Tariff (FIT) or Smart Export Guarantee (SEG) in place?",
+                              "type": "object",
+                              "ta6ed6Required": ["yesNo"],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "5.6g1a",
+                                  "title": "",
+                                  "type": "string",
+                                  "enum": ["Yes", "No"]
+                                }
+                              },
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": ["No"]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": ["Yes"]
+                                    },
+                                    "fitSegAgreementCopy": {
+                                      "ta6ed6Ref": "5.6g2",
+                                      "title": "Supply a copy of the agreement.",
+                                      "type": "string",
+                                      "enum": ["Attached", "To follow"]
+                                    },
+                                    "attachments": {
+                                      "ta6ed6Ref": "5.6g3",
+                                      "title": "Provide a copy of the electricity bill showing the credit paid for the generation.",
+                                      "type": "string",
+                                      "enum": ["Attached", "To follow"]
+                                    },
+                                    "fitSegAssignmentProcedure": {
+                                      "ta6ed6Ref": "5.6g4",
+                                      "title": "Provide details of the procedure for assigning the benefit of the FIT or SEG agreement on completion of the purchase to the buyer.",
+                                      "type": "string",
+                                      "enum": ["Attached", "To follow"]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": ["yesNo"]
+                    },
+                    "installationCertificates": {
+                      "ta6ed6Ref": "5.6h",
+                      "title": "Provide a copy of the building regulations completion certificate or compliance certificate (e.g. MCS) for the installation of the system.",
+                      "type": "string",
+                      "enum": ["Attached", "To follow", "Not available"]
                     }
                   },
                   "baspi4Required": [
@@ -18769,7 +22076,7 @@
                     "panelProviderLease",
                     "lastMaintained",
                     "inGoodWorkingOrder",
-                    "isConnectedToNationalGrid"
+                    "nationalGrid"
                   ],
                   "baspi5Required": [
                     "yearInstalled",
@@ -18777,12 +22084,22 @@
                     "panelProviderLease",
                     "lastMaintained",
                     "inGoodWorkingOrder",
-                    "isConnectedToNationalGrid"
+                    "nationalGrid"
                   ],
                   "ta6Required": [
                     "yearInstalled",
                     "panelsOwnedOutright",
                     "panelProviderLease"
+                  ],
+                  "ta6ed6Required": [
+                    "hotWaterOnly",
+                    "yearInstalled",
+                    "panelsOwnedOutright",
+                    "panelProviderLease",
+                    "maintenanceAgreement",
+                    "photovoltaicBatteries",
+                    "nationalGrid",
+                    "installationCertificates"
                   ]
                 },
                 {
@@ -18818,7 +22135,9 @@
               "baspi4Ref": "A7.1.0.9",
               "baspi5Ref": "A7.1.0.9",
               "piqRef": "A7.1.19",
+              "ta6ed6Ref": "12.6",
               "title": "Ground or air source heat pump",
+              "ta6ed6Title": "Shared ground / air source heat pumps",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -18828,13 +22147,15 @@
                   "ntsl2Ref": "B3.8.1",
                   "baspi4Ref": "A7.1.0.10.1",
                   "baspi5Ref": "A7.1.0.10.1",
+                  "ta6ed6Ref": "12.6.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "To be connected", "No"],
                   "ntsEnum": ["Yes", "No"],
                   "nts2Enum": ["Yes", "No"],
                   "ntslEnum": ["Yes", "No"],
-                  "ntsl2Enum": ["Yes", "No"]
+                  "ntsl2Enum": ["Yes", "No"],
+                  "ta6ed6Enum": ["Yes", "No"]
                 }
               },
               "baspi4Required": ["yesNo"],
@@ -18843,6 +22164,7 @@
               "nts2Required": ["yesNo"],
               "ntslRequired": ["yesNo"],
               "ntsl2Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -18870,7 +22192,9 @@
                     "supplier": {
                       "baspi4Ref": "A7.1.0.10.2",
                       "baspi5Ref": "A7.1.0.10.2",
+                      "ta6ed6Ref": "12.6.2",
                       "title": "Supplier",
+                      "ta6ed6Title": "Provider name",
                       "type": "string"
                     },
                     "dateInstalled": {
@@ -18886,6 +22210,16 @@
                       "title": "If after 2013 please provide Building Regulations approval / MCS Certificate or equivalent.",
                       "type": "string",
                       "enum": ["Attached", "To follow", "Not applicable"]
+                    },
+                    "makeModel": {
+                      "ta6ed6Ref": "12.6.3",
+                      "title": "Make/model",
+                      "type": "string"
+                    },
+                    "serviceProviderName": {
+                      "ta6ed6Ref": "12.6.4",
+                      "title": "Service provider name",
+                      "type": "string"
                     }
                   },
                   "baspi4Required": ["dateInstalled", "attachments"],
@@ -18893,7 +22227,12 @@
                   "ntsRequired": ["details"],
                   "nts2Required": ["details"],
                   "ntslRequired": ["details"],
-                  "ntsl2Required": ["details"]
+                  "ntsl2Required": ["details"],
+                  "ta6ed6Required": [
+                    "supplier",
+                    "makeModel",
+                    "serviceProviderName"
+                  ]
                 },
                 {
                   "properties": {
@@ -19046,6 +22385,7 @@
           "baspi4Ref": "A7.1.0",
           "baspi5Ref": "A7.1.0",
           "ta6Ref": "13",
+          "ta6ed6Ref": "11",
           "con29DWRef": "0",
           "title": "Water and Drainage",
           "description": "Please describe the water and drainage services that are connected to the property.",
@@ -19053,6 +22393,7 @@
           "baspi4Required": ["water", "drainage", "maintenanceAgreements"],
           "baspi5Required": ["water", "drainage", "maintenanceAgreements"],
           "ta6Required": ["water", "drainage"],
+          "ta6ed6Required": ["water", "drainage"],
           "ntsRequired": ["water", "drainage"],
           "nts2Required": ["water", "drainage"],
           "ntslRequired": ["water", "drainage"],
@@ -19090,6 +22431,7 @@
               "baspi4Ref": "A7.1.0.10",
               "baspi5Ref": "A7.1.0.10",
               "ta6Ref": "13",
+              "ta6ed6Ref": "12.3",
               "con29DWRef": "3",
               "title": "Water",
               "type": "object",
@@ -19100,6 +22442,7 @@
               "ntslRequired": ["mainsWater"],
               "ntsl2Required": ["mainsWater"],
               "ta6Required": ["mainsWater"],
+              "ta6ed6Required": ["mainsWater"],
               "con29DWRequired": [
                 "mainsWater",
                 "waterMainsWithinBoundaries",
@@ -19116,6 +22459,7 @@
                   "baspi4Ref": "A7.1.0.10.0",
                   "baspi5Ref": "A7.1.0.10.0",
                   "ta6Ref": "13.3",
+                  "ta6ed6Ref": "12.3",
                   "piqRef": "A7.1.7",
                   "rdsRef": "Services/PotableWaterSupply",
                   "con29DWRef": "3.1",
@@ -19130,11 +22474,13 @@
                       "baspi4Ref": "A7.1.0.10.1",
                       "baspi5Ref": "A7.1.0.10.1",
                       "ta6Ref": "13.3.1",
+                      "ta6ed6Ref": "12.3.1",
                       "con29DWRef": "3.1.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "To be connected", "No"],
                       "ta6Enum": ["Yes", "No"],
+                      "ta6ed6Enum": ["Yes", "No"],
                       "ntsEnum": ["Yes", "No"],
                       "nts2Enum": ["Yes", "No"],
                       "ntslEnum": ["Yes", "No"],
@@ -19149,6 +22495,7 @@
                   "ntslRequired": ["yesNo"],
                   "ntsl2Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "con29DWRequired": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -19168,12 +22515,46 @@
                           "description": "e.g. Private well, borehole, springs etc.",
                           "type": "string",
                           "minLength": 1
+                        },
+                        "associatedCost": {
+                          "sef25Ref": "U1.1",
+                          "title": "Please provide the associated costs for water supply",
+                          "type": "object",
+                          "sef25Required": ["frequency"],
+                          "properties": {
+                            "frequency": {
+                              "sef25Ref": "U1.1.2",
+                              "title": "Payment frequency if costs are associated",
+                              "type": "string",
+                              "enum": ["Per month", "Per year", "Not applicable"]
+                            }
+                          },
+                          "discriminator": { "propertyName": "frequency" },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": { "enum": ["Not applicable"] }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": { "enum": ["Per month", "Per year"] },
+                                "amount": {
+                                  "sef25Ref": "U1.1.1",
+                                  "title": "Associated costs of supply if any (£)",
+                                  "type": "number"
+                                }
+                              },
+                              "required": ["amount"]
+                            }
+                          ]
                         }
                       },
                       "ntsRequired": ["details"],
                       "nts2Required": ["details"],
                       "ntslRequired": ["details"],
-                      "ntsl2Required": ["details"]
+                      "ntsl2Required": ["details"],
+                      "sef25Required": ["associatedCost"]
                     },
                     {
                       "properties": {
@@ -19184,6 +22565,7 @@
                           "baspi4Ref": "A7.1.0.10.2",
                           "baspi5Ref": "A7.1.0.10.2",
                           "ta6Ref": "13.3.2",
+                          "ta6ed6Ref": "12.3.2",
                           "piqRef": "A7.1.8",
                           "title": "Supplier",
                           "type": "string",
@@ -19199,15 +22581,17 @@
                           "baspi4Ref": "B4.6.1",
                           "baspi5Ref": "B4.6.1",
                           "ta6Ref": "13.3b",
+                          "ta6ed6Ref": "12.3.3",
                           "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
+                          "ta6ed6Required": ["location"],
                           "title": "Location of stopcock",
                           "type": "object",
-                          "required": ["location"],
                           "properties": {
                             "location": {
                               "baspi4Ref": "4.6.1.1",
                               "baspi5Ref": "4.6.1.1",
                               "ta6Ref": "13.3b1",
+                              "ta6ed6Ref": "12.3.3",
                               "title": "Describe the location of the stopcock",
                               "type": "string",
                               "minLength": 1
@@ -19230,6 +22614,7 @@
                           "baspi4Ref": "A7.",
                           "baspi5Ref": "A7.",
                           "ta6Ref": "13.3b",
+                          "ta6ed6Ref": "12.3.4",
                           "ntsRequired": ["isSupplyMetered"],
                           "nts2Required": ["isSupplyMetered"],
                           "ntslRequired": ["isSupplyMetered"],
@@ -19237,6 +22622,7 @@
                           "baspi4Required": ["isSupplyMetered"],
                           "baspi5Required": ["isSupplyMetered"],
                           "ta6Required": ["isSupplyMetered"],
+                          "ta6ed6Required": ["isSupplyMetered"],
                           "con29DWRequired": ["isSupplyMetered"],
                           "properties": {
                             "isSupplyMetered": {
@@ -19245,6 +22631,7 @@
                               "ntslRef": "3.2.3",
                               "ntsl2Ref": "3.2.3",
                               "ta6Ref": "13.3b",
+                              "ta6ed6Ref": "12.3.4",
                               "baspi4Ref": "B4.6.2",
                               "baspi5Ref": "B4.6.2",
                               "title": "Is the supply metered?",
@@ -19272,6 +22659,7 @@
                                   "baspi4Ref": "4.6.2.1",
                                   "baspi5Ref": "4.6.2.1",
                                   "ta6Ref": "13.3b2",
+                                  "ta6ed6Ref": "12.3.4",
                                   "con29DWRef": "3.6",
                                   "title": "Describe the location of the meter",
                                   "type": "string",
@@ -19288,12 +22676,14 @@
                               "baspi4Required": ["location"],
                               "baspi5Required": ["location"],
                               "ta6Required": ["location"],
+                              "ta6ed6Required": ["location"],
                               "con29DWRequired": ["location"]
                             }
                           ]
                         }
                       },
                       "ta6Required": ["supplier", "stopcock", "waterMeter"],
+                      "ta6ed6Required": ["supplier", "stopcock", "waterMeter"],
                       "con29DWRequired": ["details", "waterMeter"],
                       "baspi4Required": ["stopcock", "waterMeter"],
                       "baspi5Required": ["stopcock", "waterMeter"],
@@ -19464,8 +22854,10 @@
               "baspi4Ref": "A7.1.0.12",
               "baspi5Ref": "A7.1.0.12",
               "ta6Ref": "12.4",
+              "ta6ed6Ref": "11.5",
               "con29DWRef": "2",
               "title": "Drainage",
+              "ta6ed6Title": "Drains and sewers",
               "type": "object",
               "baspi4Required": [
                 "mainsSurfaceWaterDrainage",
@@ -19489,6 +22881,10 @@
                 "mainsFoulDrainage"
               ],
               "ta6Required": ["mainsSurfaceWaterDrainage", "mainsFoulDrainage"],
+              "ta6ed6Required": [
+                "mainsFoulDrainage",
+                "mainsSurfaceWaterDrainage"
+              ],
               "con29DWRequired": [
                 "mainsSurfaceWaterDrainage",
                 "mainsFoulDrainage",
@@ -19512,6 +22908,7 @@
                   "baspi5Ref": "A7.1.0.12.0",
                   "rdsRef": "Services/StormWaterDrainage",
                   "ta6Ref": "12.4b",
+                  "ta6ed6Ref": "11.5b",
                   "con29DWRef": "2.2",
                   "title": "Mains surface water drainage",
                   "type": "object",
@@ -19524,6 +22921,7 @@
                       "ntslRef": "B3.3.1.1",
                       "ntsl2Ref": "B3.3.1.1",
                       "ta6Ref": "12.4b1",
+                      "ta6ed6Ref": "11.5b",
                       "con29DWRef": "2.2.1",
                       "type": "string",
                       "title": "",
@@ -19533,7 +22931,8 @@
                       "nts2Enum": ["Yes", "No"],
                       "ntslEnum": ["Yes", "No"],
                       "ntsl2Enum": ["Yes", "No"],
-                      "ta6Enum": ["Yes", "No", "Not known"]
+                      "ta6Enum": ["Yes", "No", "Not known"],
+                      "ta6ed6Enum": ["Yes", "No", "Not known"]
                     }
                   },
                   "baspi4Required": ["yesNo"],
@@ -19543,6 +22942,7 @@
                   "ntslRequired": ["yesNo"],
                   "ntsl2Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -19595,12 +22995,14 @@
                   "baspi5Ref": "A7.1.0.11",
                   "rdsRef": "Services/WasteWaterSewerageDisposal",
                   "ta6Ref": "12.4a",
+                  "ta6ed6Ref": "11.5a",
                   "con29DWRef": "2.1",
                   "title": "Mains foul drainage / sewerage",
                   "type": "object",
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "ntsRequired": ["yesNo"],
                   "nts2Required": ["yesNo"],
                   "ntslRequired": ["yesNo"],
@@ -19614,6 +23016,7 @@
                       "baspi4Ref": "A7.1.0.11.1",
                       "baspi5Ref": "A7.1.0.11.1",
                       "ta6Ref": "12.4a1",
+                      "ta6ed6Ref": "11.5a1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "To be connected", "No", "Not known"],
@@ -19622,7 +23025,8 @@
                       "nts2Enum": ["Yes", "No"],
                       "ntslEnum": ["Yes", "No"],
                       "ntsl2Enum": ["Yes", "No"],
-                      "ta6Enum": ["Yes", "No", "Not known"]
+                      "ta6Enum": ["Yes", "No", "Not known"],
+                      "ta6ed6Enum": ["Yes", "No", "Not known"]
                     }
                   },
                   "discriminator": {
@@ -19642,15 +23046,18 @@
                         },
                         "supplier": {
                           "ta6Ref": "13.4.2",
+                          "ta6ed6Ref": "12.4.2",
                           "baspi4Ref": "A7.1.0.11.2",
                           "baspi5Ref": "A7.1.0.11.2",
                           "title": "Supplier",
+                          "ta6ed6Title": "Provider's name",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "con29DWRequired": ["details"],
-                      "ta6Required": ["supplier"]
+                      "ta6Required": ["supplier"],
+                      "ta6ed6Required": ["supplier"]
                     },
                     {
                       "properties": {
@@ -19688,6 +23095,7 @@
                           "baspi4Ref": "A7.1.10.13",
                           "baspi5Ref": "A7.1.10.13",
                           "ta6Ref": "12.4a",
+                          "ta6ed6Ref": "11.6",
                           "type": "object",
                           "baspi4Required": [
                             "offMainsDrainageSystemType",
@@ -19712,6 +23120,13 @@
                             "otherConnectedProperties",
                             "plantOnOtherLand"
                           ],
+                          "ta6ed6Required": [
+                            "offMainsDrainageSystemType",
+                            "otherConnectedProperties",
+                            "plantOnOtherLand",
+                            "plantRegistered",
+                            "plantDrainsIntoWaterway"
+                          ],
                           "properties": {
                             "offMainsDrainageSystemType": {
                               "ntsRef": "B3.3.3.1",
@@ -19721,6 +23136,7 @@
                               "baspi4Ref": "A7.1",
                               "baspi5Ref": "A7.1",
                               "ta6Ref": "12.5",
+                              "ta6ed6Ref": "11.6",
                               "type": "string",
                               "enum": [
                                 "Sustainable Drainage System",
@@ -19729,6 +23145,12 @@
                                 "Sewerage treatment plant",
                                 "Other",
                                 "Not known"
+                              ],
+                              "ta6ed6Enum": [
+                                "Septic tank",
+                                "Cesspit",
+                                "Sewerage treatment plant",
+                                "Other"
                               ]
                             },
                             "otherConnectedProperties": {
@@ -19736,6 +23158,7 @@
                               "baspi5Ref": "A7.1.1",
                               "rdsRef": "Services/OtherServices/SharedWith",
                               "ta6Ref": "12.6",
+                              "ta6ed6Ref": "11.7h",
                               "piqRef": "A7.1.29",
                               "title": "Do other properties connect to the septic tank, cesspit or sewerage treatment plant?",
                               "type": "object",
@@ -19744,6 +23167,7 @@
                                   "baspi4Ref": "A7.1.1.1",
                                   "baspi5Ref": "A7.1.1.1",
                                   "ta6Ref": "12.6.1",
+                                  "ta6ed6Ref": "11.7h",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
@@ -19752,6 +23176,7 @@
                               "baspi4Required": ["yesNo"],
                               "baspi5Required": ["yesNo"],
                               "ta6Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -19778,7 +23203,9 @@
                                     "details": {
                                       "baspi4Ref": "A7.1.1.2",
                                       "baspi5Ref": "A7.1.1.2",
+                                      "ta6ed6Ref": "11.7h",
                                       "title": "Provide details of the properties sharing the system and explain how maintenance of the system is arranged and paid for",
+                                      "ta6ed6Title": "Give details about how many properties share the system, the arrangements for jointly managing it and how the costs are shared",
                                       "type": "string",
                                       "minLength": 1
                                     }
@@ -19791,7 +23218,8 @@
                                     "numberOfPropertiesSharing",
                                     "details"
                                   ],
-                                  "ta6Required": ["numberOfPropertiesSharing"]
+                                  "ta6Required": ["numberOfPropertiesSharing"],
+                                  "ta6ed6Required": ["details"]
                                 }
                               ]
                             },
@@ -19800,8 +23228,9 @@
                               "baspi5Ref": "A7.1.2",
                               "rdsRef": "Services/OtherServices/Located,Services/OtherServices/{access=?}",
                               "ta6Ref": "12.10",
+                              "ta6ed6Ref": "11.7i",
                               "piqRef": "A7.1.30",
-                              "title": "Is any part of the septic tank, cesspit or sewerage treatment plant located on someone else’s land?",
+                              "title": "Is any part of the septic tank, cesspit or sewerage treatment plant located on someone else's land?",
                               "ta6Title": "Is any part of the septic tank, sewage treatment plant (including any soakaway or outfall) or cesspool, or the access to it, outside the boundary of the property?",
                               "type": "object",
                               "properties": {
@@ -19809,6 +23238,7 @@
                                   "baspi4Ref": "7.1.2.1",
                                   "baspi5Ref": "7.1.2.1",
                                   "ta6Ref": "12.10.1",
+                                  "ta6ed6Ref": "11.7i",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
@@ -19836,6 +23266,7 @@
                                       "baspi4Ref": "7.1.2.2",
                                       "baspi5Ref": "7.1.2.2",
                                       "ta6Ref": "12.10.2",
+                                      "ta6ed6Ref": "11.7i",
                                       "title": "Please supply a plan showing the location of the system and how access is obtained.",
                                       "type": "string",
                                       "enum": ["Attached", "To follow"]
@@ -19843,22 +23274,26 @@
                                   },
                                   "baspi4Required": ["attachments"],
                                   "baspi5Required": ["attachments"],
-                                  "ta6Required": ["attachments"]
+                                  "ta6Required": ["attachments"],
+                                  "ta6ed6Required": ["attachments"]
                                 }
                               ],
-                              "ta6Required": ["yesNo"]
+                              "ta6Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"]
                             },
                             "plantRegistered": {
                               "baspi4Ref": "A7.1.3",
                               "baspi5Ref": "A7.1.3",
                               "rdsRef": "Services/OtherServices/Certificates",
                               "piqRef": "A7.1.31",
+                              "ta6ed6Ref": "11.7j",
                               "title": "Is the septic tank, cesspit or sewerage treatment plant registered with the Environment Agency or exempted?",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
                                   "baspi4Ref": "A7.1.3.1",
                                   "baspi5Ref": "A7.1.3.1",
+                                  "ta6ed6Ref": "11.7j",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
@@ -19866,6 +23301,7 @@
                               },
                               "baspi4Required": ["yesNo"],
                               "baspi5Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -19899,12 +23335,15 @@
                               "baspi4Ref": "A7.1.4",
                               "baspi5Ref": "A7.1.4",
                               "rdsRef": "Services/OtherServices/{isExternallyConnected='yes?true'}",
+                              "ta6ed6Ref": "11.7f",
                               "title": "Does the septic tank, cesspit or sewerage treatment plant drain into a waterway (lake, river, stream etc)",
+                              "ta6ed6Title": "Does the sewerage system discharge to the ground or to surface water?",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
                                   "baspi4Ref": "A7.1.4.1",
                                   "baspi5Ref": "A7.1.4.1",
+                                  "ta6ed6Ref": "11.7f",
                                   "type": "string",
                                   "title": "",
                                   "enum": [
@@ -19915,6 +23354,7 @@
                               },
                               "baspi4Required": ["yesNo"],
                               "baspi5Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -19925,6 +23365,20 @@
                                       "enum": [
                                         "No, the effluent is discharged through a soakaway system."
                                       ]
+                                    },
+                                    "hasInfiltrationSystem": {
+                                      "ta6ed6Ref": "11.7g",
+                                      "title": "Does the sewerage system have an infiltration system?",
+                                      "type": "object",
+                                      "ta6ed6Required": ["yesNo"],
+                                      "properties": {
+                                        "yesNo": {
+                                          "ta6ed6Ref": "11.7g",
+                                          "type": "string",
+                                          "title": "",
+                                          "enum": ["Yes", "No"]
+                                        }
+                                      }
                                     }
                                   }
                                 },
@@ -19966,11 +23420,32 @@
                                 "offMainsDrainageSystemType": {
                                   "enum": ["Septic tank"]
                                 },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a",
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "dateInstalled": {
+                                  "ta6ed6Ref": "11.7b",
+                                  "title": "When was the system installed?",
+                                  "type": "string",
+                                  "format": "date"
+                                },
                                 "dateReplaced": {
                                   "baspi4Ref": "A7.1.0.14.2",
                                   "baspi5Ref": "A7.1.0.14.2",
                                   "ta6Ref": "12.5.1",
-                                  "title": "Date replaced or upgraded",
+                                  "ta6ed6Ref": "11.7c",
+                                  "title": "When was the system last replaced or upgraded?",
                                   "type": "string",
                                   "format": "date"
                                 },
@@ -19978,6 +23453,7 @@
                                   "baspi4Ref": "A7.1.0.14.3",
                                   "baspi5Ref": "A7.1.0.14.3",
                                   "ta6Ref": "12.7",
+                                  "ta6ed6Ref": "11.7d",
                                   "piqRef": "A7.1.24",
                                   "title": "Date last emptied",
                                   "type": "string",
@@ -19992,17 +23468,52 @@
                                 "dateReplaced",
                                 "dateLastEmptied"
                               ],
-                              "ta6Required": ["dateReplaced", "dateLastEmptied"]
+                              "ta6Required": [
+                                "dateReplaced",
+                                "dateLastEmptied"
+                              ],
+                              "ta6ed6Required": [
+                                "dateDischargeCommenced",
+                                "dateInstalled",
+                                "dateLastEmptied"
+                              ]
                             },
                             {
                               "properties": {
                                 "offMainsDrainageSystemType": {
                                   "enum": ["Cesspit"]
                                 },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a",
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "dateInstalled": {
+                                  "ta6ed6Ref": "11.7b",
+                                  "title": "Date installed",
+                                  "type": "string",
+                                  "format": "date"
+                                },
+                                "dateReplaced": {
+                                  "ta6ed6Ref": "11.7c",
+                                  "title": "When was the system last replaced or upgraded?",
+                                  "type": "string",
+                                  "format": "date"
+                                },
                                 "dateLastEmptied": {
                                   "baspi4Ref": "A7.1.0.15.2",
                                   "baspi5Ref": "A7.1.0.15.2",
                                   "ta6Ref": "12.7",
+                                  "ta6ed6Ref": "11.7d",
                                   "piqRef": "A7.1.26",
                                   "title": "Date last emptied",
                                   "type": "string",
@@ -20011,18 +23522,59 @@
                               },
                               "baspi4Required": ["dateLastEmptied"],
                               "baspi5Required": ["dateLastEmptied"],
-                              "ta6Required": ["dateLastEmptied"]
+                              "ta6Required": ["dateLastEmptied"],
+                              "ta6ed6Required": [
+                                "dateDischargeCommenced",
+                                "dateLastEmptied",
+                                "dateInstalled"
+                              ]
                             },
                             {
                               "properties": {
                                 "offMainsDrainageSystemType": {
                                   "enum": ["Sewerage treatment plant"]
                                 },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a",
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "supplier": {
+                                  "ta6ed6Ref": "12.5.2",
+                                  "title": "Provider name",
+                                  "type": "string"
+                                },
+                                "makeModel": {
+                                  "ta6ed6Ref": "12.5.3",
+                                  "title": "Make/model",
+                                  "type": "string"
+                                },
+                                "serviceProviderName": {
+                                  "ta6ed6Ref": "12.5.4",
+                                  "title": "Service provider name",
+                                  "type": "string"
+                                },
                                 "dateInstalled": {
                                   "baspi4Ref": "A7.1.0.16.2",
                                   "baspi5Ref": "A7.1.0.16.2",
                                   "ta6Ref": "12.9",
-                                  "title": "Date installed",
+                                  "ta6ed6Ref": "11.7b",
+                                  "title": "When was the system installed",
+                                  "type": "string",
+                                  "format": "date"
+                                },
+                                "dateReplaced": {
+                                  "ta6ed6Ref": "11.7c",
+                                  "title": "When was the system last replaced or upgraded?",
                                   "type": "string",
                                   "format": "date"
                                 },
@@ -20030,7 +23582,8 @@
                                   "baspi4Ref": "A7.1.0.16.3",
                                   "baspi5Ref": "A7.1.0.16.3",
                                   "ta6Ref": "12.8",
-                                  "title": "Date last serviced",
+                                  "ta6ed6Ref": "11.7e",
+                                  "title": "When was the treatment plant last serviced",
                                   "type": "string",
                                   "format": "date"
                                 },
@@ -20059,6 +23612,14 @@
                               "ta6Required": [
                                 "dateInstalled",
                                 "dateLastServiced"
+                              ],
+                              "ta6ed6Required": [
+                                "dateDischargeCommenced",
+                                "dateInstalled",
+                                "dateLastServiced",
+                                "supplier",
+                                "makeModel",
+                                "serviceProviderName"
                               ]
                             },
                             {
@@ -20081,12 +23642,48 @@
                               "ntsl2Required": ["details"]
                             }
                           ]
+                        },
+                        "associatedCost": {
+                          "sef25Ref": "U1.2",
+                          "title": "Associated costs for sewerage",
+                          "type": "object",
+                          "sef25Required": ["frequency"],
+                          "properties": {
+                            "frequency": {
+                              "sef25Ref": "U1.2.2",
+                              "title": "Payment frequency if costs are associated",
+                              "type": "string",
+                              "enum": ["Per month", "Per year", "Not applicable"]
+                            }
+                          },
+                          "discriminator": { "propertyName": "frequency" },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": { "enum": ["Not applicable"] }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": { "enum": ["Per month", "Per year"] },
+                                "amount": {
+                                  "sef25Ref": "U1.2.1",
+                                  "title": "Associated costs for sewerage if any (£)",
+                                  "type": "number"
+                                }
+                              },
+                              "required": ["amount"]
+                            }
+                          ]
                         }
                       },
                       "ntsRequired": ["offMainsDrainageSystem"],
                       "nts2Required": ["offMainsDrainageSystem"],
                       "ntslRequired": ["offMainsDrainageSystem"],
-                      "ntsl2Required": ["offMainsDrainageSystem"]
+                      "ntsl2Required": ["offMainsDrainageSystem"],
+                      "ta6Required": ["offMainsDrainageSystem"],
+                      "ta6ed6Required": ["offMainsDrainageSystem"],
+                      "sef25Required": ["associatedCost"]
                     }
                   ]
                 },
@@ -20535,6 +24132,8 @@
           "baspi4Ref": "A7.4",
           "baspi5Ref": "A7.4",
           "ta6Ref": "12.3",
+          "ta6ed6Ref": "11.4",
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4",
           "rdsRef": "Buildings|BuildingSections/isUnheated=no|yes|true|false",
           "piqRef": "A7.3",
           "title": "Heating",
@@ -20542,6 +24141,11 @@
           "baspi4Required": ["heatingSystem"],
           "baspi5Required": ["heatingSystem"],
           "ta6Required": ["heatingSystem"],
+          "ta6ed6Required": [
+            "heatingSystem",
+            "otherHeatingFeatures",
+            "multipleHeatingSystems"
+          ],
           "ntsRequired": ["heatingSystem"],
           "nts2Required": ["heatingSystem"],
           "ntslRequired": ["heatingSystem"],
@@ -20555,12 +24159,14 @@
               "baspi4Ref": "A7.4.0",
               "baspi5Ref": "A7.4.0",
               "ta6Ref": "12.3.1",
+              "ta6ed6Ref": "11.4",
               "piqRef": "A7.3.1",
               "type": "object",
               "title": "Heating system",
               "baspi4Required": ["heatingType"],
               "baspi5Required": ["heatingType"],
               "ta6Required": ["heatingType"],
+              "ta6ed6Required": ["heatingType"],
               "ntsRequired": ["heatingType"],
               "nts2Required": ["heatingType"],
               "ntslRequired": ["heatingType"],
@@ -20574,6 +24180,7 @@
                   "baspi4Ref": "A7.4.0",
                   "baspi5Ref": "A7.4.0",
                   "ta6Ref": "12.3.1",
+                  "ta6ed6Ref": "11.4.1",
                   "piqRef": "A7.3.1",
                   "title": "What type of heating system does the property have?",
                   "type": "string",
@@ -20609,6 +24216,7 @@
                       "baspi4Ref": "A7.4.0.0",
                       "baspi5Ref": "A7.4.0.0",
                       "ta6Ref": "12.3.2",
+                      "ta6ed6Ref": "11.4.1",
                       "piqRef": "A7.3.1.1",
                       "type": "object",
                       "title": "Central Heating Details",
@@ -20646,6 +24254,15 @@
                         "heatingLastServicedReport",
                         "heatingInGoodWorkingOrder"
                       ],
+                      "ta6ed6Required": [
+                        "centralHeatingFuel",
+                        "centralHeatingInstalled",
+                        "boilerInstallationCertificate",
+                        "replacementOtherThanBoiler",
+                        "heatingLastServicedDate",
+                        "heatingLastServicedReport",
+                        "heatingInGoodWorkingOrder"
+                      ],
                       "properties": {
                         "centralHeatingFuel": {
                           "ntsRef": "B3.4.3.1",
@@ -20655,6 +24272,7 @@
                           "baspi4Ref": "A7.4.0.1",
                           "baspi5Ref": "A7.4.0.1",
                           "ta6Ref": "12.3.3",
+                          "ta6ed6Ref": "11.4.2",
                           "rdsRef": "Buildings|BuildingSections/Heating/isGas=no|yes|true|false",
                           "type": "object",
                           "title": "Central Heating Fuel",
@@ -20665,6 +24283,7 @@
                           "baspi4Required": ["centralHeatingFuelType"],
                           "baspi5Required": ["centralHeatingFuelType"],
                           "ta6Required": ["centralHeatingFuelType"],
+                          "ta6ed6Required": ["centralHeatingFuelType"],
                           "properties": {
                             "centralHeatingFuelType": {
                               "ntsRef": "B3.4.3.1.1",
@@ -20674,6 +24293,7 @@
                               "baspi4Ref": "A7.4.0.2",
                               "baspi5Ref": "A7.4.0.2",
                               "ta6Ref": "12.3a1",
+                              "ta6ed6Ref": "11.4.2.1",
                               "title": "What type of fuel does the system run on?",
                               "type": "string",
                               "enum": [
@@ -20699,6 +24319,8 @@
                                   "baspi4Ref": "A7.1.0",
                                   "baspi5Ref": "A7.1.0",
                                   "ta6Ref": "13.2b",
+                                  "ta6ed6Ref": "12.2.2",
+                                  "ta6ed6Title": "Provider",
                                   "title": "Supplier",
                                   "type": "string"
                                 },
@@ -20706,6 +24328,7 @@
                                   "baspi4Ref": "B4.5",
                                   "baspi5Ref": "B4.5",
                                   "ta6Ref": "13.2c",
+                                  "ta6ed6Ref": "12.2.3",
                                   "rdsRef": "Objects/class='meters'&access=?&accessLocation=?",
                                   "title": "Location of gas meter",
                                   "type": "object",
@@ -20714,6 +24337,7 @@
                                       "baspi4Ref": "4.5.1",
                                       "baspi5Ref": "4.5.1",
                                       "ta6Ref": "13.2c1",
+                                      "ta6ed6Ref": "12.2.3",
                                       "title": "Describe the location of the meter",
                                       "type": "string",
                                       "minLength": 1
@@ -20726,19 +24350,22 @@
                                       "enum": ["Attached", "To follow"]
                                     },
                                     "mprn": {
+                                      "ta6ed6Ref": "12.2.4",
                                       "title": "Meter Point Reference Number (MPRN)",
-                                      "description": "You can find your property’s MPRN on your gas or dual fuel bill. It’s usually marked ‘Meter Point Reference Number’ and is between six and 10 digits long.",
-                                      "type": "integer"
+                                      "description": "You can find your property's MPRN on your gas or dual fuel bill. It's usually marked 'Meter Point Reference Number' and is between six and 10 digits long.",
+                                      "type": "string"
                                     }
                                   },
                                   "baspi4Required": ["location"],
                                   "baspi5Required": ["location"],
-                                  "ta6Required": ["location"]
+                                  "ta6Required": ["location"],
+                                  "ta6ed6Required": ["location", "mprn"]
                                 }
                               },
                               "baspi4Required": ["supplier", "gasMeter"],
                               "baspi5Required": ["supplier", "gasMeter"],
-                              "ta6Required": ["supplier", "gasMeter"]
+                              "ta6Required": ["supplier", "gasMeter"],
+                              "ta6ed6Required": ["supplier", "gasMeter"]
                             },
                             {
                               "properties": {
@@ -20769,6 +24396,7 @@
                                   "baspi4Ref": "A7.4.0.3",
                                   "baspi5Ref": "A7.4.0.3",
                                   "ta6Ref": "12.3a2",
+                                  "ta6ed6Ref": "11.4.2.2",
                                   "title": "Please describe the other fuel type",
                                   "type": "string",
                                   "minLength": 1
@@ -20776,7 +24404,8 @@
                               },
                               "baspi4Required": ["otherCentralHeatingFuelType"],
                               "baspi5Required": ["otherCentralHeatingFuelType"],
-                              "ta6Required": ["otherCentralHeatingFuelType"]
+                              "ta6Required": ["otherCentralHeatingFuelType"],
+                              "ta6ed6Required": ["otherCentralHeatingFuelType"]
                             }
                           ]
                         },
@@ -20787,6 +24416,7 @@
                           "ntsl2Ref": "B3.4.3.2",
                           "rdsRef": "Objects/Installed",
                           "ta6Ref": "12.3b1",
+                          "ta6ed6Ref": "11.4a",
                           "piqRef": "A7.4.1",
                           "title": "When was the heating system installed?",
                           "type": "string",
@@ -20804,13 +24434,16 @@
                           "baspi5Ref": "A7.4.1.1",
                           "rdsRef": "Objects/Installation,Objects/Certificates",
                           "ta6Ref": "12.3b2",
+                          "ta6ed6Ref": "11.4b",
                           "title": "Was a gas boiler installed after 1st April 2005, or a solid fuel or oil boiler installed after 1st October 2010?",
+                          "ta6ed6Title": "Is a boiler (of any kind) installed?",
                           "type": "object",
                           "properties": {
                             "yesNo": {
                               "baspi4Ref": "A10.1.1",
                               "baspi5Ref": "A10.1.1",
                               "ta6Ref": "12.3b3",
+                              "ta6ed6Ref": "11.4b1",
                               "type": "string",
                               "title": "",
                               "enum": ["Yes", "No"]
@@ -20819,6 +24452,7 @@
                           "baspi4Required": ["yesNo"],
                           "baspi5Required": ["yesNo"],
                           "ta6Required": ["yesNo"],
+                          "ta6ed6Required": ["yesNo"],
                           "discriminator": {
                             "propertyName": "yesNo"
                           },
@@ -20835,18 +24469,77 @@
                                 "yesNo": {
                                   "enum": ["Yes"]
                                 },
+                                "boilerInstallationDate": {
+                                  "ta6ed6Ref": "11.4b2",
+                                  "title": "When was the boiler installed?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
                                 "attachments": {
                                   "baspi4Ref": "A7.4.1.2",
                                   "baspi5Ref": "A7.4.1.2",
                                   "ta6Ref": "12.3b4",
+                                  "ta6ed6Ref": "11.4d1",
                                   "title": "Please supply a copy of the installation completion certificate from a competent person qualified under the relevant self-certification scheme e.g. HETAS etc",
+                                  "ta6ed6Title": "Supply compliance certificates or documentation for the installation (such as a building regulation completion certificate).",
                                   "type": "string",
-                                  "enum": ["Attached", "To follow"]
+                                  "enum": ["Attached", "To follow", "None"]
                                 }
                               },
                               "baspi4Required": ["attachments"],
                               "baspi5Required": ["attachments"],
-                              "ta6Required": ["attachments"]
+                              "ta6Required": ["attachments"],
+                              "ta6ed6Required": [
+                                "boilerInstallationDate",
+                                "attachments"
+                              ]
+                            }
+                          ]
+                        },
+                        "replacementOtherThanBoiler": {
+                          "ta6ed6Ref": "11.4c",
+                          "title": "Has there been any replacement to the heating system (other than replacement of a boiler)?",
+                          "type": "object",
+                          "properties": {
+                            "yesNo": {
+                              "ta6ed6Ref": "11.4c1",
+                              "type": "string",
+                              "enum": ["Yes", "No", "Not known"]
+                            }
+                          },
+                          "ta6ed6Required": ["yesNo"],
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": ["No", "Not known"]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": ["Yes"]
+                                },
+                                "attachments": {
+                                  "ta6ed6Ref": "11.4d2",
+                                  "title": "Supply compliance certificates or documentation for the alteration (such as a building regulation completion certificate).",
+                                  "type": "string",
+                                  "enum": ["Attached", "To follow", "None"]
+                                }
+                              },
+                              "ta6ed6Required": ["attachments"]
                             }
                           ]
                         },
@@ -20855,6 +24548,7 @@
                           "baspi5Ref": "A7.4.2.1",
                           "rdsRef": "Objects/Maintenance",
                           "ta6Ref": "12.3d1",
+                          "ta6ed6Ref": "11.4g1",
                           "piqRef": "A7.5.1",
                           "title": "When was the heating system last serviced or maintained?",
                           "type": "string",
@@ -20871,31 +24565,38 @@
                           "baspi4Ref": "A7.4.2.2",
                           "baspi5Ref": "A7.4.2.2",
                           "ta6Ref": "12.3d2",
+                          "ta6ed6Ref": "11.4g2",
                           "title": "Please provide a copy of the service or maintenance works report.",
                           "type": "string",
-                          "enum": ["Attached", "To follow", "Not available"]
+                          "enum": ["Attached", "To follow", "Not available"],
+                          "ta6ed6Enum": ["Attached", "To follow"]
                         },
                         "heatingInGoodWorkingOrder": {
                           "baspi4Ref": "A7.4.3",
                           "baspi5Ref": "A7.4.3",
                           "rdsRef": "Objects/Condition=?",
                           "ta6Ref": "12.3c",
+                          "ta6ed6Ref": "11.4f",
                           "piqRef": "A7.6",
                           "title": "Is the heating system in good working order to your satisfaction?",
+                          "ta6ed6Title": "Is the boiler and heating system working?",
                           "type": "object",
                           "properties": {
                             "yesNo": {
                               "baspi4Ref": "A7.4.3.1",
                               "baspi5Ref": "A7.4.3.1",
                               "ta6Ref": "12.3c1",
+                              "ta6ed6Ref": "11.4f1",
                               "type": "string",
                               "title": "",
-                              "enum": ["Yes", "No"]
+                              "enum": ["Yes", "No", "Not known"],
+                              "ta6Enum": ["Yes", "No"]
                             }
                           },
                           "baspi4Required": ["yesNo"],
                           "baspi5Required": ["yesNo"],
                           "ta6Required": ["yesNo"],
+                          "ta6ed6Required": ["yesNo"],
                           "discriminator": {
                             "propertyName": "yesNo"
                           },
@@ -20903,7 +24604,7 @@
                             {
                               "properties": {
                                 "yesNo": {
-                                  "enum": ["Yes"]
+                                  "enum": ["Yes", "Not known"]
                                 }
                               }
                             },
@@ -20934,7 +24635,8 @@
                   "nts2Required": ["centralHeatingDetails"],
                   "ntslRequired": ["centralHeatingDetails"],
                   "ntsl2Required": ["centralHeatingDetails"],
-                  "ta6Required": ["centralHeatingDetails"]
+                  "ta6Required": ["centralHeatingDetails"],
+                  "ta6ed6Required": ["centralHeatingDetails"]
                 },
                 {
                   "properties": {
@@ -20964,9 +24666,13 @@
               "nts2Ref": "B3.4.2",
               "ntslRef": "B3.4.2",
               "ntsl2Ref": "B3.4.2",
+              "ta6ed6Ref": "11.4",
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4.other",
               "title": "What other heating features does the property have?",
+              "ta6ed6Title": "Other heating types",
               "type": "array",
               "items": {
+                "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4.other.item",
                 "type": "string",
                 "enum": [
                   "None",
@@ -20982,9 +24688,106 @@
                   "Ground source heat pump",
                   "Air source heat pump",
                   "Solar thermal",
+                  "Passive House design",
+                  "Mains gas",
+                  "Electricity",
+                  "Oil",
+                  "LPG",
+                  "Biomass"
+                ],
+                "ntsEnum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
                   "Passive House design"
+                ],
+                "nts2Enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ],
+                "ntslEnum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ],
+                "ntsl2Enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ],
+                "ta6ed6CompatEnum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design",
+                  "Mains gas",
+                  "Electricity",
+                  "Oil",
+                  "LPG",
+                  "Biomass"
                 ]
               }
+            },
+            "multipleHeatingSystems": {
+              "ta6ed6Ref": "11.4h",
+              "title": "Multiple heating systems",
+              "description": "If there is more than one heating system, attach answers to the above here.",
+              "type": "string",
+              "enum": ["Attached", "To follow", "Not applicable"]
             }
           }
         },
@@ -20996,6 +24799,7 @@
           "ntslRef": "B3",
           "ntsl2Ref": "B3",
           "ta6Ref": "13",
+          "ta6ed6Ref": "12",
           "title": "Connectivity",
           "type": "object",
           "baspi4Required": [
@@ -21015,11 +24819,13 @@
           "ntslRequired": ["broadband"],
           "ntsl2Required": ["broadband"],
           "ta6Required": ["telephone", "cableSatelliteTV"],
+          "ta6ed6Required": ["telephone", "broadband"],
           "properties": {
             "telephone": {
               "baspi4Ref": "A7.1.0.5",
               "baspi5Ref": "A7.1.0.5",
               "ta6Ref": "13.5",
+              "ta6ed6Ref": "12.7",
               "piqRef": "A7.1.11",
               "rdsRef": "Services/Telephone",
               "title": "Telephone",
@@ -21029,6 +24835,7 @@
                   "baspi4Ref": "A7.1.0.5.1",
                   "baspi5Ref": "A7.1.0.5.1",
                   "ta6Ref": "13.5.1",
+                  "ta6ed6Ref": "12.7.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "To be connected", "No"],
@@ -21036,12 +24843,14 @@
                   "nts2Enum": ["Yes", "No"],
                   "ntslEnum": ["Yes", "No"],
                   "ntsl2Enum": ["Yes", "No"],
-                  "ta6Enum": ["Yes", "No"]
+                  "ta6Enum": ["Yes", "No"],
+                  "ta6ed6Enum": ["Yes", "No"]
                 }
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21062,12 +24871,14 @@
                       "baspi4Ref": "A7.1.0.5.2",
                       "baspi5Ref": "A7.1.0.5.2",
                       "ta6Ref": "13.5.2",
+                      "ta6ed6Ref": "12.7.2",
                       "piqRef": "A7.1.12",
                       "title": "Supplier",
                       "type": "string"
                     }
                   },
-                  "ta6Required": ["supplier"]
+                  "ta6Required": ["supplier"],
+                  "ta6ed6Required": ["supplier"]
                 },
                 {
                   "properties": {
@@ -21179,6 +24990,7 @@
               "ntsl2Ref": "B3.5",
               "baspi4Ref": "A7.1.0.7",
               "baspi5Ref": "A7.1.0.7",
+              "ta6ed6Ref": "12.8",
               "title": "Broadband",
               "rdsRef": "Services/Internet",
               "piqRef": "A7.1.15",
@@ -21192,6 +25004,7 @@
                   "baspi4Ref": "A7.1.0.7.2",
                   "baspi5Ref": "A7.1.0.7.2",
                   "piqRef": "A7.1.16",
+                  "ta6ed6Ref": "12.8.1",
                   "title": "Type of connection",
                   "type": "string",
                   "enum": [
@@ -21233,10 +25046,45 @@
                   }
                 }
               },
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": ["None"]
+                    }
+                  }
+                },
+
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    },
+                    "providerName": {
+                      "ta6ed6Ref": "12.8.2",
+                      "title": "Provider name",
+                      "type": "string"
+                    }
+                  },
+
+                  "ta6ed6Required": ["providerName"]
+                }
+              ],
+              "baspi4Required": ["typeOfConnection"],
+              "baspi5Required": ["typeOfConnection"],
               "ntsRequired": ["typeOfConnection"],
               "nts2Required": ["typeOfConnection"],
               "ntslRequired": ["typeOfConnection"],
-              "ntsl2Required": ["typeOfConnection"]
+              "ntsl2Required": ["typeOfConnection"],
+              "ta6ed6Required": ["typeOfConnection"]
             },
             "mobilePhone": {
               "baspi4Ref": "A7.1.0.8",
@@ -21412,6 +25260,11 @@
                   }
                 }
               }
+            },
+            "otherServices": {
+              "ta6ed6Ref": "12.9.1",
+              "title": "Details of any other services",
+              "type": "string"
             }
           }
         },
@@ -21419,20 +25272,29 @@
           "baspi4Ref": "A8",
           "baspi5Ref": "A8",
           "ta6Ref": "6",
+          "ta6ed6Ref": "7",
+          "sef25Ref": "I1",
           "title": "Insurance",
           "type": "object",
           "baspi4Required": ["difficultiesObtainingInsurance", "isInsured"],
           "baspi5Required": ["difficultiesObtainingInsurance", "isInsured"],
           "ta6Required": ["difficultiesObtainingInsurance", "isInsured"],
+          "ta6ed6Required": [
+            "isInsured",
+            "difficultiesObtainingInsurance"
+          ],
+          "sef25Required": ["isInsured"],
           "properties": {
             "difficultiesObtainingInsurance": {
               "baspi4Ref": "A8.1.2.1",
               "baspi5Ref": "A8.1.2.1",
               "rdsRef": "Insurance/Flags,Insurance/refusalReason=?",
               "ta6Ref": "6.4",
+              "ta6ed6Ref": "7.2",
               "piqRef": "A8.1",
               "title": "Have you had any difficulty obtaining competitively priced building insurance due to the structure or location of the property or had insurance refused?",
               "ta6Title": "Has any buildings insurance taken out by the seller ever been:",
+              "ta6ed6Title": "Are you aware of the property insurance ever being difficult to obtain or subject to special conditions?",
               "type": "object",
               "baspi4Required": [
                 "abnormalRiseInPremiums",
@@ -21452,11 +25314,18 @@
                 "subjectToUnusualConditions",
                 "refused"
               ],
+              "ta6ed6Required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
               "properties": {
                 "abnormalRiseInPremiums": {
                   "baspi4Ref": "A8.1.2.1.1",
                   "baspi5Ref": "A8.1.2.1.1",
                   "ta6Ref": "6.4a",
+                  "ta6ed6Ref": "7.2a",
                   "piqRef": "A8.1a",
                   "title": "Subject to abnormal rise in premiums?",
                   "type": "object",
@@ -21465,6 +25334,7 @@
                       "baspi4Ref": "A8.1.2.1.1.1",
                       "baspi5Ref": "A8.1.2.1.1.1",
                       "ta6Ref": "6.4a1",
+                      "ta6ed6Ref": "7.2a1",
                       "piqRef": "A8.1a1",
                       "type": "string",
                       "title": "",
@@ -21474,6 +25344,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -21494,6 +25365,7 @@
                           "baspi4Ref": "A8.1.2.1.1.2",
                           "baspi5Ref": "A8.1.2.1.1.2",
                           "ta6Ref": "6.4.2",
+                          "ta6ed6Ref": "7.2a2",
                           "piqRef": "A8.1a1.1",
                           "title": "Provide details",
                           "type": "string",
@@ -21502,7 +25374,8 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -21510,6 +25383,7 @@
                   "baspi4Ref": "A8.1.2.1.2",
                   "baspi5Ref": "A8.1.2.1.2",
                   "ta6Ref": "6.4b",
+                  "ta6ed6Ref": "7.2b",
                   "piqRef": "A8.1b",
                   "title": "Subject to high excesses?",
                   "type": "object",
@@ -21518,6 +25392,7 @@
                       "baspi4Ref": "A8.1.2.1.2.1",
                       "baspi5Ref": "A8.1.2.1.2.1",
                       "ta6Ref": "6.4b1",
+                      "ta6ed6Ref": "7.2b1",
                       "piqRef": "A8.1b1",
                       "type": "string",
                       "title": "",
@@ -21527,6 +25402,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -21547,6 +25423,7 @@
                           "baspi4Ref": "A8.1.2.1.2.2",
                           "baspi5Ref": "A8.1.2.1.2.2",
                           "ta6Ref": "6.4.2",
+                          "ta6ed6Ref": "7.2b2",
                           "piqRef": "A8.1b2",
                           "title": "Provide details",
                           "type": "string",
@@ -21555,7 +25432,8 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -21563,6 +25441,7 @@
                   "baspi4Ref": "A8.1.2.1.3",
                   "baspi5Ref": "A8.1.2.1.3",
                   "ta6Ref": "6.4c",
+                  "ta6ed6Ref": "7.2c",
                   "piqRef": "A8.1c",
                   "title": "Subject to unusual conditions?",
                   "type": "object",
@@ -21571,6 +25450,7 @@
                       "baspi4Ref": "A8.1.2.1.3.1",
                       "baspi5Ref": "A8.1.2.1.3.1",
                       "ta6Ref": "6.4c1",
+                      "ta6ed6Ref": "7.2c1",
                       "piqRef": "A8.1c1",
                       "type": "string",
                       "title": "",
@@ -21580,6 +25460,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -21600,6 +25481,7 @@
                           "baspi4Ref": "A8.1.2.1.3.2",
                           "baspi5Ref": "A8.1.2.1.3.2",
                           "ta6Ref": "6.4.2",
+                          "ta6ed6Ref": "7.2c2",
                           "piqRef": "A8.1c2",
                           "title": "Provide details",
                           "type": "string",
@@ -21608,7 +25490,8 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -21616,6 +25499,7 @@
                   "baspi4Ref": "A8.1.2.1.4",
                   "baspi5Ref": "A8.1.2.1.4",
                   "ta6Ref": "6.4d",
+                  "ta6ed6Ref": "7.2d",
                   "piqRef": "A8.1d",
                   "title": "Refused?",
                   "type": "object",
@@ -21624,6 +25508,7 @@
                       "baspi4Ref": "A8.1.2.1.4.1",
                       "baspi5Ref": "A8.1.2.1.4.1",
                       "ta6Ref": "6.4d1",
+                      "ta6ed6Ref": "7.2d1",
                       "piqRef": "A8.1d1",
                       "type": "string",
                       "title": "",
@@ -21633,6 +25518,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -21653,6 +25539,7 @@
                           "baspi4Ref": "A8.1.2.1.4.2",
                           "baspi5Ref": "A8.1.2.1.4.2",
                           "ta6Ref": "6.4.2",
+                          "ta6ed6Ref": "7.2d2",
                           "piqRef": "A8.1d2",
                           "title": "Provide details",
                           "type": "string",
@@ -21661,7 +25548,8 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 }
@@ -21672,9 +25560,12 @@
               "baspi5Ref": "A8.1",
               "rdsRef": "Insurance/isInsured=no|yes|true|false",
               "ta6Ref": "6.1",
+              "ta6ed6Ref": "7.1",
+              "sef25Ref": "I1.2",
               "piqRef": "A8.2",
               "title": "Do you currently insure the property?",
               "ta6Title": "Does the seller insure the property?",
+              "ta6ed6Title": "Do you insure the property?",
               "type": "string",
               "enum": ["Yes", "No"]
             }
@@ -21703,31 +25594,42 @@
                   "title": "If the property is a flat, does the landlord insure the building?",
                   "type": "string",
                   "enum": ["Yes", "No", "Not applicable"]
+                },
+                "whoInsures": {
+                  "ta6ed6Ref": "7.1.1",
+                  "title": "Who insures the property?",
+                  "type": "string",
+                  "minLength": 1
                 }
               },
               "baspi4Required": ["details", "landlordInsuresIfFlat"],
               "baspi5Required": ["details", "landlordInsuresIfFlat"],
-              "ta6Required": ["details", "landlordInsuresIfFlat"]
+              "ta6Required": ["details", "landlordInsuresIfFlat"],
+              "ta6ed6Required": ["whoInsures"]
             },
             {
               "properties": {
                 "isInsured": {
                   "enum": ["Yes"]
                 },
-
                 "insuranceClaims": {
                   "baspi4Ref": "A8.2",
                   "baspi5Ref": "A8.2",
                   "rdsRef": "Insurance/Claims",
                   "ta6Ref": "6.5",
+                  "ta6ed6Ref": "7.3",
+                  "sef25Ref": "I1.1",
                   "title": "Have you ever made a claim against your building insurance in relation to the property?",
                   "Title": "Has the seller made any buildings insurance claims?",
+                  "ta6ed6Title": "Have you made any buildings insurance claims?",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "A8.2.1",
                       "baspi5Ref": "A8.2.1",
                       "ta6Ref": "6.5.1",
+                      "ta6ed6Ref": "7.3.1",
+                      "sef25Ref": "I1.1.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -21736,6 +25638,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -21756,21 +25660,28 @@
                           "baspi4Ref": "A8.2.1",
                           "baspi5Ref": "A8.2.1",
                           "ta6Ref": "6.5.2",
+                          "ta6ed6Ref": "7.3.2",
+                          "sef25Ref": "I1.1.2",
                           "title": "Provide details",
+                          "ta6ed6Title": "Give details, including the date(s) of any claim(s) and how they were resolved",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"],
+                      "sef25Required": ["details"]
                     }
                   ]
                 }
               },
               "baspi4Required": ["insuranceClaims"],
               "baspi5Required": ["insuranceClaims"],
-              "ta6Required": ["insuranceClaims"]
+              "ta6Required": ["insuranceClaims"],
+              "ta6ed6Required": ["insuranceClaims"],
+              "sef25Required": ["insuranceClaims"]
             }
           ]
         },
@@ -21782,6 +25693,9 @@
           "baspi4Ref": "A10",
           "baspi5Ref": "A10",
           "ta6Ref": "8",
+          "ta6ed6Ref": "9",
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.9",
+          "sef25Ref": "R1",
           "title": "Rights and Informal Arrangements",
           "type": "object",
           "baspi4Required": [
@@ -21806,12 +25720,20 @@
             "accessRestrictionAttempts",
             "rightsOrArrangements"
           ],
+          "ta6ed6Required": [
+            "neighbouringLandRights",
+            "sharedContributions",
+            "rightsOrArrangements",
+            "askedOthersToContribute"
+          ],
           "properties": {
             "sharedContributions": {
               "baspi4Ref": "A10.1",
               "baspi5Ref": "A10.1",
               "rdsRef": "Services/SharedCosts",
               "ta6Ref": "8.1",
+              "ta6ed6Ref": "9.2",
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.9.2",
               "piqRef": "A10.1",
               "title": "Other than service charges and estate rentcharges, do you have to contribute towards the shared cost of a jointly-used service such as a shared driveway, road, parking area, garden or drain?",
               "type": "object",
@@ -21820,15 +25742,20 @@
                   "baspi4Ref": "A10.1.1",
                   "baspi5Ref": "A10.1.1",
                   "ta6Ref": "8.1.1",
+                  "ta6ed6Ref": "9.2.1",
                   "piqRef": "A10.1.1",
                   "type": "string",
                   "title": "",
-                  "enum": ["Yes", "No"]
+                  "enum": ["Yes", "No", "Not applicable"]
                 }
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6CompatRequired": ["yesNo"],
+              "ta6ed6Title": "Have you been asked to contribute towards the cost of the jointly used facilities?",
+              "ta6ed6Description": "If yes, give details of how much, how often and who you pay:",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21836,7 +25763,10 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No"]
+                      "ta6ed6CompatRef": "TA6ED6-COMPAT.9.2.1.no",
+                      "enum": ["No", "Not applicable"],
+                      "ta6ed6Enum": ["No", "Not applicable"],
+                      "ta6ed6CompatEnum": ["No", "Not applicable"]
                     }
                   }
                 },
@@ -21849,15 +25779,57 @@
                       "baspi4Ref": "A10.1.2",
                       "baspi5Ref": "A10.1.2",
                       "ta6Ref": "8.1.2",
+                      "ta6ed6Ref": "9.2.2",
                       "piqRef": "A10.1.2",
+                      "ta6ed6Title": "Please give details of how much, how often and who you pay:",
                       "title": "Please give details including who collects payments and organises the work, the amount of the payments in the last year and whether they are regular payments or only when maintenance work is required",
                       "type": "string",
                       "minLength": 1
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.3",
+                      "title": "Are you aware of any disagreement or complaint about any such right or arrangement?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.3.1",
+                          "type": "string",
+                          "enum": ["Yes", "No", "Not known"]
+                        }
+                      },
+                      "ta6ed6Required": ["yesNo"],
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not known"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "details": {
+                              "title": "Provide details",
+                              "ta6ed6Ref": "9.3.2",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
                     }
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details", "disagreementOrComplaint"]
                 }
               ]
             },
@@ -21866,14 +25838,17 @@
               "baspi5Ref": "A10.2",
               "rdsRef": "Tenure/Rights,Tenure *with different property entity and references etc*",
               "ta6Ref": "8.2",
+              "ta6ed6Ref": "9.1",
               "piqRef": "A10.2",
-              "title": "Do any rights and arrangements exist over neighbouring land from which the property benefits?  (e.g. taking wheelie bins along an accessway through a neighbour’s back garden, parking, access to maintain the boundaries from the neighbour’s side etc)",
+              "title": "Do any rights and arrangements exist over neighbouring land from which the property benefits?  (e.g. taking wheelie bins along an accessway through a neighbour's back garden, parking, access to maintain the boundaries from the neighbour's side etc)",
+              "ta6ed6Title": "Do you exercise any rights or arrangements over any other properties?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "A10.2.1",
                   "baspi5Ref": "A10.2.1",
                   "ta6Ref": "8.2.1",
+                  "ta6ed6Ref": "9.1.1",
                   "piqRef": "A10.2.1",
                   "type": "string",
                   "title": "",
@@ -21883,6 +25858,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21903,10 +25879,50 @@
                       "baspi4Ref": "A10.2.2",
                       "baspi5Ref": "A10.2.2",
                       "ta6Ref": "8.2.2",
+                      "ta6ed6Ref": "9.1.2",
                       "piqRef": "A10.2.2",
+                      "ta6ed6Title": "Please give details",
                       "title": "Please give details and provide a plan showing the route of the access, parking etc",
                       "type": "string",
                       "minLength": 1
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.3",
+                      "title": "Are you aware of any disagreement or complaint about any such right or arrangement?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.3.1",
+                          "type": "string",
+                          "enum": ["Yes", "No", "Not known"]
+                        }
+                      },
+                      "ta6ed6Required": ["yesNo"],
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not known"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "9.3.2",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
                     },
                     "attachments": {
                       "baspi4Ref": "A10.2.3",
@@ -21918,7 +25934,8 @@
                   },
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details", "disagreementOrComplaint"]
                 }
               ]
             },
@@ -21927,6 +25944,7 @@
               "baspi5Ref": "A10.3",
               "rdsRef": "Tenure/Restrictions",
               "ta6Ref": "8.3",
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.9.3",
               "piqRef": "A10.3",
               "title": "Has anyone tried to stop you using an access way to the property or asked you to pay to use the access?",
               "type": "object",
@@ -21936,14 +25954,16 @@
                   "baspi5Ref": "A10.3.1",
                   "ta6Ref": "8.3.1",
                   "piqRef": "A10.3.1",
+                  "ta6ed6Enum": ["Yes", "No", "Not known"],
                   "type": "string",
                   "title": "",
-                  "enum": ["Yes", "No"]
+                  "enum": ["Yes", "No", "Not known"]
                 }
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6CompatRequired": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -21951,7 +25971,10 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No"]
+                      "ta6ed6CompatRef": "TA6ED6-COMPAT.9.3.1.no",
+                      "enum": ["No", "Not known"],
+                      "ta6ed6Enum": ["No", "Not known"],
+                      "ta6ed6CompatEnum": ["No", "Not known"]
                     }
                   }
                 },
@@ -21984,6 +26007,8 @@
               "baspi4Ref": "A10.4",
               "baspi5Ref": "A10.4",
               "ta6Ref": "8.4",
+              "ta6ed6Ref": "9.4",
+              "sef25Ref": "R1",
               "title": "Do you know if any of the following rights or arrangements affect the property?",
               "type": "object",
               "ntsRequired": ["publicRightOfWay"],
@@ -22019,6 +26044,18 @@
                 "rightsToTakeFromLand",
                 "otherRights"
               ],
+              "ta6ed6Required": [
+                "publicRightOfWay",
+                "rightsOfLight",
+                "rightsOfSupport",
+                "rightsCreatedThroughCustom",
+                "minesAndMinerals",
+                "churchChancel",
+                "rightsToTakeFromLand",
+                "otherRights",
+                "disagreementOrComplaint"
+              ],
+              "sef25Required": ["privateRightOfWay"],
               "properties": {
                 "publicRightOfWay": {
                   "ntsRef": "C2.2.1",
@@ -22029,6 +26066,7 @@
                   "baspi5Ref": "A10.4.1",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities,Tenure/CadastralMapOfParcels",
                   "ta6Ref": "8.6",
+                  "ta6ed6Ref": "9.4.1",
                   "piqRef": "A10.4",
                   "title": "A public right of way through and/or across your property, buildings or land",
                   "ntsTitle": "Is there a public right of way through and/or across your house, buildings or land?",
@@ -22042,6 +26080,7 @@
                       "baspi4Ref": "A10.4.1.1",
                       "baspi5Ref": "A10.4.1.1",
                       "ta6Ref": "8.6.1",
+                      "ta6ed6Ref": "9.4.1.1",
                       "piqRef": "A10.4.1",
                       "type": "string",
                       "title": "",
@@ -22055,6 +26094,7 @@
                   "ntslRequired": ["yesNo"],
                   "ntsl2Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22079,6 +26119,7 @@
                           "baspi4Ref": "A10.4.1.2",
                           "baspi5Ref": "A10.4.1.2",
                           "ta6Ref": "8.6.2",
+                          "ta6ed6Ref": "9.4.1.2",
                           "piqRef": "A10.4.2",
                           "title": "Please provide details",
                           "type": "string",
@@ -22095,10 +26136,51 @@
                       "baspi4Required": ["details", "attachments"],
                       "baspi5Required": ["details", "attachments"],
                       "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"],
                       "ntsRequired": ["details"],
                       "nts2Required": ["details"],
                       "ntslRequired": ["details"],
                       "ntsl2Required": ["details"]
+                    }
+                  ]
+                },
+                "privateRightOfWay": {
+                  "sef25Ref": "R1.1",
+                  "title": "A private right of way through and/or across your house, buildings or land",
+                  "type": "object",
+                  "sef25Required": ["yesNo"],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "R1.1.1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "sef25Ref": "R1.1.2",
+                          "title": "Please provide details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "sef25Required": ["details"]
                     }
                   ]
                 },
@@ -22107,6 +26189,7 @@
                   "baspi5Ref": "A10.4.2a",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4a",
+                  "ta6ed6Ref": "9.4a",
                   "piqRef": "A10.5a",
                   "title": "Rights of light",
                   "type": "object",
@@ -22115,6 +26198,7 @@
                       "baspi4Ref": "A10.4.2a.1",
                       "baspi5Ref": "A10.4.2a.1",
                       "ta6Ref": "8.4a1",
+                      "ta6ed6Ref": "9.4a1",
                       "piqRef": "A10.5a1",
                       "type": "string",
                       "title": "",
@@ -22124,6 +26208,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22143,13 +26228,15 @@
                         "details": {
                           "baspi4Ref": "A10.4.2a.2",
                           "baspi5Ref": "A10.4.2a.2",
+                          "ta6ed6Ref": "9.4a2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
-                      "baspi5Required": ["details"]
+                      "baspi5Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22158,6 +26245,7 @@
                   "baspi5Ref": "A10.4.2b",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4a",
+                  "ta6ed6Ref": "9.4b",
                   "piqRef": "A10.5b",
                   "title": "Rights of support from adjoining properties",
                   "type": "object",
@@ -22166,6 +26254,7 @@
                       "baspi4Ref": "A10.4.2b.1",
                       "baspi5Ref": "A10.4.2b.1",
                       "ta6Ref": "8.4b1",
+                      "ta6ed6Ref": "9.4b1",
                       "piqRef": "A10.5b1",
                       "type": "string",
                       "title": "",
@@ -22175,6 +26264,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22194,13 +26284,15 @@
                         "details": {
                           "baspi4Ref": "A10.4.2b.2",
                           "baspi5Ref": "A10.4.2b.2",
+                          "ta6ed6Ref": "9.4b2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
-                      "baspi5Required": ["details"]
+                      "baspi5Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22209,6 +26301,7 @@
                   "baspi5Ref": "A10.4.3a",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.4c",
+                  "ta6ed6Ref": "9.4c",
                   "piqRef": "A10.5c",
                   "title": "Rights created through custom or use (e.g. rights to graze on other land or forage)",
                   "type": "object",
@@ -22217,6 +26310,7 @@
                       "baspi4Ref": "A10.4.3a1",
                       "baspi5Ref": "A10.4.3a1",
                       "ta6Ref": "8.4c1",
+                      "ta6ed6Ref": "9.4c1",
                       "piqRef": "A10.5c1",
                       "type": "string",
                       "title": "",
@@ -22226,6 +26320,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22245,13 +26340,15 @@
                         "details": {
                           "baspi4Ref": "A10.4.3a2",
                           "baspi5Ref": "A10.4.3a2",
+                          "ta6ed6Ref": "9.4c2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
-                      "baspi5Required": ["details"]
+                      "baspi5Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22260,6 +26357,7 @@
                   "baspi5Ref": "A10.4.3b",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5b",
+                  "ta6ed6Ref": "9.4d",
                   "piqRef": "A10.5f",
                   "title": "Other people's rights to take things from the land (such as timber, hay or fish)",
                   "type": "object",
@@ -22268,6 +26366,7 @@
                       "baspi4Ref": "A10.4.3b1",
                       "baspi5Ref": "A10.4.3b1",
                       "ta6Ref": "8.5c1",
+                      "ta6ed6Ref": "9.4d1",
                       "piqRef": "A10.5f1",
                       "type": "string",
                       "title": "",
@@ -22277,6 +26376,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22297,6 +26397,7 @@
                           "baspi4Ref": "A10.4.3b2",
                           "baspi5Ref": "A10.4.3b2",
                           "ta6Ref": "8.5c2",
+                          "ta6ed6Ref": "9.4d2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
@@ -22304,7 +26405,8 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22313,6 +26415,7 @@
                   "baspi5Ref": "A10.4.4",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5a",
+                  "ta6ed6Ref": "9.4e",
                   "piqRef": "A10.5d",
                   "title": "Mines and minerals under the property",
                   "type": "object",
@@ -22321,6 +26424,7 @@
                       "baspi4Ref": "A10.4.4.1",
                       "baspi5Ref": "A10.4.4.1",
                       "ta6Ref": "8.5a1",
+                      "ta6ed6Ref": "9.4e1",
                       "piqRef": "A10.5d1",
                       "type": "string",
                       "title": "",
@@ -22330,6 +26434,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22349,13 +26454,15 @@
                         "details": {
                           "baspi4Ref": "A10.4.4.2",
                           "baspi5Ref": "A10.4.4.2",
+                          "ta6ed6Ref": "9.4e2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
-                      "baspi5Required": ["details"]
+                      "baspi5Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22364,6 +26471,7 @@
                   "baspi5Ref": "A10.4.5",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.5b",
+                  "ta6ed6Ref": "9.4f",
                   "piqRef": "A10.5e",
                   "title": "Liability to contribute to the maintenance of a church chancel?",
                   "type": "object",
@@ -22372,6 +26480,7 @@
                       "baspi4Ref": "A10.4.5.1",
                       "baspi5Ref": "A10.4.5.1",
                       "ta6Ref": "8.5b1",
+                      "ta6ed6Ref": "9.4f1",
                       "piqRef": "A10.5e1",
                       "type": "string",
                       "title": "",
@@ -22381,6 +26490,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22400,13 +26510,15 @@
                         "details": {
                           "baspi4Ref": "A10.4.5.2",
                           "baspi5Ref": "A10.4.5.2",
+                          "ta6ed6Ref": "9.4f2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "baspi4Required": ["details"],
-                      "baspi5Required": ["details"]
+                      "baspi5Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -22415,6 +26527,7 @@
                   "baspi5Ref": "A10.4.6",
                   "rdsRef": "Tenure/Rights,Tenure/Restrictions,Tenure/Responsibilities",
                   "ta6Ref": "8.6",
+                  "ta6ed6Ref": "9.4g",
                   "piqRef": "A10.5g",
                   "title": "Any other rights or arrangements affecting the property?",
                   "type": "object",
@@ -22423,6 +26536,7 @@
                       "baspi4Ref": "A10.4.6.1",
                       "baspi5Ref": "A10.4.6.1",
                       "ta6Ref": "8.6.1",
+                      "ta6ed6Ref": "9.4g1",
                       "piqRef": "A10.5g1",
                       "type": "string",
                       "title": "",
@@ -22432,6 +26546,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22452,6 +26567,7 @@
                           "baspi4Ref": "A10.4.6.2",
                           "baspi5Ref": "A10.4.6.2",
                           "ta6Ref": "8.6.2",
+                          "ta6ed6Ref": "9.4g2",
                           "title": "Details",
                           "type": "string",
                           "minLength": 1
@@ -22459,11 +26575,128 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
+                    }
+                  ]
+                },
+                "disagreementOrComplaint": {
+                  "ta6ed6Ref": "9.6",
+                  "title": "Are you aware of any disagreement or complaint about any such rights?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.6.1",
+                      "type": "string",
+                      "enum": ["Yes", "No", "Not known"]
+                    }
+                  },
+                  "ta6ed6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No", "Not known"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.6.2",
+                          "title": "Details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 }
               }
+            },
+            "askedOthersToContribute": {
+              "ta6ed6Ref": "9.5",
+              "title": "Have you asked the owner of any other properties to contribute towards the cost of the jointly used facilities?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.5.1",
+                  "type": "string",
+                  "enum": ["Yes", "No", "Not applicable"]
+                }
+              },
+              "ta6ed6Required": ["yesNo"],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No", "Not applicable"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.5.2",
+                      "title": "Specify whether you receive this payment or if it is made to a third party. Include details about how much is paid and how often payments are made:",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.6",
+                      "title": "Are you aware of any disagreement or complaint about any such arrangements?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.6.1",
+                          "type": "string",
+                          "enum": ["Yes", "No", "Not known"]
+                        }
+                      },
+                      "ta6ed6Required": ["yesNo"],
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["No", "Not known"]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": ["Yes"]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "9.6.2",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "ta6ed6Required": ["details"]
+                        }
+                      ]
+                    }
+                  },
+                  "ta6ed6Required": ["details", "disagreementOrComplaint"]
+                }
+              ]
             }
           }
         },
@@ -22475,7 +26708,9 @@
           "baspi4Ref": "A11.1",
           "baspi5Ref": "A11.1",
           "ta6Ref": "7",
+          "ta6ed6Ref": "8",
           "piqRef": "A11.1",
+          "sef25Ref": "E1",
           "title": "Environmental Issues Affecting the Property",
           "type": "object",
           "baspi4Required": ["flooding", "radon", "otherEnvironmental"],
@@ -22510,6 +26745,8 @@
             "coastalErosion"
           ],
           "ta6Required": ["flooding", "radon"],
+          "ta6ed6Required": ["flooding", "radon"],
+          "sef25Required": ["stormFireFloodDamage"],
           "properties": {
             "flooding": {
               "ntsRef": "C3.1.1",
@@ -22519,7 +26756,8 @@
               "baspi4Ref": "A11.1.1",
               "baspi5Ref": "A11.1.1",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
-              "ta6Ref": "7.1.0",
+              "ta6Ref": "7",
+              "ta6ed6Ref": "8",
               "title": "Flooding",
               "type": "object",
               "baspi4Required": ["historicalFlooding"],
@@ -22536,8 +26774,49 @@
                 "historicalFlooding",
                 "floodDefences"
               ],
-              "ta6Required": ["historicalFlooding"],
+              "ta6Required": ["floodRiskReport", "historicalFlooding"],
+              "ta6ed6Required": ["historicalFlooding", "floodDefences"],
               "properties": {
+                "floodRiskReport": {
+                  "ta6Ref": "7.3",
+                  "title": "Flood risk report",
+                  "type": "object",
+                  "ta6Required": ["hasReportBeenPrepared"],
+                  "properties": {
+                    "hasReportBeenPrepared": {
+                      "ta6Ref": "7.3.1",
+                      "title": "Has a flood risk report been prepared?",
+                      "type": "string",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "discriminator": {
+                    "propertyName": "hasReportBeenPrepared"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": ["Yes"]
+                        },
+                        "attachments": {
+                          "ta6Ref": "7.3.2",
+                          "title": "Please supply a copy",
+                          "type": "string",
+                          "enum": ["Attached", "To follow"]
+                        }
+                      },
+                      "ta6Required": ["attachments"]
+                    }
+                  ]
+                },
                 "floodRisk": {
                   "ntsRef": "C3.1.1.1",
                   "nts2Ref": "C3.1.1.1",
@@ -22674,6 +26953,7 @@
                   "baspi4Ref": "A11.1.2",
                   "baspi5Ref": "A11.1.2",
                   "ta6Ref": "7.1",
+                  "ta6ed6Ref": "8.1",
                   "title": "Historical flooding",
                   "type": "object",
                   "baspi4Required": ["hasBeenFlooded"],
@@ -22683,6 +26963,9 @@
                   "ntslRequired": ["hasBeenFlooded"],
                   "ntsl2Required": ["hasBeenFlooded"],
                   "ta6Required": ["hasBeenFlooded"],
+                  "ta6ed6Required": ["hasBeenFlooded"],
+                  "ta6ed6Title": "Are you aware of the property or any part of it ever being flooded?",
+                  "ta6ed6Description": "If yes, what type of flooding took place?",
                   "properties": {
                     "hasBeenFlooded": {
                       "ntsRef": "C3.1.1.2.1",
@@ -22692,6 +26975,8 @@
                       "baspi4Ref": "A11.1.2.1",
                       "baspi5Ref": "A11.1.2.1",
                       "ta6Ref": "7.1.1",
+                      "ta6ed6Ref": "8.1.1",
+                      "sef25Ref": "E1.2",
                       "title": "Has the property been flooded in the last 5 years?",
                       "ta6Title": "Has any part of the property (whether buildings or surrounding garden or land) ever been flooded?",
                       "type": "string",
@@ -22723,6 +27008,8 @@
                           "baspi5Ref": "A11.1.2.2",
                           "rdsRef": "Sustainability/Environmental|Natural|Situational",
                           "ta6Ref": "7.2",
+                          "ta6ed6Ref": "8.1",
+                          "ta6ed6Title": "If yes, what type of flooding took place?",
                           "title": "What type of flooding occurred?",
                           "type": "array",
                           "items": {
@@ -22745,6 +27032,8 @@
                           "baspi4Ref": "A11.1.2.1",
                           "baspi5Ref": "A11.1.2.1",
                           "ta6Ref": "7.1.2",
+                          "ta6ed6Ref": "8.1.2",
+                          "ta6ed6Title": "Give details about the date(s) any flooding occurred and which parts flooded:",
                           "title": "Please state when the flooding occurred and identify the parts that flooded",
                           "type": "string",
                           "minLength": 1
@@ -22756,21 +27045,27 @@
                       "nts2Required": ["typeOfFlooding", "details"],
                       "ntslRequired": ["typeOfFlooding", "details"],
                       "ntsl2Required": ["typeOfFlooding", "details"],
-                      "ta6Required": ["typeOfFlooding", "details"]
+                      "ta6Required": ["typeOfFlooding", "details"],
+                      "ta6ed6Required": ["typeOfFlooding", "details"]
                     }
                   ]
                 },
                 "floodDefences": {
                   "nts2Ref": "C3.1.1.3",
                   "ntsl2Ref": "C3.1.1.3",
+                  "ta6ed6Ref": "8.2",
                   "title": "Flood defences",
                   "type": "object",
                   "nts2Required": ["hasFloodDefences"],
                   "ntsl2Required": ["hasFloodDefences"],
+                  "ta6ed6Required": ["hasFloodDefences"],
+                  "ta6ed6Title": "Are you aware of any defences installed at the property to prevent flooding?",
+                  "ta6ed6Description": "If yes, please give details:",
                   "properties": {
                     "hasFloodDefences": {
                       "nts2Ref": "C3.1.1.3.1",
                       "ntsl2Ref": "C3.1.1.3.1",
+                      "ta6ed6Ref": "8.2.1",
                       "title": "Are there any defences to prevent flooding installed at the property?",
                       "type": "string",
                       "enum": ["Yes", "No"]
@@ -22795,27 +27090,73 @@
                         "details": {
                           "nts2Ref": "C3.1.1.3.2",
                           "ntsl2Ref": "C3.1.1.3.2",
+                          "ta6ed6Ref": "8.2.2",
+                          "ta6ed6Title": "Please give details:",
                           "title": "Please provide details",
                           "type": "string",
                           "minLength": 1
                         }
                       },
                       "nts2Required": ["details"],
-                      "ntsl2Required": ["details"]
+                      "ntsl2Required": ["details"],
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 }
               }
+            },
+            "stormFireFloodDamage": {
+              "sef25Ref": "E1.1",
+              "title": "Has the property ever suffered storm, fire or flood damage?",
+              "type": "object",
+              "sef25Required": ["yesNo"],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "E1.1.1",
+                  "type": "string",
+                  "title": "",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": ["Yes"]
+                    },
+                    "details": {
+                      "sef25Ref": "E1.1.2",
+                      "title": "Please provide details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "sef25Required": ["details"]
+                }
+              ]
             },
             "radon": {
               "baspi4Ref": "A11.1.3",
               "baspi5Ref": "A11.1.3",
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
               "ta6Ref": "7.4",
+              "ta6ed6Ref": "8.3",
               "title": "Radon",
               "type": "object",
               "baspi4Required": ["remedialMeasuresOnConstruction", "radonTest"],
               "baspi5Required": ["remedialMeasuresOnConstruction", "radonTest"],
+              "ta6Required": ["remedialMeasuresOnConstruction", "radonTest"],
+              "ta6ed6Required": ["remedialMeasuresOnConstruction", "radonTest"],
               "properties": {
                 "radonRisk": {
                   "type": "object",
@@ -22902,6 +27243,7 @@
                   "baspi4Ref": "A11.1.3",
                   "baspi5Ref": "A11.1.3",
                   "ta6Ref": "7.4",
+                  "ta6ed6Ref": "8.3",
                   "title": "Has a Radon test been carried out on the property?",
                   "type": "object",
                   "properties": {
@@ -22909,13 +27251,19 @@
                       "baspi4Ref": "A11.1.3.1",
                       "baspi5Ref": "A11.1.3.1",
                       "ta6Ref": "7.4.1",
+                      "ta6ed6Ref": "8.3.1",
                       "type": "string",
                       "title": "",
-                      "enum": ["Yes", "No"]
+                      "enum": ["Yes", "No", "Not known"],
+                      "baspi4Enum": ["Yes", "No"],
+                      "baspi5Enum": ["Yes", "No"],
+                      "ta6Enum": ["Yes", "No"]
                     }
                   },
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
+                  "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -22923,7 +27271,7 @@
                     {
                       "properties": {
                         "yesNo": {
-                          "enum": ["No"]
+                          "enum": ["No", "Not known"]
                         }
                       }
                     },
@@ -22935,6 +27283,7 @@
                         "details": {
                           "baspi4Ref": "A11.1.3.2",
                           "baspi5Ref": "A11.1.3.2",
+                          "ta6ed6Ref": "8.3.1a",
                           "ta6Ref": "7.4b",
                           "title": "Was the test result was below the recommended action level?",
                           "type": "string",
@@ -22943,6 +27292,7 @@
                         "attachments": {
                           "baspi4Ref": "A11.1.3.3",
                           "baspi5Ref": "A11.1.3.3",
+                          "ta6ed6Ref": "8.3.1b",
                           "ta6Ref": "7.4a",
                           "title": "Please supply a copy of the report",
                           "type": "string",
@@ -22951,22 +27301,25 @@
                       },
                       "baspi4Required": ["details", "attachments"],
                       "baspi5Required": ["details", "attachments"],
-                      "ta6Required": ["details", "attachments"]
+                      "ta6Required": ["details", "attachments"],
+                      "ta6ed6Required": ["details", "attachments"]
                     }
-                  ],
-                  "ta6Required": ["yesNo"]
+                  ]
                 },
                 "remedialMeasuresOnConstruction": {
                   "baspi4Ref": "A11.1.3.4",
                   "baspi5Ref": "A11.1.3.4",
                   "rdsRef": "Sustainability/Environmental|Natural|Situational",
+                  "ta6ed6Ref": "8.4",
                   "ta6Ref": "7.5",
                   "title": "Were any remedial measures undertaken on construction to reduce Radon gas levels on the property?",
+                  "ta6ed6Description": "Measures could have been undertaken during construction or while adding an extension.",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "A11.1.3.4.1",
                       "baspi5Ref": "A11.1.3.4.1",
+                      "ta6ed6Ref": "8.4.1",
                       "ta6Ref": "7.5.1",
                       "type": "string",
                       "title": "",
@@ -22975,10 +27328,10 @@
                   },
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
-                  "ta6Required": ["yesNo"]
+                  "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"]
                 }
-              },
-              "ta6Required": ["remedialMeasuresOnConstruction", "radonTest"]
+              }
             },
             "contaminatedLand": {
               "rdsRef": "Sustainability/Environmental|Natural|Situational",
@@ -23120,7 +27473,6 @@
                           },
                           "riskIndicator": {
                             "type": "string",
-
                             "title": "Is action recommended?",
                             "enum": ["Yes", "No"]
                           },
@@ -23853,6 +28205,7 @@
               "nts2Required": ["riskIndicator"],
               "ntslRequired": ["riskIndicator"],
               "ntsl2Required": ["riskIndicator"],
+              "baspi5Required": ["riskIndicator"],
               "properties": {
                 "riskIndicator": {
                   "ntsRef": "C3.2.1",
@@ -23990,7 +28343,7 @@
                 {
                   "properties": {
                     "riskIndicator": {
-                      "enum": ["No", "Not known"]
+                      "enum": ["No"]
                     }
                   }
                 },
@@ -24098,7 +28451,7 @@
                   "baspi4Ref": "A11.3.1",
                   "baspi5Ref": "A11.4.1",
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, has the property been subject to any crime, burglary or violent death?",
                   "piqRef": "A11.3.1",
                   "enum": ["Yes", "No"]
                 }
@@ -24150,7 +28503,7 @@
                 "yesNo": {
                   "baspi4Ref": "A11.4.1",
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, has the property been occupied by someone who has been cautioned or convicted of a serious crime?",
                   "enum": ["Yes", "No"]
                 }
               },
@@ -24203,7 +28556,7 @@
                   "baspi5Ref": "A11.5.1",
                   "piqRef": "A11.6.1",
                   "type": "string",
-                  "title": "",
+                  "title": "Have there been any failed purchase transactions on the property within the last 12 months?",
                   "enum": ["Yes", "No"]
                 }
               },
@@ -24251,6 +28604,8 @@
           "baspi4Ref": "A12",
           "baspi5Ref": "A12",
           "ta6Ref": "10",
+          "ta6ed6Ref": "15",
+          "sef25Ref": "M1",
           "title": "Additional Information",
           "type": "object",
           "baspi4Required": [
@@ -24264,7 +28619,59 @@
             "otherCharges"
           ],
           "ta6Required": ["otherCharges"],
+          "ta6ed6Required": ["consents", "furtherInformation"],
+          "sef25Required": ["otherMaterialIssue"],
           "properties": {
+            "consents": {
+              "ta6ed6Ref": "15.1",
+              "title": "Please supply copies of all consents that have been given under any covenants, estate management schemes or other restrictions affecting the title to the property for all actions you have disclosed in your answers to questions 5 (Alterations), 8.5 (Green Deal), 10.3 (EV charging points) and 11 (Services).",
+              "type": "object",
+              "properties": {
+                "attachments": {
+                  "ta6ed6Ref": "15.1.1",
+                  "enum": [
+                    "Attached",
+                    "To follow",
+                    "Not applicable",
+                    "Not available"
+                  ]
+                },
+                "consentsAttached": {
+                  "ta6ed6Ref": "15.1.2",
+                  "title": "List the consents that are attached",
+                  "type": "string",
+                  "ta6ed6MinLength": 1
+                },
+                "consentsToFollow": {
+                  "ta6ed6Ref": "15.1.3",
+                  "title": "List the consents to follow",
+                  "type": "string",
+                  "ta6ed6MinLength": 1
+                },
+                "consentsNotAvailable": {
+                  "ta6ed6Ref": "15.1.4",
+                  "title": "List any consents that are not available",
+                  "type": "string",
+                  "ta6ed6MinLength": 1
+                }
+              }
+            },
+            "furtherInformation": {
+              "ta6ed6Ref": "15.2",
+              "title": "If there is any further information about any of your answers supplied, provide details below and/or supply additional documents.",
+              "type": "object",
+              "properties": {
+                "details": {
+                  "ta6ed6Ref": "15.2.1",
+                  "type": "string",
+                  "ta6ed6MinLength": 1
+                },
+                "attachments": {
+                  "ta6ed6Ref": "15.2.2",
+                  "enum": ["Attached", "To follow", "Not applicable"]
+                }
+              }
+            },
             "restrictionsOnUseNotCompliedWith": {
               "baspi4Ref": "A12.1",
               "baspi5Ref": "A12.1",
@@ -24326,7 +28733,8 @@
               "baspi5Ref": "A12.2",
               "rdsRef": "Tenure/OtherMaterialIssues",
               "piqRef": "A12.2",
-              "title": "Are you aware of any other material issue or information which relates to the property or has anything occurred which may affect the average person’s decision to proceed?",
+              "sef25Ref": "M1.1",
+              "title": "Are you aware of any other material issue or information which relates to the property or has anything occurred which may affect the average person's decision to proceed?",
               "description": "This disclosure is required under the Consumer Protection from Unfair Trading Regulations 2008",
               "type": "object",
               "properties": {
@@ -24334,6 +28742,7 @@
                   "baspi4Ref": "A12.2.1",
                   "baspi5Ref": "A12.2.1",
                   "piqRef": "A12.2.1",
+                  "sef25Ref": "M1.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -24341,6 +28750,7 @@
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
+              "sef25Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -24361,6 +28771,7 @@
                       "baspi4Ref": "A12.2.2",
                       "baspi5Ref": "A12.2.2",
                       "piqRef": "A12.2.2",
+                      "sef25Ref": "M1.1.2",
                       "title": "Please describe this issue and any action that has been taken, if applicable.",
                       "type": "string",
                       "minLength": 1
@@ -24374,7 +28785,8 @@
                     }
                   },
                   "baspi4Required": ["details"],
-                  "baspi5Required": ["details"]
+                  "baspi5Required": ["details"],
+                  "sef25Required": ["details"]
                 }
               ]
             },
@@ -24452,13 +28864,12 @@
             "consumerProtectionRegulationsResponse": {
               "baspi4Ref": "A13.1",
               "baspi5Ref": "A13.1",
-              "title": "Seller’s declaration",
+              "title": "Seller's declaration",
               "description": "I/we confirm the answers to be truthful and accurate and to the best of my/our knowledge. The questions have been designed to assist with the disclosure of material information and any misleading or incorrect answers are likely to be exposed later in the legal process which may hinder my/our sale. I/we will provide my property lawyer with the additional documentation in support of the information supplied on this form. If there are any changes which alter the information provided, I/we will immediately notify the person marketing the property as well as my/our property lawyer.",
               "type": "boolean"
             }
           }
         },
-
         "legalOwners": {
           "baspi4Ref": "B1",
           "baspi5Ref": "B1",
@@ -24549,6 +28960,8 @@
           "baspi4Ref": "B2.1",
           "baspi5Ref": "B2.1",
           "ta6Ref": "1",
+          "ta6ed6Ref": "2",
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.2",
           "piqRef": "B3.1",
           "title": "Legal Boundaries",
           "description": "",
@@ -24579,13 +28992,18 @@
             "adjacentLandIncluded",
             "flyingFreehold"
           ],
+          "ta6ed6Required": [
+            "ownership",
+            "haveBoundaryFeaturesMoved",
+            "flyingFreehold"
+          ],
           "properties": {
             "partOutsideLegalOwnership": {
               "baspi4Ref": "A9.1",
               "baspi5Ref": "A9.1",
               "rdsRef": "Tenure/Interests",
               "piqRef": "A9.1",
-              "title": "Is any part of the property outside the seller’s legal ownership?",
+              "title": "Is any part of the property outside the seller's legal ownership?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -24781,6 +29199,7 @@
               "baspi4Ref": "B2.1.0",
               "baspi5Ref": "B2.1.0",
               "ta6Ref": "1",
+              "ta6ed6Ref": "2",
               "rdsRef": "Tenure/Boundaries",
               "title": "Boundary ownership",
               "description": "If the property is leasehold this section, or parts of it, may not apply.",
@@ -24788,11 +29207,13 @@
               "baspi4Required": ["areBoundariesUniform"],
               "baspi5Required": ["areBoundariesUniform"],
               "ta6Required": ["areBoundariesUniform"],
+              "ta6ed6Required": ["areBoundariesUniform"],
               "properties": {
                 "areBoundariesUniform": {
                   "baspi4Ref": "B2.1.0.1",
                   "baspi5Ref": "B2.1.0.1",
                   "ta6Ref": "1.2",
+                  "ta6ed6Ref": "2.1",
                   "title": "Are the boundaries uniform?",
                   "type": "string",
                   "enum": ["Yes", "No", "Not applicable"]
@@ -24811,6 +29232,7 @@
                       "baspi4Ref": "B2.1.0.2",
                       "baspi5Ref": "B2.1.0.2",
                       "ta6Ref": "1.1",
+                      "ta6ed6Ref": "2.1",
                       "title": "Please indicate who has repaired, or treated as belonging to them, each of the boundaries. Identify each boundary as if you were looking at the property from the road.",
                       "ta6title": "Looking towards the property from the road, who owns or accepts responsibility to maintain or repair the boundary features:",
                       "type": "object",
@@ -24820,6 +29242,7 @@
                           "baspi5Ref": "B2.1.1",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1a",
+                          "ta6ed6Ref": "2.1a",
                           "piqRef": "B3.1.1",
                           "title": "On the left",
                           "type": "string",
@@ -24830,6 +29253,7 @@
                           "baspi5Ref": "B2.1.2",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1b",
+                          "ta6ed6Ref": "2.1b",
                           "piqRef": "B3.1.2",
                           "title": "On the right",
                           "type": "string",
@@ -24840,6 +29264,7 @@
                           "baspi5Ref": "B2.1.3",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1c",
+                          "ta6ed6Ref": "2.1c",
                           "piqRef": "B3.1.3",
                           "title": "At the rear",
                           "type": "string",
@@ -24850,6 +29275,7 @@
                           "baspi5Ref": "B2.1.4",
                           "rdsRef": "Tenure/Boundaries",
                           "ta6Ref": "1.1d",
+                          "ta6ed6Ref": "2.1d",
                           "piqRef": "B3.1.4",
                           "title": "At the front",
                           "type": "string",
@@ -24858,7 +29284,8 @@
                       },
                       "baspi4Required": ["left", "right", "rear", "front"],
                       "baspi5Required": ["left", "right", "rear", "front"],
-                      "ta6Required": ["left", "right", "rear", "front"]
+                      "ta6Required": ["left", "right", "rear", "front"],
+                      "ta6ed6Required": ["left", "right", "rear", "front"]
                     }
                   }
                 },
@@ -24871,6 +29298,7 @@
                       "baspi4Ref": "B2.1.5",
                       "baspi5Ref": "B2.1.5",
                       "ta6Ref": "1.2.1",
+                      "ta6ed6Ref": "2.2.1",
                       "title": "Please indicate ownership or those you have repaired by written description or marking them on a plan of the property",
                       "type": "string",
                       "minLength": 1
@@ -24879,6 +29307,7 @@
                       "baspi4Ref": "B2.1.6",
                       "baspi5Ref": "B2.1.6",
                       "ta6Ref": "1.2.2",
+                      "ta6ed6Ref": "2.2",
                       "title": "Attachments",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
@@ -24886,7 +29315,8 @@
                   },
                   "baspi4Required": ["details", "attachments"],
                   "baspi5Required": ["details", "attachments"],
-                  "ta6Required": ["details", "attachments"]
+                  "ta6Required": ["details", "attachments"],
+                  "ta6ed6Required": ["details", "attachments"]
                 },
                 {
                   "properties": {
@@ -24902,9 +29332,11 @@
               "baspi5Ref": "B2.2",
               "rdsRef": "Tenure/Boundaries",
               "ta6Ref": "1.3",
+              "ta6ed6Ref": "2.3",
               "piqRef": "B3.3",
               "title": "Has any boundary features been moved during your ownership or in the last 10 years, to your knowledge?",
-              "ta6Title": "Is the seller aware of any boundary feature having been moved in the last 10 years or during the seller’s period of ownership if longer?",
+              "ta6Title": "Is the seller aware of any boundary feature having been moved in the last 10 years or during the seller's period of ownership if longer?",
+              "ta6ed6Title": "Are you aware of any boundary feature being moved, any adjacent land being added to the property, or any neighbour taking over or building on any part of your property?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -24912,6 +29344,8 @@
                   "baspi5Ref": "B2.2.1",
                   "piqRef": "B3.3.1",
                   "ta6Ref": "1.3.1",
+                  "ta6ed6Ref": "2.3.1",
+                  "ta6ed6Enum": ["Yes", "No"],
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "Not applicable"]
@@ -24920,6 +29354,8 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Description": "If yes, please give details:",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -24927,7 +29363,8 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No", "Not applicable"]
+                      "enum": ["No", "Not applicable"],
+                      "ta6ed6Enum": ["No"]
                     }
                   }
                 },
@@ -24940,6 +29377,7 @@
                       "baspi4Ref": "B2.2.2",
                       "baspi5Ref": "B2.2.2",
                       "ta6Ref": "1.3.2",
+                      "ta6ed6Ref": "2.3.2",
                       "piqRef": "B3.3.2",
                       "title": "Details",
                       "type": "string",
@@ -24948,7 +29386,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -24958,7 +29397,7 @@
               "rdsRef": "Property/Flags,Property/GUID/name='UPRN'&id=?",
               "ta6Ref": "1.4",
               "title": "Has any adjacent land or property been purchased by you that will be included in the sale?",
-              "ta6Title": "During the seller’s ownership, has any adjacent land or property been purchased by the seller?",
+              "ta6Title": "During the seller's ownership, has any adjacent land or property been purchased by the seller?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -25010,24 +29449,34 @@
               "baspi5Ref": "B2.5",
               "rdsRef": "Tenure/tenure=?",
               "ta6Ref": "1.5",
+              "ta6ed6Ref": "2.4",
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.2.4",
               "title": "Is there a flying freehold?",
               "ta6Title": "Does any part of the property or any building on the property overhang, or project under, the boundary of the neighbouring property or road, for example cellars under the pavement, overhanging eaves or covered walkways?",
+              "ta6ed6Title": "Does any part of the property or any building on the property overhang or project under the boundary of the neighbouring property or road? For example, cellars under the pavement, overhanging eaves or covered walkways.",
               "description": "NOTE: a flying freehold is when part of the property overhangs a neighbour's property or an accessway - e.g. a terrace house where part of the upstairs is over an accessway which belongs to someone else.",
               "ta6Description": "",
+              "ta6ed6Description": "If yes, please give details:",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "B2.5.1",
                   "baspi5Ref": "B2.5.1",
                   "ta6Ref": "1.5.1",
+                  "ta6ed6Ref": "2.4.1",
+                  "ta6ed6CompatRef": "TA6ED6-COMPAT.2.4.1",
+                  "ta6ed6Enum": ["Yes", "No", "Not known"],
+                  "ta6ed6CompatEnum": ["Yes", "No", "Not known"],
                   "type": "string",
                   "title": "",
-                  "enum": ["Yes", "No", "Not applicable"]
+                  "enum": ["Yes", "No", "Not applicable", "Not known"]
                 }
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6CompatRequired": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25035,7 +29484,10 @@
                 {
                   "properties": {
                     "yesNo": {
-                      "enum": ["No", "Not applicable"]
+                      "ta6ed6CompatRef": "TA6ED6-COMPAT.2.4.1.no",
+                      "enum": ["No", "Not applicable", "Not known"],
+                      "ta6ed6Enum": ["No", "Not known"],
+                      "ta6ed6CompatEnum": ["No", "Not known"]
                     }
                   }
                 },
@@ -25048,6 +29500,7 @@
                       "baspi4Ref": "B2.5.2",
                       "baspi5Ref": "B2.5.2",
                       "ta6Ref": "1.5.2",
+                      "ta6ed6Ref": "2.4.2",
                       "title": "Details",
                       "type": "string",
                       "minLength": 1
@@ -25055,7 +29508,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             }
@@ -25065,6 +29519,7 @@
           "baspi4Ref": "B3",
           "baspi5Ref": "B3",
           "ta6Ref": "8",
+          "ta6ed6Ref": "9",
           "title": "Services Crossing Other Property",
           "type": "object",
           "baspi4Required": [
@@ -25082,21 +29537,29 @@
             "pipesWiresCablesDrainsFromProperty",
             "formalOrInformalAgreements"
           ],
+          "ta6ed6Required": [
+            "pipesWiresCablesDrainsToProperty",
+            "pipesWiresCablesDrainsFromProperty",
+            "formalOrInformalAgreements"
+          ],
           "properties": {
             "pipesWiresCablesDrainsToProperty": {
               "baspi4Ref": "B3.1",
               "baspi5Ref": "B3.1",
               "rdsRef": "Services/.../Located",
               "ta6Ref": "8.7",
+              "ta6ed6Ref": "9.7",
               "piqRef": "B4.1",
               "title": "Are you aware of any pipes, wires, cables or drains bringing services to the property which cross any neighbouring land or property?",
-              "ta6Title": "Do any drains, pipes or wires serving the property cross any neighbour’s property?",
+              "ta6Title": "Do any drains, pipes or wires serving the property cross any neighbour's property?",
+              "ta6ed6Title": "Are you aware of any drains, pipes or wires serving the property that cross any other property?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "B3.1.1",
                   "baspi5Ref": "B3.1.1",
                   "ta6Ref": "8.7.1",
+                  "ta6ed6Ref": "9.7.1",
                   "piqRef": "B4.1.1",
                   "type": "string",
                   "title": "",
@@ -25106,6 +29569,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25127,6 +29591,7 @@
                       "baspi5Ref": "B3.1.2",
                       "piqRef": "B4.1.2",
                       "ta6Ref": "8.7.2",
+                      "ta6ed6Ref": "9.7.2",
                       "title": "Please provide details",
                       "type": "string",
                       "minLength": 1
@@ -25141,7 +29606,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -25150,15 +29616,17 @@
               "baspi5Ref": "B3.2",
               "rdsRef": "Services/.../Located *with Property entities and references for the related properties etc",
               "ta6Ref": "8.8",
+              "ta6ed6Ref": "9.8",
               "piqRef": "B4.2",
               "title": "Are you aware of any pipes, wires, cables or drains taking services to neighbouring property cross this property?",
-              "ta6Ttle": "Do any drains, pipes or wires leading to any neighbour’s property cross the property?",
+              "ta6Ttle": "Do any drains, pipes or wires leading to any neighbour's property cross the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "B3.2.1",
                   "baspi5Ref": "B3.2.1",
                   "ta6Ref": "8.8.1",
+                  "ta6ed6Ref": "9.8.1",
                   "piqRef": "B4.2.1",
                   "type": "string",
                   "title": "",
@@ -25168,6 +29636,8 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Title": "Are you aware of any drains, pipes or wires leading to any other property that cross the property?",
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25188,6 +29658,7 @@
                       "baspi4Ref": "B3.2.2",
                       "baspi5Ref": "B3.2.2",
                       "ta6Ref": "8.8.2",
+                      "ta6ed6Ref": "9.8.2",
                       "piqRef": "B4.2.2",
                       "title": "Please provide details",
                       "type": "string",
@@ -25203,7 +29674,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -25212,15 +29684,18 @@
               "baspi5Ref": "B3.3",
               "rdsRef": "Services/.../Consent",
               "ta6Ref": "8.9",
+              "ta6ed6Ref": "9.9",
               "piqRef": "B4.3",
               "title": "Are you aware of any formal or informal agreements or arrangements for pipes, wires cables or drains to cross either your property or neighbouring property?",
               "ta6Title": "Is there any agreement or arrangement about drains, pipes or wires?",
+              "ta6ed6Title": "Is there any agreement or arrangement about drains, pipes or wires?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "B3.3.1",
                   "baspi5Ref": "B3.3.1",
                   "ta6Ref": "8.9.1",
+                  "ta6ed6Ref": "9.9.1",
                   "piqRef": "B4.3.1",
                   "type": "string",
                   "title": "",
@@ -25230,6 +29705,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25250,6 +29726,7 @@
                       "baspi4Ref": "B3.3.2",
                       "baspi5Ref": "B3.3.2",
                       "ta6Ref": "8.9.2",
+                      "ta6ed6Ref": "9.9.2",
                       "piqRef": "B4.3.2",
                       "title": "Please provide details",
                       "type": "string",
@@ -25259,6 +29736,7 @@
                       "baspi4Ref": "B3.3.3",
                       "baspi5Ref": "B3.3.3",
                       "ta6Ref": "8.9.3",
+                      "ta6ed6Ref": "9.9.3",
                       "title": "Please supply a copy",
                       "type": "string",
                       "enum": ["Attached", "To follow"]
@@ -25266,7 +29744,8 @@
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             }
@@ -25276,6 +29755,7 @@
           "baspi4Ref": "B4",
           "baspi5Ref": "B4",
           "ta6Ref": "12",
+          "ta6ed6Ref": "11",
           "title": "Electrical Works",
           "type": "object",
           "baspi4Required": [
@@ -25290,12 +29770,17 @@
             "testedByQualifiedElectrician",
             "electricalWorkSince2005"
           ],
+          "ta6ed6Required": [
+            "testedByQualifiedElectrician",
+            "electricalWorkSince2005"
+          ],
           "properties": {
             "testedByQualifiedElectrician": {
               "baspi4Ref": "B4.1",
               "baspi5Ref": "B4.1",
               "rdsRef": "Objects/Servicing",
               "ta6Ref": "12.1",
+              "ta6ed6Ref": "11.3",
               "piqRef": "B7.1",
               "title": "Have the electrics at the property been tested by a qualified electrician?",
               "type": "object",
@@ -25304,6 +29789,7 @@
                   "baspi4Ref": "B4.1.1",
                   "baspi5Ref": "B4.1.1",
                   "ta6Ref": "12.1.1",
+                  "ta6ed6Ref": "11.3",
                   "piqRef": "B7.1.1",
                   "type": "string",
                   "title": "",
@@ -25313,6 +29799,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25333,6 +29820,7 @@
                       "baspi4Ref": "B4.1.2",
                       "baspi5Ref": "B4.1.2",
                       "ta6Ref": "12.1.2",
+                      "ta6ed6Ref": "11.3",
                       "piqRef": "B7.1.2",
                       "title": "State the year they were last tested",
                       "type": "integer"
@@ -25341,14 +29829,20 @@
                       "baspi4Ref": "B4.1.3",
                       "baspi5Ref": "B4.1.3",
                       "ta6Ref": "12.1.3",
+                      "ta6ed6Ref": "11.3",
                       "title": "Please upload the test certificate.",
+                      "ta6ed6Title": "Please supply a copy of the EICR",
                       "type": "string",
-                      "enum": ["Attached", "To follow"]
+                      "enum": ["Attached", "To follow", "Not available"],
+                      "ta6Enum": ["Attached", "To follow"],
+                      "baspi4Enum": ["Attached", "To follow"],
+                      "baspi5Enum": ["Attached", "To follow"]
                     }
                   },
                   "baspi4Required": ["yearTested", "attachments"],
                   "baspi5Required": ["yearTested", "attachments"],
-                  "ta6Required": ["yearTested", "attachments"]
+                  "ta6Required": ["yearTested", "attachments"],
+                  "ta6ed6Required": ["yearTested", "attachments"]
                 }
               ]
             },
@@ -25357,6 +29851,7 @@
               "baspi5Ref": "B4.2",
               "rdsRef": "WorksAlterationsChanges/Consent,WorksAlterationsChanges/Consent/Certificates",
               "ta6Ref": "12.2",
+              "ta6ed6Ref": "11.1",
               "piqRef": "B7.2",
               "title": "Since 1st January 2005, has any electrical work been carried out to the property?",
               "type": "object",
@@ -25365,6 +29860,7 @@
                   "baspi4Ref": "B4.2.1",
                   "baspi5Ref": "B4.2.1",
                   "ta6Ref": "12.2.1",
+                  "ta6ed6Ref": "11.1",
                   "piqRef": "B7.2.1",
                   "type": "string",
                   "title": "",
@@ -25376,6 +29872,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -25396,25 +29893,30 @@
                       "baspi4Ref": "B4.2.2",
                       "baspi5Ref": "B4.2.2",
                       "piqRef": "B7.2.2",
+                      "ta6ed6Ref": "11.2",
                       "title": "State the year the work was carried out",
                       "type": "integer"
                     },
                     "details": {
                       "baspi4Ref": "B4.2.3",
                       "baspi5Ref": "B4.2.3",
+                      "ta6ed6Ref": "11.1",
                       "title": "Provide details",
                       "type": "string",
                       "minLength": 1
                     },
                     "suppliedCertificate": {
                       "title": "Please supply one of the following:",
+                      "ta6ed6Title": "Please supply any certificates for electrical installation work",
                       "type": "object",
                       "baspi4Ref": "B4.2.4.1",
                       "baspi5Ref": "B4.2.4.1",
                       "ta6Ref": "12.2.2a",
+                      "ta6ed6Ref": "11.2",
                       "baspi4Required": ["certificateType", "attachments"],
                       "baspi5Required": ["certificateType", "attachments"],
                       "ta6Required": ["certificateType", "attachments"],
+                      "ta6ed6Required": ["attachments"],
                       "properties": {
                         "certificateType": {
                           "baspi4Ref": "B4.2.3.1",
@@ -25431,9 +29933,13 @@
                           "baspi4Ref": "B4.2.3.2",
                           "baspi5Ref": "B4.2.3.2",
                           "ta6Ref": "12.2.2a.2",
+                          "ta6ed6Ref": "11.2",
                           "title": "Attachments",
                           "type": "string",
-                          "enum": ["Attached", "To follow"]
+                          "enum": ["Attached", "To follow", "Not available"],
+                          "ta6Enum": ["Attached", "To follow"],
+                          "baspi4Enum": ["Attached", "To follow"],
+                          "baspi5Enum": ["Attached", "To follow"]
                         }
                       }
                     }
@@ -25448,7 +29954,8 @@
                     "details",
                     "suppliedCertificate"
                   ],
-                  "ta6Required": ["suppliedCertificate"]
+                  "ta6Required": ["suppliedCertificate"],
+                  "ta6ed6Required": ["details", "suppliedCertificate"]
                 }
               ]
             }
@@ -25652,18 +30159,24 @@
           "baspi4Ref": "B5",
           "baspi5Ref": "B5",
           "ta6Ref": "5",
+          "ta6ed6Ref": "6",
+          "sef25Ref": "W1",
           "title": "Guarantees, Warranties and Indemnity Insurances",
           "type": "object",
           "baspi4Required": ["hasValidGuaranteesOrWarranties"],
           "baspi5Required": ["hasValidGuaranteesOrWarranties"],
           "ta6Required": ["hasValidGuaranteesOrWarranties"],
+          "ta6ed6Required": ["hasValidGuaranteesOrWarranties"],
+          "sef25Required": ["hasValidGuaranteesOrWarranties"],
           "properties": {
             "hasValidGuaranteesOrWarranties": {
               "baspi4Ref": "B5.1",
               "baspi5Ref": "B5.1",
               "ta6Ref": "5.1",
+              "ta6ed6Ref": "6.1",
               "rdsRef": "Certificates",
               "piqRef": "B5.1",
+              "sef25Ref": "W1.0",
               "title": "Are there any valid guarantees, warranties or indemnity insurances relating to this property?",
               "type": "string",
               "enum": ["Yes", "No"]
@@ -25689,15 +30202,19 @@
                   "baspi4Ref": "B5.1.1",
                   "baspi5Ref": "B5.1.1",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1a",
                   "ta6Ref": "5.1a",
                   "piqRef": "B5.1.1",
+                  "sef25Ref": "W1.1",
                   "title": "New Home Warranty (NHBC or similar)",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.1.1",
                       "baspi5Ref": "B5.1.1.1",
+                      "ta6ed6Ref": "6.1a1",
                       "ta6Ref": "5.1a1",
+                      "sef25Ref": "W1.1.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -25706,6 +30223,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25733,6 +30252,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.3",
                           "baspi5Ref": "B5.1.1.3",
+                          "ta6ed6Ref": "6.1a3",
                           "ta6Ref": "5.1a3",
                           "title": "",
                           "type": "string",
@@ -25741,7 +30261,8 @@
                       },
                       "baspi4Required": ["details", "attachments"],
                       "baspi5Required": ["details", "attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -25749,15 +30270,19 @@
                   "baspi4Ref": "B5.1.2",
                   "baspi5Ref": "B5.1.2",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1e",
                   "ta6Ref": "5.1f",
+                  "sef25Ref": "W1.2",
                   "title": "Roofing work",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.2.1",
                       "baspi5Ref": "B5.1.2.1",
+                      "ta6ed6Ref": "6.1e1",
                       "ta6Ref": "5.1f1",
                       "piqRef": "B5.1.2",
+                      "sef25Ref": "W1.2.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -25766,6 +30291,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25785,6 +30312,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1e2",
                           "ta6Ref": "5.1f2",
                           "title": "",
                           "type": "string",
@@ -25793,7 +30321,8 @@
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -25801,15 +30330,19 @@
                   "baspi4Ref": "B5.1.3",
                   "baspi5Ref": "B5.1.3",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1b",
                   "ta6Ref": "5.1b",
                   "piqRef": "B5.1.3",
+                  "sef25Ref": "W1.3",
                   "title": "Damp proofing treatment",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.3.1",
                       "baspi5Ref": "B5.1.3.1",
+                      "ta6ed6Ref": "6.1b1",
                       "ta6Ref": "5.1b1",
+                      "sef25Ref": "W1.3.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -25818,6 +30351,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25837,6 +30372,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1b2",
                           "ta6Ref": "5.1b2",
                           "title": "",
                           "type": "string",
@@ -25845,7 +30381,8 @@
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -25853,6 +30390,7 @@
                   "baspi4Ref": "B5.1.4",
                   "baspi5Ref": "B5.1.4",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1c",
                   "ta6Ref": "5.1c",
                   "piqRef": "B5.1.4",
                   "title": "Timber rot or infestation treatment",
@@ -25861,6 +30399,7 @@
                     "yesNo": {
                       "baspi4Ref": "B5.1.4.1",
                       "baspi5Ref": "B5.1.4.1",
+                      "ta6ed6Ref": "6.1c1",
                       "ta6Ref": "5.1c1",
                       "type": "string",
                       "title": "",
@@ -25870,6 +30409,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25889,6 +30429,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1c2",
                           "ta6Ref": "5.1c2",
                           "title": "",
                           "type": "string",
@@ -25897,7 +30438,8 @@
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -25905,15 +30447,20 @@
                   "baspi4Ref": "B5.1.5",
                   "baspi5Ref": "B5.1.5",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1f",
                   "ta6Ref": "5.1g",
                   "piqRef": "B5.1.5",
+                  "sef25Ref": "W1.4",
                   "title": "Central heating and/or plumbing",
+                  "ta6ed6Title": "Boiler or heating systems",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.5.1",
                       "baspi5Ref": "B5.1.5.1",
+                      "ta6ed6Ref": "6.1f1",
                       "ta6Ref": "5.1g1",
+                      "sef25Ref": "W1.4.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -25922,6 +30469,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25941,6 +30490,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1f2",
                           "ta6Ref": "5.1g2",
                           "title": "",
                           "type": "string",
@@ -25949,7 +30499,8 @@
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -25957,15 +30508,19 @@
                   "baspi4Ref": "B5.1.6",
                   "baspi5Ref": "B5.1.6",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1d",
                   "ta6Ref": "5.1d",
                   "piqRef": "B5.1.6",
+                  "sef25Ref": "W1.8",
                   "title": "Double glazing (windows, doors, roof lights, conservatory etc)",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.6.1",
                       "baspi5Ref": "B5.1.6.1",
+                      "ta6ed6Ref": "6.1d1",
                       "ta6Ref": "5.1d1",
+                      "sef25Ref": "W1.8.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -25974,6 +30529,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -25993,15 +30550,50 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1d2",
                           "ta6Ref": "5.1d2",
                           "title": "",
                           "type": "string",
                           "enum": ["Attached", "To follow"]
+                        },
+                        "fensaCertificates": {
+                          "type": "object",
+                          "properties": {
+                            "certificates": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "certificateId": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "numberOfWindows": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "numberOfDoors": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "certificateIssued": {
+                                    "type": "string",
+                                    "format": "date"
+                                  },
+                                  "workCompleted": {
+                                    "type": "string",
+                                    "format": "date"
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -26011,6 +30603,7 @@
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1e",
                   "piqRef": "B5.1.7",
+                  "sef25Ref": "W1.5",
                   "title": "Electrical repair or installation",
                   "type": "object",
                   "properties": {
@@ -26018,6 +30611,7 @@
                       "baspi4Ref": "B5.1.7.1",
                       "baspi5Ref": "B5.1.7.1",
                       "ta6Ref": "5.1e1",
+                      "sef25Ref": "W1.5.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -26025,6 +30619,7 @@
                   },
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
@@ -26061,15 +30656,19 @@
                   "baspi4Ref": "B5.1.8",
                   "baspi5Ref": "B5.1.8",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1g",
                   "ta6Ref": "5.1h",
                   "piqRef": "B5.1.8",
+                  "sef25Ref": "W1.6",
                   "title": "Underpinning or other preventative work and/or remedial action relating to subsidence",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.8.1",
                       "baspi5Ref": "B5.1.8.1",
+                      "ta6ed6Ref": "6.1g1",
                       "ta6Ref": "5.1h1",
+                      "sef25Ref": "W1.6.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -26078,6 +30677,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -26097,6 +30698,7 @@
                         "attachments": {
                           "baspi4Ref": "B5.1.1.2",
                           "baspi5Ref": "B5.1.1.2",
+                          "ta6ed6Ref": "6.1g2",
                           "ta6Ref": "5.1h2",
                           "title": "",
                           "type": "string",
@@ -26105,7 +30707,49 @@
                       },
                       "baspi4Required": ["attachments"],
                       "baspi5Required": ["attachments"],
-                      "ta6Required": ["attachments"]
+                      "ta6Required": ["attachments"],
+                      "ta6ed6Required": ["attachments"]
+                    }
+                  ]
+                },
+                "insulation": {
+                  "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.1h",
+                  "title": "Insulation",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1h1",
+                      "type": "string",
+                      "title": "",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "ta6ed6Required": ["yesNo"],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1h2",
+                          "title": "",
+                          "type": "string",
+                          "enum": ["Attached", "To follow"]
+                        }
+                      },
+                      "ta6ed6Required": ["attachments"]
                     }
                   ]
                 },
@@ -26161,14 +30805,18 @@
                   "baspi5Ref": "B5.1.10",
                   "rdsRef": "Certificates",
                   "ta6Ref": "5.1i",
+                  "ta6ed6Ref": "6.1i",
                   "piqRef": "B5.1.10",
+                  "sef25Ref": "W1.7",
                   "title": "Other Guarantees or warranties",
                   "type": "object",
                   "properties": {
                     "yesNo": {
                       "baspi4Ref": "B5.1.10.1",
                       "baspi5Ref": "B5.1.10.1",
+                      "ta6ed6Ref": "6.1i1",
                       "ta6Ref": "5.1i1",
+                      "sef25Ref": "W1.7.1",
                       "type": "string",
                       "title": "",
                       "enum": ["Yes", "No"]
@@ -26177,6 +30825,8 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
+                  "sef25Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -26196,12 +30846,15 @@
                         "details": {
                           "baspi4Ref": "B5.1.10.2",
                           "baspi5Ref": "B5.1.10.2",
+                          "ta6ed6Ref": "6.1i2",
                           "ta6Ref": "5.1i2",
+                          "sef25Ref": "W1.7.2",
                           "title": "Please provide details",
                           "type": "string",
                           "minLength": 1
                         },
                         "attachments": {
+                          "ta6ed6Ref": "6.1i3",
                           "ta6Ref": "5.1i3",
                           "title": "",
                           "type": "string",
@@ -26210,7 +30863,9 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details", "attachments"]
+                      "ta6Required": ["details", "attachments"],
+                      "ta6ed6Required": ["details", "attachments"],
+                      "sef25Required": ["details"]
                     }
                   ]
                 },
@@ -26218,6 +30873,7 @@
                   "baspi4Ref": "B5.2",
                   "baspi5Ref": "B5.2",
                   "rdsRef": "Certificates",
+                  "ta6ed6Ref": "6.2",
                   "ta6Ref": "5.2",
                   "piqRef": "B5.2",
                   "title": "Are there any outstanding claims or current applications relating to any of the above?",
@@ -26227,6 +30883,7 @@
                     "yesNo": {
                       "baspi4Ref": "B5.2.1",
                       "baspi5Ref": "B5.2.1",
+                      "ta6ed6Ref": "6.2.1",
                       "ta6Ref": "5.2.1",
                       "piqRef": "B5.2.1",
                       "type": "string",
@@ -26237,6 +30894,7 @@
                   "baspi4Required": ["yesNo"],
                   "baspi5Required": ["yesNo"],
                   "ta6Required": ["yesNo"],
+                  "ta6ed6Required": ["yesNo"],
                   "discriminator": {
                     "propertyName": "yesNo"
                   },
@@ -26256,6 +30914,7 @@
                         "details": {
                           "baspi4Ref": "B5.2.2",
                           "baspi5Ref": "B5.2.2",
+                          "ta6ed6Ref": "6.2.2",
                           "ta6Ref": "5.2.2",
                           "title": "Please provide details",
                           "type": "string",
@@ -26272,7 +30931,47 @@
                       },
                       "baspi4Required": ["details"],
                       "baspi5Required": ["details"],
-                      "ta6Required": ["details"]
+                      "ta6Required": ["details"],
+                      "ta6ed6Required": ["details"]
+                    }
+                  ]
+                },
+                "breachOfTermsOrConditions": {
+                  "ta6ed6Ref": "6.3",
+                  "title": "Are you aware of anything that may breach the terms and conditions of any of these guarantees or warranties?",
+                  "type": "object",
+                  "ta6ed6Required": ["yesNo"],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.3.1",
+                      "type": "string",
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["No"]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": ["Yes"]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "6.3.2",
+                          "title": "Please give details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "ta6ed6Required": ["details"]
                     }
                   ]
                 },
@@ -26370,6 +31069,28 @@
                 "subsidenceWork",
                 "otherGuarantees",
                 "outstandingClaimsOrApplications"
+              ],
+              "ta6ed6Required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "timberRotOrInfestationTreatment",
+                "centralHeatingAndorPlumbing",
+                "doubleGlazing",
+                "subsidenceWork",
+                "insulation",
+                "otherGuarantees",
+                "outstandingClaimsOrApplications",
+                "breachOfTermsOrConditions"
+              ],
+              "sef25Required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "centralHeatingAndorPlumbing",
+                "electricalRepairOrInstallation",
+                "subsidenceWork",
+                "otherGuarantees"
               ]
             }
           ]
@@ -26378,23 +31099,29 @@
           "baspi4Ref": "B6",
           "baspi5Ref": "B6",
           "ta6Ref": "11",
+          "ta6ed6Ref": "13",
           "title": "Occupiers",
           "type": "object",
           "baspi4Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
           "baspi5Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
+          "ta6Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
+          "ta6ed6Required": ["sellerLivesAtProperty", "othersAged17OrOver"],
           "properties": {
             "sellerLivesAtProperty": {
               "baspi4Ref": "B6.1",
               "baspi5Ref": "B6.1",
               "rdsRef": "Property/Flags",
               "ta6Ref": "11.1",
+              "ta6ed6Ref": "13.3",
               "title": "Does the seller live at the property?",
+              "ta6ed6Title": "Do you live at the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "B6.1.1",
                   "baspi5Ref": "B6.1.1",
                   "ta6Ref": "11.1.1",
+                  "ta6ed6Ref": "13.3.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No"]
@@ -26402,22 +31129,27 @@
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
-              "ta6Required": ["yesNo"]
+              "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"]
             },
             "othersAged17OrOver": {
               "baspi4Ref": "B6.2",
               "baspi5Ref": "B6.2",
               "rdsRef": "Participants",
               "ta6Ref": "11.2",
+              "ta6ed6Ref": "13.4",
               "type": "object",
               "baspi4Required": ["hasOthersAged17OrOver"],
               "baspi5Required": ["hasOthersAged17OrOver"],
+              "ta6Required": ["hasOthersAged17OrOver"],
+              "ta6ed6Required": ["hasOthersAged17OrOver"],
               "properties": {
                 "hasOthersAged17OrOver": {
                   "baspi4Ref": "B6.2.1",
                   "baspi5Ref": "B6.2.1",
                   "rdsRef": "Participants",
                   "ta6Ref": "11.2.1",
+                  "ta6ed6Ref": "13.4",
                   "piqRef": "B8.1",
                   "title": "Other than the sellers, does anyone else aged 17 or over live at the property?",
                   "type": "string",
@@ -26444,7 +31176,9 @@
                       "baspi4Ref": "B6.2.2",
                       "baspi5Ref": "B6.2.2",
                       "ta6Ref": "11.3",
+                      "ta6ed6Ref": "13.4a",
                       "piqRef": "B8.1.1",
+                      "ta6ed6Title": "(a) state the full names of any occupiers (other than the sellers) aged 17 or over:",
                       "title": "Please provide their full names and ages.",
                       "type": "string",
                       "minLength": 1
@@ -26454,6 +31188,7 @@
                       "baspi5Ref": "B6.2.3",
                       "rdsRef": "Property/Flags",
                       "ta6Ref": "11.4",
+                      "ta6ed6Ref": "13.4b",
                       "title": "Are any of them tenants or lodgers?",
                       "type": "object",
                       "properties": {
@@ -26461,6 +31196,7 @@
                           "baspi4Ref": "B6.2.2.1",
                           "baspi5Ref": "B6.2.2.1",
                           "ta6Ref": "11.4.1",
+                          "ta6ed6Ref": "13.4b1",
                           "type": "string",
                           "title": "",
                           "enum": ["Yes", "No"]
@@ -26468,23 +31204,28 @@
                       },
                       "baspi4Required": ["yesNo"],
                       "baspi5Required": ["yesNo"],
-                      "ta6Required": ["yesNo"]
+                      "ta6Required": ["yesNo"],
+                      "ta6ed6Required": ["yesNo"]
                     },
                     "vacantPossession": {
                       "baspi4Ref": "B6.2.4",
                       "baspi5Ref": "B6.2.4",
                       "ta6Ref": "11.5",
+                      "ta6ed6Ref": "13.5",
                       "type": "object",
                       "baspi4Required": ["soldWithVacantPossession"],
                       "baspi5Required": ["soldWithVacantPossession"],
                       "ta6Required": ["soldWithVacantPossession"],
+                      "ta6ed6Required": ["soldWithVacantPossession"],
                       "properties": {
                         "soldWithVacantPossession": {
                           "baspi4Ref": "B6.2.4.1",
                           "baspi5Ref": "B6.2.4.1",
+                          "ta6ed6Ref": "13.5.1",
                           "ta6Ref": "11.5.1",
                           "type": "string",
                           "title": "Is the property being sold with vacant possession?",
+                          "description": "(empty of all occupiers, rubbish and any contents or fittings not included in the sale)",
                           "enum": ["Yes", "No"]
                         }
                       },
@@ -26499,13 +31240,16 @@
                             },
                             "details": {
                               "baspi4Ref": "B6.2.4.2",
+                              "ta6ed6Ref": "13.7a",
                               "baspi5Ref": "B6.2.4.2",
                               "title": "Please provide details (e.g. the property is sold let to tenants)",
+                              "ta6ed6Title": "Please provide details (e.g. the property is sold let to tenants)",
                               "type": "string",
                               "minLength": 1
                             },
                             "attachments": {
                               "baspi4Ref": "B6.2.4.3",
+                              "ta6ed6Ref": "13.7b",
                               "baspi5Ref": "B6.2.4.3",
                               "title": "If applicable please supply a copy of the tenancy agreement together with a copy of any notice to quit which has been served upon them.",
                               "type": "string",
@@ -26513,7 +31257,8 @@
                             }
                           },
                           "baspi4Required": ["details"],
-                          "baspi5Required": ["details"]
+                          "baspi5Required": ["details"],
+                          "ta6ed6Required": ["details", "attachments"]
                         },
                         {
                           "properties": {
@@ -26524,6 +31269,7 @@
                               "baspi4Ref": "B6.3.1",
                               "baspi5Ref": "B6.3.1",
                               "rdsRef": "RightsHolders,TenureAgreements,Notifications",
+                              "ta6ed6Ref": "13.6a",
                               "ta6Ref": "11.5a",
                               "title": "Have all occupiers aged 17 or over agreed to leave prior to completion?",
                               "type": "object",
@@ -26532,6 +31278,7 @@
                                   "baspi4Ref": "B6.3.1.1",
                                   "baspi5Ref": "B6.3.1.1",
                                   "ta6Ref": "11.5a1",
+                                  "ta6ed6Ref": "13.6a",
                                   "type": "string",
                                   "title": "",
                                   "enum": ["Yes", "No"]
@@ -26539,12 +31286,14 @@
                               },
                               "baspi4Required": ["yesNo"],
                               "baspi5Required": ["yesNo"],
-                              "ta6Required": ["yesNo"]
+                              "ta6Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"]
                             },
                             "aged17OrOverWillSignToConfirmWillVacate": {
                               "baspi4Ref": "B6.3.2",
                               "baspi5Ref": "B6.3.2",
                               "rdsRef": "RightsHolders,TenureAgreements,Notifications",
+                              "ta6ed6Ref": "13.6b",
                               "ta6Ref": "11.5b",
                               "piqRef": "B8.2",
                               "title": "Have all occupiers aged 17 or over, agreed to sign the sale contract to confirm that they will vacate the property prior to completion of the sale?",
@@ -26553,6 +31302,7 @@
                                 "yesNo": {
                                   "baspi4Ref": "B6.3.2.1",
                                   "baspi5Ref": "B6.3.2.1",
+                                  "ta6ed6Ref": "13.6b1",
                                   "ta6Ref": "11.5b1",
                                   "piqRef": "B8.2.1",
                                   "type": "string",
@@ -26563,6 +31313,7 @@
                               "baspi4Required": ["yesNo"],
                               "baspi5Required": ["yesNo"],
                               "ta6Required": ["yesNo"],
+                              "ta6ed6Required": ["yesNo"],
                               "discriminator": {
                                 "propertyName": "yesNo"
                               },
@@ -26613,6 +31364,10 @@
                           "ta6Required": [
                             "aged17OrOverAgreedToLeave",
                             "aged17OrOverWillSignToConfirmWillVacate"
+                          ],
+                          "ta6ed6Required": [
+                            "aged17OrOverAgreedToLeave",
+                            "aged17OrOverWillSignToConfirmWillVacate"
                           ]
                         }
                       ]
@@ -26632,18 +31387,21 @@
                     "aged17OrOverNames",
                     "aged17OrOverTenantsOrLodgers",
                     "vacantPossession"
+                  ],
+                  "ta6ed6Required": [
+                    "aged17OrOverNames",
+                    "aged17OrOverTenantsOrLodgers"
                   ]
                 }
-              ],
-              "ta6Required": ["hasOthersAged17OrOver"]
+              ]
             }
-          },
-          "ta6Required": ["sellerLivesAtProperty", "othersAged17OrOver"]
+          }
         },
         "completionAndMoving": {
           "baspi4Ref": "B7",
           "baspi5Ref": "B7",
           "ta6Ref": "14",
+          "ta6ed6Ref": "14",
           "nts2Ref": "A1.5.7",
           "title": "Completion and Moving",
           "type": "object",
@@ -26667,6 +31425,10 @@
             "moveRestrictionDates",
             "sufficientToRepayAllMortgages"
           ],
+          "ta6ed6Required": [
+            "sellerWillEnsure",
+            "sufficientToRepayAllMortgages"
+          ],
           "nts2Required": ["otherPropertyInChain"],
           "properties": {
             "sellerWillEnsure": {
@@ -26674,6 +31436,14 @@
               "baspi5Ref": "B7.1",
               "rdsRef": "RightsHolders/Flags",
               "ta6Ref": "14.4",
+              "ta6ed6Ref": "14.2",
+              "ta6ed6Title": "Will you ensure that before or on completion:",
+              "ta6ed6Required": [
+                "removeRubbish",
+                "replaceLightFittings",
+                "takeReasonableCare",
+                "leaveKeys"
+              ],
               "title": "Please confirm that on completion you will:",
               "type": "object",
               "required": [
@@ -26687,7 +31457,9 @@
                   "baspi4Ref": "B7.1.1",
                   "baspi5Ref": "B7.1.1",
                   "ta6Ref": "14.4a",
+                  "ta6ed6Ref": "14.2a",
                   "piqRef": "B9.3",
+                  "ta6ed6Title": "All rubbish is removed from the property (including from the loft, garden, outbuildings, garages and sheds) and that the property will be left in a clean and tidy condition?",
                   "title": "Remove all rubbish and items not included in the sale from the property (including its garden, loft and any sheds or outbuildings) and leave the property in a clean and tidy condition.",
                   "type": "boolean"
                 },
@@ -26695,7 +31467,9 @@
                   "baspi4Ref": "B7.1.2",
                   "baspi5Ref": "B7.1.2",
                   "ta6Ref": "14.4b",
+                  "ta6ed6Ref": "14.2b",
                   "piqRef": "B9.4",
+                  "ta6ed6Title": "If light fittings are removed, the fittings will be replaced with ceiling rose, flex, bulb holder and bulb?",
                   "title": "If light fittings are removed, the fittings will be replaced with ceiling rose, flex, bulb holder and bulb.",
                   "type": "boolean"
                 },
@@ -26703,7 +31477,9 @@
                   "baspi4Ref": "B7.1.3",
                   "baspi5Ref": "B7.1.3",
                   "ta6Ref": "14.4c",
+                  "ta6ed6Ref": "14.2c",
                   "piqRef": "B9.6",
+                  "ta6ed6Title": "Reasonable care will be taken when removing any other fittings or contents?",
                   "title": "Take reasonable care when removing any other fittings or contents.",
                   "type": "boolean"
                 },
@@ -26711,7 +31487,9 @@
                   "baspi4Ref": "B7.1.4",
                   "baspi5Ref": "B7.1.4",
                   "ta6Ref": "14.4d",
+                  "ta6ed6Ref": "14.2d",
                   "piqRef": "B9.5",
+                  "ta6ed6Title": "Keys to all windows and doors and details of codes for alarms and any other equipment will be left at the property or with the estate agent?",
                   "title": "Leave keys for all door and window locks, along with any alarm codes, for the buyer on the day of completion.",
                   "type": "boolean"
                 }
@@ -26722,6 +31500,7 @@
               "baspi5Ref": "B7.2",
               "rdsRef": "RightsHolders/Flags",
               "ta6Ref": "14.1",
+              "ta6ed6Ref": "13.1",
               "piqRef": "B9.1",
               "nts2Ref": "A1.5.7.1",
               "title": "Will you need the purchase, sale or remortgage of another property to co-ordinate with the sale of this property?",
@@ -26733,6 +31512,7 @@
                   "baspi4Ref": "B7.2.1",
                   "baspi5Ref": "B7.2.1",
                   "ta6Ref": "14.1.1",
+                  "ta6ed6Ref": "13.1",
                   "piqRef": "B9.1.1",
                   "nts2Ref": "A1.5.7.1.1",
                   "type": "string",
@@ -26743,6 +31523,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "nts2Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
@@ -26825,6 +31606,7 @@
               "baspi5Ref": "B7.3",
               "rdsRef": "RightsHolders/Text",
               "ta6Ref": "14.2",
+              "ta6ed6Ref": "13.2",
               "piqRef": "B9.2",
               "title": "Are there any dates on which you cannot move?",
               "description": "Note that: the moving date will not be fixed until contracts are exchanged i.e. have become binding, until then you should only make provisional removal arrangements; you do not need to be physically present on the day of completion so long as the property is cleared; timescales to completion vary depending on the complexity of the transaction, length of the chain and requirements of the people involved.",
@@ -26834,6 +31616,7 @@
                   "baspi4Ref": "B7.3.1",
                   "baspi5Ref": "B7.3.1",
                   "ta6Ref": "14.2.1",
+                  "ta6ed6Ref": "13.2.1",
                   "piqRef": "B9.1.2",
                   "type": "string",
                   "title": "",
@@ -26843,6 +31626,7 @@
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
               "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
               "discriminator": {
                 "propertyName": "yesNo"
               },
@@ -26860,15 +31644,18 @@
                       "enum": ["Yes"]
                     },
                     "details": {
+                      "title": "Please provide details",
                       "baspi4Ref": "B7.3.2",
                       "baspi5Ref": "B7.3.2",
                       "ta6Ref": "14.2.2",
+                      "ta6ed6Ref": "13.2.2",
                       "type": "string"
                     }
                   },
                   "baspi4Required": ["details"],
                   "baspi5Required": ["details"],
-                  "ta6Required": ["details"]
+                  "ta6Required": ["details"],
+                  "ta6ed6Required": ["details"]
                 }
               ]
             },
@@ -26928,6 +31715,7 @@
               "baspi4Ref": "B7.6",
               "baspi5Ref": "B7.6",
               "ta6Ref": "14.3",
+              "ta6ed6Ref": "14.1",
               "title": "Will the sale price be sufficient to repay all mortgages and charges secured on the property?",
               "type": "object",
               "properties": {
@@ -26935,6 +31723,7 @@
                   "baspi4Ref": "A7.6.1",
                   "baspi5Ref": "A7.6.1",
                   "ta6Ref": "14.3.1",
+                  "ta6ed6Ref": "14.1.1",
                   "type": "string",
                   "title": "",
                   "enum": ["Yes", "No", "No mortgage"]
@@ -26942,7 +31731,9 @@
               },
               "baspi4Required": ["yesNo"],
               "baspi5Required": ["yesNo"],
-              "ta6Required": ["yesNo"]
+              "ta6Required": ["yesNo"],
+              "ta6ed6Required": ["yesNo"],
+              "ta6ed6Title": "Will the sale price be sufficient to pay off on completion all mortgages and charges secured on the property?"
             }
           }
         },
@@ -26950,6 +31741,7 @@
           "baspi4Ref": "B8",
           "baspi5Ref": "B8",
           "ta6Ref": "14.5",
+          "ta6ed6Ref": "16",
           "title": "Confirmation to be supplied by all owners or their representative",
           "type": "object",
           "baspi4Required": [
@@ -26961,6 +31753,7 @@
             "confirmInformationIsAccurate"
           ],
           "ta6Required": ["confirmInformationIsAccurate"],
+          "ta6ed6Required": ["confirmInformationIsAccurate"],
           "properties": {
             "confirmWillProvideAdditionalDocumentation": {
               "baspi4Ref": "B8.1",
@@ -26972,6 +31765,7 @@
               "baspi4Ref": "B8.2",
               "baspi5Ref": "B8.2",
               "ta6Ref": "14.5.1",
+              "ta6ed6Ref": "15.3.1",
               "title": "I/we confirm that all information provided is accurate to the best of our knowledge and if we become aware of any change to/changes which alter the information supplied/provided prior to exchange of contracts for the sale of the property, I/we will update immediately notify the person marketing the property as well as my/our property lawyer",
               "type": "boolean"
             }
@@ -27017,7 +31811,28 @@
                     "format": "date-time"
                   },
                   "externalIds": {
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "patternProperties": {
+                              ".*": {}
+                            }
+                          }
+                        ]
+                      }
+                    }
                   }
                 }
               }
@@ -39594,12 +44409,12 @@
                     "documentDate": {
                       "title": "Date of original document",
                       "type": "string",
-                      "fornat": "date"
+                      "format": "date"
                     },
                     "retrievedOn": {
                       "title": "Datetime retrieved from HMLR",
                       "type": "string",
-                      "fornat": "date-time"
+                      "format": "date-time"
                     },
                     "filedUnder": {
                       "title": "Related title number",
@@ -39726,6 +44541,34 @@
                 "minLength": 1
               },
               "externalIds": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {}
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "isDeleted": {
+                "type": "boolean"
+              },
+              "summary": {
+                "title": "Structured summary of the document",
                 "type": "object"
               }
             }
@@ -39744,25 +44587,53 @@
                   "chimneyStacks": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "visibilityRestriction": { "type": "string" },
-                      "flashings": { "type": "string" },
-                      "defectsFlag": { "type": "boolean" },
-                      "defectsList": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "visibilityRestriction": {
+                        "type": "string"
+                      },
+                      "flashings": {
+                        "type": "string"
+                      },
+                      "defectsFlag": {
+                        "type": "boolean"
+                      },
+                      "defectsList": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -39771,80 +44642,192 @@
                   "roofCoverings": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restriction": { "type": "string" },
-                      "features": { "type": "string" },
-                      "mainPitchedCovering": { "type": "string" },
-                      "mainPitchedFeatures": { "type": "string" },
-                      "mainFlatCovering": { "type": "string" },
-                      "mainFlatFeatures": { "type": "string" },
-                      "additionalPitchedCovering": { "type": "string" },
-                      "additionalPitchedFeatures": { "type": "string" },
-                      "additionalDetail": { "type": "string" },
-                      "additionalFeatures": { "type": "string" },
-                      "bay": { "type": "string" },
-                      "bayFeatures": { "type": "string" },
-                      "dormer": { "type": "string" },
-                      "dormerFeatures": { "type": "string" },
-                      "defectsGeneral": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restriction": {
+                        "type": "string"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
+                      "mainPitchedCovering": {
+                        "type": "string"
+                      },
+                      "mainPitchedFeatures": {
+                        "type": "string"
+                      },
+                      "mainFlatCovering": {
+                        "type": "string"
+                      },
+                      "mainFlatFeatures": {
+                        "type": "string"
+                      },
+                      "additionalPitchedCovering": {
+                        "type": "string"
+                      },
+                      "additionalPitchedFeatures": {
+                        "type": "string"
+                      },
+                      "additionalDetail": {
+                        "type": "string"
+                      },
+                      "additionalFeatures": {
+                        "type": "string"
+                      },
+                      "bay": {
+                        "type": "string"
+                      },
+                      "bayFeatures": {
+                        "type": "string"
+                      },
+                      "dormer": {
+                        "type": "string"
+                      },
+                      "dormerFeatures": {
+                        "type": "string"
+                      },
+                      "defectsGeneral": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "mainPitchedDefects": { "type": "boolean" },
-                      "mainPitchedDefectsDetail": { "type": "string" },
-                      "mainFlatDefects": { "type": "string" },
-                      "mainFlatDefectsDetail": { "type": "string" },
-                      "additionalPitchedDefects": { "type": "boolean" },
-                      "additionalPitchedDefectsDetail": { "type": "string" },
-                      "additionalFlatDefects": { "type": "boolean" },
-                      "additionalFlatDefectsDetail": { "type": "string" },
-                      "bayDefects": { "type": "boolean" },
-                      "bayDefectsDetail": { "type": "string" },
-                      "dormerDefects": { "type": "boolean" },
-                      "dormerDefectsDetail": { "type": "string" }
+                      "mainPitchedDefects": {
+                        "type": "boolean"
+                      },
+                      "mainPitchedDefectsDetail": {
+                        "type": "string"
+                      },
+                      "mainFlatDefects": {
+                        "type": "string"
+                      },
+                      "mainFlatDefectsDetail": {
+                        "type": "string"
+                      },
+                      "additionalPitchedDefects": {
+                        "type": "boolean"
+                      },
+                      "additionalPitchedDefectsDetail": {
+                        "type": "string"
+                      },
+                      "additionalFlatDefects": {
+                        "type": "boolean"
+                      },
+                      "additionalFlatDefectsDetail": {
+                        "type": "string"
+                      },
+                      "bayDefects": {
+                        "type": "boolean"
+                      },
+                      "bayDefectsDetail": {
+                        "type": "string"
+                      },
+                      "dormerDefects": {
+                        "type": "boolean"
+                      },
+                      "dormerDefectsDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "rainwaterPipesGutters": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "features": { "type": "string" },
-                      "gutterDescription": { "type": "string" },
-                      "downpipeDescription": { "type": "string" },
-                      "hopperHeadDescription": { "type": "string" },
-                      "gutterIssues": { "type": "boolean" },
-                      "gutterIssueLocation": { "type": "string" },
-                      "gutterDefect": { "type": "string" },
-                      "downpipeDefect": { "type": "string" },
-                      "hopperHeadDefect": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
+                      "gutterDescription": {
+                        "type": "string"
+                      },
+                      "downpipeDescription": {
+                        "type": "string"
+                      },
+                      "hopperHeadDescription": {
+                        "type": "string"
+                      },
+                      "gutterIssues": {
+                        "type": "boolean"
+                      },
+                      "gutterIssueLocation": {
+                        "type": "string"
+                      },
+                      "gutterDefect": {
+                        "type": "string"
+                      },
+                      "downpipeDefect": {
+                        "type": "string"
+                      },
+                      "hopperHeadDefect": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -39853,77 +44836,177 @@
                   "mainWalls": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "externalElevation": { "type": "string" },
-                      "construction": { "type": "string" },
-                      "features": { "type": "string" },
-                      "dpc": { "type": "string" },
-                      "structuralMovement": { "type": "boolean" },
-                      "movementType": { "type": "string" },
-                      "movementCause": { "type": "string" },
-                      "movementStatus": { "type": "string" },
-                      "otherDefects": { "type": "boolean" },
-                      "otherDefectsDescription": { "type": "string" },
-                      "cladding": { "type": "string" },
-                      "fireRisk": { "type": "boolean" },
-                      "advice": { "type": "string" },
-                      "extensions": { "type": "string" },
-                      "movementLocation": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "externalElevation": {
+                        "type": "string"
+                      },
+                      "construction": {
+                        "type": "string"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
+                      "dpc": {
+                        "type": "string"
+                      },
+                      "structuralMovement": {
+                        "type": "boolean"
+                      },
+                      "movementType": {
+                        "type": "string"
+                      },
+                      "movementCause": {
+                        "type": "string"
+                      },
+                      "movementStatus": {
+                        "type": "string"
+                      },
+                      "otherDefects": {
+                        "type": "boolean"
+                      },
+                      "otherDefectsDescription": {
+                        "type": "string"
+                      },
+                      "cladding": {
+                        "type": "string"
+                      },
+                      "fireRisk": {
+                        "type": "boolean"
+                      },
+                      "advice": {
+                        "type": "string"
+                      },
+                      "extensions": {
+                        "type": "string"
+                      },
+                      "movementLocation": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
                       "extension1": {
                         "type": "object",
                         "properties": {
-                          "detail": { "type": "string" },
-                          "construction": { "type": "string" },
-                          "dpc": { "type": "string" },
-                          "defects": { "type": "boolean" },
-                          "defectDescription": { "type": "string" },
-                          "movementType": { "type": "string" },
-                          "movementCause": { "type": "string" },
-                          "movementStatus": { "type": "string" }
+                          "detail": {
+                            "type": "string"
+                          },
+                          "construction": {
+                            "type": "string"
+                          },
+                          "dpc": {
+                            "type": "string"
+                          },
+                          "defects": {
+                            "type": "boolean"
+                          },
+                          "defectDescription": {
+                            "type": "string"
+                          },
+                          "movementType": {
+                            "type": "string"
+                          },
+                          "movementCause": {
+                            "type": "string"
+                          },
+                          "movementStatus": {
+                            "type": "string"
+                          }
                         }
                       },
                       "extension2": {
                         "type": "object",
                         "properties": {
-                          "detail": { "type": "string" },
-                          "construction": { "type": "string" },
-                          "dpc": { "type": "string" },
-                          "defects": { "type": "boolean" },
-                          "defectDescription": { "type": "string" },
-                          "movementType": { "type": "string" },
-                          "movementCause": { "type": "string" },
-                          "movementStatus": { "type": "string" }
+                          "detail": {
+                            "type": "string"
+                          },
+                          "construction": {
+                            "type": "string"
+                          },
+                          "dpc": {
+                            "type": "string"
+                          },
+                          "defects": {
+                            "type": "boolean"
+                          },
+                          "defectDescription": {
+                            "type": "string"
+                          },
+                          "movementType": {
+                            "type": "string"
+                          },
+                          "movementCause": {
+                            "type": "string"
+                          },
+                          "movementStatus": {
+                            "type": "string"
+                          }
                         }
                       },
                       "extension3": {
                         "type": "object",
                         "properties": {
-                          "detail": { "type": "string" },
-                          "construction": { "type": "string" },
-                          "dpc": { "type": "string" },
-                          "defects": { "type": "boolean" },
-                          "defectDescription": { "type": "string" },
-                          "movementType": { "type": "string" },
-                          "movementCause": { "type": "string" },
-                          "movementStatus": { "type": "string" }
+                          "detail": {
+                            "type": "string"
+                          },
+                          "construction": {
+                            "type": "string"
+                          },
+                          "dpc": {
+                            "type": "string"
+                          },
+                          "defects": {
+                            "type": "boolean"
+                          },
+                          "defectDescription": {
+                            "type": "string"
+                          },
+                          "movementType": {
+                            "type": "string"
+                          },
+                          "movementCause": {
+                            "type": "string"
+                          },
+                          "movementStatus": {
+                            "type": "string"
+                          }
                         }
                       }
                     }
@@ -39931,28 +45014,62 @@
                   "windows": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "visibilityRestrictions": { "type": "string" },
-                      "glazingType": { "type": "string" },
-                      "glazingDescription": { "type": "string" },
-                      "glazingHeight": { "type": "boolean" },
-                      "glazingSafety": { "type": "boolean" },
-                      "glazingDefects": { "type": "boolean" },
-                      "glazingDefectList": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "visibilityRestrictions": {
+                        "type": "string"
+                      },
+                      "glazingType": {
+                        "type": "string"
+                      },
+                      "glazingDescription": {
+                        "type": "string"
+                      },
+                      "glazingHeight": {
+                        "type": "boolean"
+                      },
+                      "glazingSafety": {
+                        "type": "boolean"
+                      },
+                      "glazingDefects": {
+                        "type": "boolean"
+                      },
+                      "glazingDefectList": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "string" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -39961,28 +45078,62 @@
                   "outsideDoors": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "glazingDescription": { "type": "string" },
-                      "glazingType": { "type": "string" },
-                      "glazingHeight": { "type": "boolean" },
-                      "glazingSafety": { "type": "boolean" },
-                      "glazingDefects": { "type": "boolean" },
-                      "glazingDefectDetails": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "glazingDescription": {
+                        "type": "string"
+                      },
+                      "glazingType": {
+                        "type": "string"
+                      },
+                      "glazingHeight": {
+                        "type": "boolean"
+                      },
+                      "glazingSafety": {
+                        "type": "boolean"
+                      },
+                      "glazingDefects": {
+                        "type": "boolean"
+                      },
+                      "glazingDefectDetails": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -39991,52 +45142,134 @@
                   "conservatoryPorches": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "conservatory": { "type": "boolean" },
-                      "porch": { "type": "boolean" },
-                      "restrictions": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "conservatoryWall": { "type": "string" },
-                      "conservatoryFrame": { "type": "string" },
-                      "conservatoryGlazing": { "type": "string" },
-                      "conservatoryRoof": { "type": "string" },
-                      "conservatorySeparate": { "type": "boolean" },
-                      "conservatoryHeating": { "type": "string" },
-                      "porchWall": { "type": "string" },
-                      "porchFrame": { "type": "string" },
-                      "porchGlazing": { "type": "string" },
-                      "porchRoof": { "type": "string" },
-                      "porchPitched": { "type": "string" },
-                      "porchFlat": { "type": "string" },
-                      "defectsFlag": { "type": "boolean" },
-                      "defectLocation": { "type": "string" },
-                      "conservatoryEconomic": { "type": "boolean" },
-                      "conservatoryStructural": { "type": "boolean" },
-                      "conservatoryMovement": { "type": "string" },
-                      "conservatoryMovementCause": { "type": "string" },
-                      "conservatoryMovementStatus": { "type": "string" },
-                      "conservatoryDefects": { "type": "boolean" },
-                      "conservatoryDefectDetail": { "type": "string" },
-                      "porchEconomic": { "type": "boolean" },
-                      "porchStructural": { "type": "boolean" },
-                      "porchMovement": { "type": "string" },
-                      "porchMovementCause": { "type": "string" },
-                      "porchMovementStatus": { "type": "string" },
-                      "porchDefects": { "type": "boolean" },
-                      "porchDefectDetail": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "conservatory": {
+                        "type": "boolean"
+                      },
+                      "porch": {
+                        "type": "boolean"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "conservatoryWall": {
+                        "type": "string"
+                      },
+                      "conservatoryFrame": {
+                        "type": "string"
+                      },
+                      "conservatoryGlazing": {
+                        "type": "string"
+                      },
+                      "conservatoryRoof": {
+                        "type": "string"
+                      },
+                      "conservatorySeparate": {
+                        "type": "boolean"
+                      },
+                      "conservatoryHeating": {
+                        "type": "string"
+                      },
+                      "porchWall": {
+                        "type": "string"
+                      },
+                      "porchFrame": {
+                        "type": "string"
+                      },
+                      "porchGlazing": {
+                        "type": "string"
+                      },
+                      "porchRoof": {
+                        "type": "string"
+                      },
+                      "porchPitched": {
+                        "type": "string"
+                      },
+                      "porchFlat": {
+                        "type": "string"
+                      },
+                      "defectsFlag": {
+                        "type": "boolean"
+                      },
+                      "defectLocation": {
+                        "type": "string"
+                      },
+                      "conservatoryEconomic": {
+                        "type": "boolean"
+                      },
+                      "conservatoryStructural": {
+                        "type": "boolean"
+                      },
+                      "conservatoryMovement": {
+                        "type": "string"
+                      },
+                      "conservatoryMovementCause": {
+                        "type": "string"
+                      },
+                      "conservatoryMovementStatus": {
+                        "type": "string"
+                      },
+                      "conservatoryDefects": {
+                        "type": "boolean"
+                      },
+                      "conservatoryDefectDetail": {
+                        "type": "string"
+                      },
+                      "porchEconomic": {
+                        "type": "boolean"
+                      },
+                      "porchStructural": {
+                        "type": "boolean"
+                      },
+                      "porchMovement": {
+                        "type": "string"
+                      },
+                      "porchMovementCause": {
+                        "type": "string"
+                      },
+                      "porchMovementStatus": {
+                        "type": "string"
+                      },
+                      "porchDefects": {
+                        "type": "boolean"
+                      },
+                      "porchDefectDetail": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -40045,30 +45278,68 @@
                   "otherJoinery": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "features": { "type": "string" },
-                      "fasciaDescription": { "type": "string" },
-                      "bargeboardsDescription": { "type": "string" },
-                      "soffitsDescription": { "type": "string" },
-                      "claddingDescription": { "type": "string" },
-                      "issues": { "type": "boolean" },
-                      "issueLocation": { "type": "string" },
-                      "issueDetail": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
+                      "fasciaDescription": {
+                        "type": "string"
+                      },
+                      "bargeboardsDescription": {
+                        "type": "string"
+                      },
+                      "soffitsDescription": {
+                        "type": "string"
+                      },
+                      "claddingDescription": {
+                        "type": "string"
+                      },
+                      "issues": {
+                        "type": "boolean"
+                      },
+                      "issueLocation": {
+                        "type": "string"
+                      },
+                      "issueDetail": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "string" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -40077,24 +45348,50 @@
                   "other": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "defectsFlag": { "type": "boolean" },
-                      "defectDetail": { "type": "string" },
-                      "fireSafety": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "defectsFlag": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      },
+                      "fireSafety": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
@@ -40108,62 +45405,148 @@
                   "roofStructure": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "lining": { "type": "string" },
-                      "insulation": { "type": "string" },
-                      "firewall": { "type": "string" },
-                      "features": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "lining": {
+                        "type": "string"
+                      },
+                      "insulation": {
+                        "type": "string"
+                      },
+                      "firewall": {
+                        "type": "string"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "string" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       },
-                      "additional1Visibility": { "type": "string" },
-                      "additional1Restrictions": { "type": "string" },
-                      "additional1Description": { "type": "string" },
-                      "additional1Lining": { "type": "string" },
-                      "additional1Insulation": { "type": "string" },
-                      "additional1Defects": { "type": "boolean" },
-                      "additional1DefectDetail": { "type": "string" },
-                      "additional2Visibility": { "type": "string" },
-                      "additional2Restrictions": { "type": "string" },
-                      "additional2Description": { "type": "string" },
-                      "additional2Lining": { "type": "string" },
-                      "additional2Insulation": { "type": "string" },
-                      "additional2Defects": { "type": "boolean" },
-                      "additional2DefectDetail": { "type": "string" },
-                      "defectDetail": { "type": "string" }
+                      "additional1Visibility": {
+                        "type": "string"
+                      },
+                      "additional1Restrictions": {
+                        "type": "string"
+                      },
+                      "additional1Description": {
+                        "type": "string"
+                      },
+                      "additional1Lining": {
+                        "type": "string"
+                      },
+                      "additional1Insulation": {
+                        "type": "string"
+                      },
+                      "additional1Defects": {
+                        "type": "boolean"
+                      },
+                      "additional1DefectDetail": {
+                        "type": "string"
+                      },
+                      "additional2Visibility": {
+                        "type": "string"
+                      },
+                      "additional2Restrictions": {
+                        "type": "string"
+                      },
+                      "additional2Description": {
+                        "type": "string"
+                      },
+                      "additional2Lining": {
+                        "type": "string"
+                      },
+                      "additional2Insulation": {
+                        "type": "string"
+                      },
+                      "additional2Defects": {
+                        "type": "boolean"
+                      },
+                      "additional2DefectDetail": {
+                        "type": "string"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "ceilings": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "defectDetail": { "type": "string" },
-                      "integralGarageDefects": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      },
+                      "integralGarageDefects": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "integer" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40171,25 +45554,57 @@
                   "wallsPartitions": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "construction": { "type": "string" },
-                      "adequateSupport": { "type": "boolean" },
-                      "wallFinish": { "type": "string" },
-                      "defectsMinor": { "type": "string" },
-                      "defectsMajor": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "construction": {
+                        "type": "string"
+                      },
+                      "adequateSupport": {
+                        "type": "boolean"
+                      },
+                      "wallFinish": {
+                        "type": "string"
+                      },
+                      "defectsMinor": {
+                        "type": "string"
+                      },
+                      "defectsMajor": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "integer" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40197,23 +45612,51 @@
                   "floors": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "generalDefects": { "type": "string" },
-                      "solidDefects": { "type": "string" },
-                      "timberDefects": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "generalDefects": {
+                        "type": "string"
+                      },
+                      "solidDefects": {
+                        "type": "string"
+                      },
+                      "timberDefects": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "integer" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40221,21 +45664,45 @@
                   "fireplaces": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "defectDetail": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "integer" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40243,22 +45710,48 @@
                   "builtinFittings": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "defectDetail": { "type": "string" },
-                      "advice": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      },
+                      "advice": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "string" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40266,26 +45759,60 @@
                   "woodwork": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "doorDescription": { "type": "string" },
-                      "stairDescription": { "type": "string" },
-                      "joineryDescription": { "type": "string" },
-                      "defectsDetail": { "type": "string" },
-                      "defectsDoorsWindows": { "type": "string" },
-                      "defectsStairs": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "doorDescription": {
+                        "type": "string"
+                      },
+                      "stairDescription": {
+                        "type": "string"
+                      },
+                      "joineryDescription": {
+                        "type": "string"
+                      },
+                      "defectsDetail": {
+                        "type": "string"
+                      },
+                      "defectsDoorsWindows": {
+                        "type": "string"
+                      },
+                      "defectsStairs": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "string" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40293,21 +45820,45 @@
                   "bathroomFittings": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "defectDetail": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "integer" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "integer"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40315,26 +45866,60 @@
                   "other": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
-                      "visibility": { "type": "string" },
-                      "roofConversion": { "type": "string" },
-                      "cellar": { "type": "string" },
-                      "commonAreas": { "type": "string" },
-                      "alarms": { "type": "string" },
-                      "defectsRoof": { "type": "string" },
-                      "defectsBasement": { "type": "string" },
-                      "defectsOther": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "roofConversion": {
+                        "type": "string"
+                      },
+                      "cellar": {
+                        "type": "string"
+                      },
+                      "commonAreas": {
+                        "type": "string"
+                      },
+                      "alarms": {
+                        "type": "string"
+                      },
+                      "defectsRoof": {
+                        "type": "string"
+                      },
+                      "defectsBasement": {
+                        "type": "string"
+                      },
+                      "defectsOther": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "object",
                         "properties": {
-                          "photoId": { "type": "string" },
-                          "description": { "type": "string" },
-                          "report": { "type": "boolean" }
+                          "photoId": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "report": {
+                            "type": "boolean"
+                          }
                         }
                       }
                     }
@@ -40347,217 +45932,467 @@
                   "electricity": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "meter": { "type": "string" },
-                      "consumerUnit": { "type": "string" },
-                      "cutOffDevices": { "type": "string" },
-                      "wiring": { "type": "string" },
-                      "additionalFeatures": { "type": "string" },
-                      "supplementary": { "type": "string" },
-                      "testCertificate": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "meter": {
+                        "type": "string"
+                      },
+                      "consumerUnit": {
+                        "type": "string"
+                      },
+                      "cutOffDevices": {
+                        "type": "string"
+                      },
+                      "wiring": {
+                        "type": "string"
+                      },
+                      "additionalFeatures": {
+                        "type": "string"
+                      },
+                      "supplementary": {
+                        "type": "string"
+                      },
+                      "testCertificate": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "gasOil": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "meter": { "type": "string" },
-                      "privateGas": { "type": "string" },
-                      "tankLocation": { "type": "string" },
-                      "tankInside": { "type": "string" },
-                      "tankOutside": { "type": "string" },
-                      "tankType": { "type": "string" },
-                      "testCertificate": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "meter": {
+                        "type": "string"
+                      },
+                      "privateGas": {
+                        "type": "string"
+                      },
+                      "tankLocation": {
+                        "type": "string"
+                      },
+                      "tankInside": {
+                        "type": "string"
+                      },
+                      "tankOutside": {
+                        "type": "string"
+                      },
+                      "tankType": {
+                        "type": "string"
+                      },
+                      "testCertificate": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "water": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "string" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "stopTap": { "type": "string" },
-                      "supply": { "type": "string" },
-                      "distribution": { "type": "string" },
-                      "storageTank": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "stopTap": {
+                        "type": "string"
+                      },
+                      "supply": {
+                        "type": "string"
+                      },
+                      "distribution": {
+                        "type": "string"
+                      },
+                      "storageTank": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "heating": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "extent": { "type": "string" },
-                      "source": { "type": "string" },
-                      "emitter": { "type": "string" },
-                      "pipework": { "type": "string" },
-                      "controls": { "type": "string" },
-                      "otherFeatures": { "type": "string" },
-                      "testCertificate": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "extent": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "emitter": {
+                        "type": "string"
+                      },
+                      "pipework": {
+                        "type": "string"
+                      },
+                      "controls": {
+                        "type": "string"
+                      },
+                      "otherFeatures": {
+                        "type": "string"
+                      },
+                      "testCertificate": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "waterHeating": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "integer" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "integer"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "primarySource": { "type": "string" },
-                      "supplementarySource": { "type": "string" },
-                      "storage": { "type": "string" },
-                      "pipework": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "primarySource": {
+                        "type": "string"
+                      },
+                      "supplementarySource": {
+                        "type": "string"
+                      },
+                      "storage": {
+                        "type": "string"
+                      },
+                      "pipework": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "drainage": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "string" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "restrictions": { "type": "string" },
-                      "system": { "type": "string" },
-                      "privateSystem": { "type": "string" },
-                      "location": { "type": "string" },
-                      "runOff": { "type": "boolean" },
-                      "features": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "restrictions": {
+                        "type": "string"
+                      },
+                      "system": {
+                        "type": "string"
+                      },
+                      "privateSystem": {
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "runOff": {
+                        "type": "boolean"
+                      },
+                      "features": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   },
                   "commonServices": {
                     "type": "object",
                     "properties": {
-                      "condition": { "type": "string" },
-                      "inspectionLimitations": { "type": "string" },
-                      "description": { "type": "string" },
-                      "defects": { "type": "string" },
-                      "advisories": { "type": "string" },
-                      "notes": { "type": "string" },
+                      "condition": {
+                        "type": "string"
+                      },
+                      "inspectionLimitations": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "defects": {
+                        "type": "string"
+                      },
+                      "advisories": {
+                        "type": "string"
+                      },
+                      "notes": {
+                        "type": "string"
+                      },
                       "photos": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "photoId": { "type": "string" },
-                            "description": { "type": "string" },
-                            "report": { "type": "boolean" }
+                            "photoId": {
+                              "type": "string"
+                            },
+                            "description": {
+                              "type": "string"
+                            },
+                            "report": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       },
-                      "visibility": { "type": "string" },
-                      "type": { "type": "string" },
-                      "defectsPresent": { "type": "boolean" },
-                      "defectDetail": { "type": "string" }
+                      "visibility": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "defectsPresent": {
+                        "type": "boolean"
+                      },
+                      "defectDetail": {
+                        "type": "string"
+                      }
                     }
                   }
                 }
@@ -40978,71 +46813,187 @@
                   "photoFront": {
                     "type": "object",
                     "properties": {
-                      "value": { "type": "string" },
-                      "photoId": { "type": "integer" },
-                      "description": { "type": "string" },
-                      "report": { "type": "boolean" }
+                      "value": {
+                        "type": "string"
+                      },
+                      "photoId": {
+                        "type": "integer"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "report": {
+                        "type": "boolean"
+                      }
                     }
                   },
                   "areaOfProperty": {
                     "type": "object",
                     "properties": {
-                      "value": { "type": "string" },
-                      "photoId": { "type": "integer" },
-                      "description": { "type": "string" },
-                      "report": { "type": "boolean" }
+                      "value": {
+                        "type": "string"
+                      },
+                      "photoId": {
+                        "type": "integer"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "report": {
+                        "type": "boolean"
+                      }
                     }
                   },
-                  "reportDate": { "type": "string" },
-                  "epc": { "type": "string" },
-                  "agentName": { "type": "string" },
-                  "access": { "type": "string" },
-                  "propertyQuestions": { "type": "boolean" },
-                  "propertyChanges": { "type": "string" },
-                  "alterations": { "type": "string" },
-                  "furnishings": { "type": "string" },
-                  "floorCoverings": { "type": "string" },
-                  "propertyType": { "type": "string" },
-                  "accommodationLocation": { "type": "string" },
-                  "propertyStyle": { "type": "string" },
-                  "topography": { "type": "string" },
-                  "floodingRisk": { "type": "string" },
-                  "coastalLocation": { "type": "boolean" },
-                  "siteRisk": { "type": "string" },
-                  "highVoltage": { "type": "string" },
-                  "buildFormat": { "type": "string" },
-                  "areaDetails": { "type": "string" },
-                  "groundRentType": { "type": "string" },
-                  "conservationArea": { "type": "boolean" },
-                  "valuationFactor": { "type": "string" },
-                  "conflict": { "type": "boolean" },
-                  "conflictType": { "type": "string" },
-                  "suspiciousActivity": { "type": "boolean" },
-                  "btl": { "type": "boolean" },
-                  "photoConsent": { "type": "boolean" },
-                  "adjacentCommercial": { "type": "boolean" },
-                  "commercialLocation": { "type": "string" },
-                  "commercialTypeAbove": { "type": "string" },
-                  "commercialTypeAdjacent": { "type": "string" },
-                  "separateAccess": { "type": "boolean" },
-                  "communal": { "type": "boolean" },
-                  "communalFacilities": { "type": "string" },
-                  "listedBuilding": { "type": "boolean" },
-                  "listedClassification": { "type": "string" },
-                  "exla": { "type": "boolean" },
-                  "exNature": { "type": "string" },
-                  "tenureSource": { "type": "string" },
-                  "roadType": { "type": "string" },
-                  "roadMadeUp": { "type": "boolean" },
-                  "pedestrian": { "type": "boolean" },
-                  "constructionType": { "type": "string" },
-                  "nonTradType": { "type": "string" },
-                  "nonTradSystem": { "type": "string" },
-                  "designatedDefective": { "type": "boolean" },
-                  "epcAvailable": { "type": "boolean" },
-                  "epcReason": { "type": "string" },
-                  "epcDiscrepancies": { "type": "boolean" },
-                  "epcDiscrepancyDetail": { "type": "string" }
+                  "reportDate": {
+                    "type": "string"
+                  },
+                  "epc": {
+                    "type": "string"
+                  },
+                  "agentName": {
+                    "type": "string"
+                  },
+                  "access": {
+                    "type": "string"
+                  },
+                  "propertyQuestions": {
+                    "type": "boolean"
+                  },
+                  "propertyChanges": {
+                    "type": "string"
+                  },
+                  "alterations": {
+                    "type": "string"
+                  },
+                  "furnishings": {
+                    "type": "string"
+                  },
+                  "floorCoverings": {
+                    "type": "string"
+                  },
+                  "propertyType": {
+                    "type": "string"
+                  },
+                  "accommodationLocation": {
+                    "type": "string"
+                  },
+                  "propertyStyle": {
+                    "type": "string"
+                  },
+                  "topography": {
+                    "type": "string"
+                  },
+                  "floodingRisk": {
+                    "type": "string"
+                  },
+                  "coastalLocation": {
+                    "type": "boolean"
+                  },
+                  "siteRisk": {
+                    "type": "string"
+                  },
+                  "highVoltage": {
+                    "type": "string"
+                  },
+                  "buildFormat": {
+                    "type": "string"
+                  },
+                  "areaDetails": {
+                    "type": "string"
+                  },
+                  "groundRentType": {
+                    "type": "string"
+                  },
+                  "conservationArea": {
+                    "type": "boolean"
+                  },
+                  "valuationFactor": {
+                    "type": "string"
+                  },
+                  "conflict": {
+                    "type": "boolean"
+                  },
+                  "conflictType": {
+                    "type": "string"
+                  },
+                  "suspiciousActivity": {
+                    "type": "boolean"
+                  },
+                  "btl": {
+                    "type": "boolean"
+                  },
+                  "photoConsent": {
+                    "type": "boolean"
+                  },
+                  "adjacentCommercial": {
+                    "type": "boolean"
+                  },
+                  "commercialLocation": {
+                    "type": "string"
+                  },
+                  "commercialTypeAbove": {
+                    "type": "string"
+                  },
+                  "commercialTypeAdjacent": {
+                    "type": "string"
+                  },
+                  "separateAccess": {
+                    "type": "boolean"
+                  },
+                  "communal": {
+                    "type": "boolean"
+                  },
+                  "communalFacilities": {
+                    "type": "string"
+                  },
+                  "listedBuilding": {
+                    "type": "boolean"
+                  },
+                  "listedClassification": {
+                    "type": "string"
+                  },
+                  "exla": {
+                    "type": "boolean"
+                  },
+                  "exNature": {
+                    "type": "string"
+                  },
+                  "tenureSource": {
+                    "type": "string"
+                  },
+                  "roadType": {
+                    "type": "string"
+                  },
+                  "roadMadeUp": {
+                    "type": "boolean"
+                  },
+                  "pedestrian": {
+                    "type": "boolean"
+                  },
+                  "constructionType": {
+                    "type": "string"
+                  },
+                  "nonTradType": {
+                    "type": "string"
+                  },
+                  "nonTradSystem": {
+                    "type": "string"
+                  },
+                  "designatedDefective": {
+                    "type": "boolean"
+                  },
+                  "epcAvailable": {
+                    "type": "boolean"
+                  },
+                  "epcReason": {
+                    "type": "string"
+                  },
+                  "epcDiscrepancies": {
+                    "type": "boolean"
+                  },
+                  "epcDiscrepancyDetail": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -41363,10 +47314,36 @@
                 "type": "object",
                 "required": ["name", "url", "requiredSignatories"],
                 "properties": {
-                  "name": { "type": "string" },
-                  "url": { "type": "string", "format": "uri" },
+                  "name": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
                   "externalIds": {
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "patternProperties": {
+                              ".*": {}
+                            }
+                          }
+                        ]
+                      }
+                    }
                   },
                   "requiredSignatories": {
                     "type": "array",
@@ -41390,7 +47367,9 @@
                             "Tenant"
                           ]
                         },
-                        "requiresAll": { "type": "boolean" }
+                        "requiresAll": {
+                          "type": "boolean"
+                        }
                       }
                     }
                   }
@@ -41407,10 +47386,36 @@
               "type": "object",
               "required": ["name", "signedOn", "role", "contractHash"],
               "properties": {
-                "name": { "type": "string" },
-                "signedOn": { "type": "string", "format": "date-time" },
+                "name": {
+                  "type": "string"
+                },
+                "signedOn": {
+                  "type": "string",
+                  "format": "date-time"
+                },
                 "externalIds": {
-                  "type": "object"
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "object",
+                          "patternProperties": {
+                            ".*": {}
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               },
               "role": {
@@ -41456,7 +47461,28 @@
                 "type": "string"
               },
               "externalIds": {
-                "type": "object"
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {}
+                        }
+                      }
+                    ]
+                  }
+                }
               },
               "address": {
                 "title": "Address",
@@ -41533,7 +47559,28 @@
               "type": "string"
             },
             "externalIds": {
-              "type": "object"
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
             },
             "address": {
               "title": "Address",
@@ -41713,6 +47760,391 @@
               "format": "date-time"
             }
           }
+        }
+      }
+    },
+    "offers": {
+      "title": "Offers for purchase of the property",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+      },
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "minimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "Pending",
+                "Withdrawn",
+                "Rejected",
+                "Accepted",
+                "Note of Interest"
+              ]
+            },
+            "inclusions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclusions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "conditions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "externalIds": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "buyerCircumstances": {
+              "title": "Buyer circumstances",
+              "description": "Information about the buyer's circumstances for lender compatibility analysis and conveyancing quotes",
+              "type": "object",
+              "properties": {
+                "intendedUse": {
+                  "type": "string",
+                  "title": "Intended use of property",
+                  "enum": [
+                    "Owner occupied",
+                    "Buy-to-let",
+                    "Holiday let",
+                    "Second home"
+                  ]
+                },
+                "firstTimeBuyer": {
+                  "type": "boolean",
+                  "title": "First-time buyer"
+                },
+                "rightToBuy": {
+                  "type": "boolean",
+                  "title": "Right to Buy purchase"
+                },
+                "ltdCompanyPurchase": {
+                  "type": "boolean",
+                  "title": "Limited company purchase"
+                },
+                "numberOfOwners": {
+                  "type": "integer",
+                  "title": "Number of owners",
+                  "nullable": true
+                },
+                "numberOfExpats": {
+                  "type": "integer",
+                  "title": "Number of expat buyers",
+                  "nullable": true
+                },
+                "giftedEquity": {
+                  "type": "boolean",
+                  "title": "Gifted equity"
+                },
+                "numberOfGiftedDeposits": {
+                  "type": "integer",
+                  "title": "Number of gifted deposits",
+                  "nullable": true
+                },
+                "requiresMortgage": {
+                  "type": "string",
+                  "title": "Requires mortgage",
+                  "enum": ["Yes", "No"]
+                }
+              },
+              "discriminator": {
+                "propertyName": "requiresMortgage"
+              },
+              "required": ["requiresMortgage"],
+              "oneOf": [
+                {
+                  "properties": {
+                    "requiresMortgage": {
+                      "enum": ["No"]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "requiresMortgage": {
+                      "enum": ["Yes"]
+                    },
+                    "helpToBuyEquityLoan": {
+                      "type": "boolean",
+                      "title": "Help to Buy equity loan"
+                    },
+                    "armedForcesHelpToBuy": {
+                      "type": "boolean",
+                      "title": "Armed Forces Help to Buy"
+                    },
+                    "numberOfHelpToBuyIsas": {
+                      "type": "integer",
+                      "title": "Number of Help to Buy ISAs",
+                      "nullable": true
+                    },
+                    "bridgingFinanceRepresentation": {
+                      "type": "string",
+                      "title": "Bridging finance representation",
+                      "enum": ["Dual", "Separate"],
+                      "nullable": true
+                    },
+                    "depositAmount": {
+                      "type": "number",
+                      "title": "Deposit amount",
+                      "minimum": 0
+                    },
+                    "loanToValue": {
+                      "type": "number",
+                      "title": "Loan-to-Value (LTV)",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "numberOfBorrowers": {
+                      "type": "integer",
+                      "title": "Number of borrowers",
+                      "minimum": 1,
+                      "maximum": 4,
+                      "default": 1
+                    },
+                    "jointProprietorSoleMortgagor": {
+                      "type": "boolean",
+                      "title": "Joint proprietor, sole mortgagor"
+                    },
+                    "soleProprietorJointMortgagor": {
+                      "type": "boolean",
+                      "title": "Sole proprietor, joint mortgagor"
+                    },
+                    "deedOfPostponement": {
+                      "type": "boolean",
+                      "title": "Deed of postponement required"
+                    },
+                    "separateRepresentation": {
+                      "type": "boolean",
+                      "title": "Separate legal representation required",
+                      "nullable": true
+                    },
+                    "oldestBorrowerAge": {
+                      "type": "integer",
+                      "title": "Oldest borrower age",
+                      "minimum": 18,
+                      "maximum": 85
+                    },
+                    "mortgageTerm": {
+                      "type": "integer",
+                      "title": "Mortgage term",
+                      "minimum": 5,
+                      "maximum": 40
+                    },
+                    "adverseCredit": {
+                      "type": "string",
+                      "title": "Adverse credit",
+                      "enum": ["No", "Yes", "Prefer not to say"]
+                    },
+                    "employmentType": {
+                      "type": "string",
+                      "title": "Employment type",
+                      "enum": [
+                        "Employed",
+                        "Self-employed",
+                        "Retired",
+                        "Contractor",
+                        "Other"
+                      ]
+                    },
+                    "existingMortgagedProperties": {
+                      "type": "integer",
+                      "title": "Existing mortgaged properties",
+                      "minimum": 0
+                    },
+                    "annualIncome": {
+                      "type": "number",
+                      "title": "Annual gross income",
+                      "minimum": 0
+                    },
+                    "residencyStatus": {
+                      "type": "string",
+                      "title": "Residency status",
+                      "enum": [
+                        "UK citizen",
+                        "Permanent resident",
+                        "Visa holder",
+                        "Non-resident"
+                      ]
+                    },
+                    "nominatedLender": {
+                      "type": "string",
+                      "title": "Nominated lender"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "enquiries": {
+      "title": "Property transaction enquiries between conveyancers",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+      },
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "subject": {
+              "description": "The subject or topic of the enquiry",
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "open",
+                "resolved",
+                "resolvedWithCondition",
+                "withdrawn"
+              ]
+            },
+            "messages": {
+              "description": "Messages exchanged regarding this enquiry",
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+              },
+              "patternProperties": {
+                ".*": {
+                  "type": "object",
+                  "properties": {
+                    "datetime": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "originatorRole": {
+                      "type": "string",
+                      "enum": [
+                        "Seller",
+                        "Seller's Conveyancer",
+                        "Buyer",
+                        "Buyer's Conveyancer",
+                        "Estate Agent",
+                        "Buyer's Agent",
+                        "Surveyor",
+                        "Mortgage Broker",
+                        "Lender"
+                      ]
+                    },
+                    "destinationRole": {
+                      "type": "string",
+                      "enum": [
+                        "Seller",
+                        "Seller's Conveyancer",
+                        "Buyer",
+                        "Buyer's Conveyancer",
+                        "Estate Agent",
+                        "Buyer's Agent",
+                        "Surveyor",
+                        "Mortgage Broker",
+                        "Lender"
+                      ]
+                    },
+                    "messageText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "datetime",
+                    "originatorRole",
+                    "destinationRole",
+                    "messageText"
+                  ]
+                }
+              }
+            },
+            "externalIds": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "required": ["subject", "status", "messages"],
+          "discriminator": {
+            "propertyName": "status"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "status": {
+                  "const": "resolvedWithCondition"
+                },
+                "resolutionCondition": {
+                  "description": "Condition that must be met for the enquiry to be fully resolved",
+                  "type": "string"
+                }
+              },
+              "required": ["resolutionCondition"]
+            },
+            {
+              "properties": {
+                "status": {
+                  "enum": ["pending", "open", "resolved", "withdrawn"]
+                }
+              }
+            }
+          ]
         }
       }
     }

--- a/src/schemas/v3/compactSkeleton.txt
+++ b/src/schemas/v3/compactSkeleton.txt
@@ -1,5 +1,5 @@
   transactionId
-  externalIds
+  externalIds{*}
   status
   participants[
     name
@@ -18,7 +18,7 @@
       street
       line1
       line2
-      line 3
+      line3
       town
       postcode
       homeNation
@@ -26,12 +26,42 @@
     organisation
     organisationReference
     role
-    externalIds
+    externalIds{*}
     participantStatus
+    verification
+      identity
+        status
+        result
+        reports[
+          reportName
+          result
+          details
+        ]
+      antiMoneyLaundering
+        status
+        result
+        reports[
+          reportName
+          result
+          details
+        ]
+      sourceOfFunds
+        status
+        result
+        reports[
+          reportName
+          result
+          details
+        ]
+    offerId
     sellersCapacity
       capacity
       sellersCapacityDetails
       attachments
+      companyName
+      companyNumber
+      countryOfIncorporation
+    dateBecameOwnerOrAuthority
   ]
   propertyPack
     address
@@ -182,6 +212,8 @@
     ownership
       numberOfSellers
       numberOfNonUkResidentSellers
+      outstandingMortgage
+      existingLender
       hasHelpToBuyEquityLoan
       isFirstRegistration
       isLimitedCompanySale
@@ -193,6 +225,9 @@
           yesNo
           details
           amount
+        titleRestrictions
+          yesNo
+          details
         wholeFreeholdForSale
           yesNo
           details
@@ -283,6 +318,17 @@
                 isApplicableParty
                 feeIncludingVAT
                 noticeViaEmail
+                contact
+                  nameOrOrganisation
+                  address
+                    line1
+                    line2
+                    line3
+                    town
+                    postcode
+                  telephone
+                  emailAddress
+                capacity
               otherDetailsRequired
                 areOtherDetailsRequired
                 details
@@ -407,6 +453,9 @@
             response
             capacity
         leaseholdInformation
+          typeOfLeasehold
+            leaseholdType
+            otherLeaseholdType
           sharedOwnership
             isSharedOwnership
             sharedOwnershipPercentage
@@ -468,6 +517,39 @@
                   accountNumber
                   reference
                   feeType
+              rightToManageCompany
+                contact
+                  nameOrOrganisation
+                  address
+                    line1
+                    line2
+                    line3
+                    town
+                    postcode
+                  emailAddress
+                  telephone
+              freeholder
+                contact
+                  nameOrOrganisation
+                  address
+                    line1
+                    line2
+                    line3
+                    town
+                    postcode
+                  emailAddress
+                  telephone
+              headLeaseHolder
+                contact
+                  nameOrOrganisation
+                  address
+                    line1
+                    line2
+                    line3
+                    town
+                    postcode
+                  emailAddress
+                  telephone
               managingAgent
                 contact
                   nameOrOrganisation
@@ -533,6 +615,17 @@
                   isApplicableParty
                   feeIncludingVAT
                   noticeViaEmail
+                  contact
+                    nameOrOrganisation
+                    address
+                      line1
+                      line2
+                      line3
+                      town
+                      postcode
+                    telephone
+                    emailAddress
+                  capacity
               noticeOfTransferAndCharge
                 rentchargeOwner
                   isApplicableParty
@@ -554,12 +647,27 @@
                   isApplicableParty
                   feeIncludingVAT
                   noticeViaEmail
+                  contact
+                    nameOrOrganisation
+                    address
+                      line1
+                      line2
+                      line3
+                      town
+                      postcode
+                    telephone
+                    emailAddress
+                  capacity
                 otherDetailsRequired
                   areOtherDetailsRequired
                   details
               collectsGroundRent
+                collector
+                otherCollector
               collectsServiceCharges
               collectsbuildingInsurancePremiums
+                collector
+                otherCollector
               dealsWithDayToDayMaintenanceOfManagedArea
               organisesBuildingInsurance
               dealsWithDayToDayMaintenanceOfBuilding
@@ -577,6 +685,10 @@
           consents
             changesInTermOfLease
               isSellerAwareOfChanges
+              details
+              attachments
+            landlordConsents
+              isSellerAwareOfLandlordConsents
               details
               attachments
           transferAndRegistration
@@ -598,6 +710,7 @@
             isGroundRentPayable
             annualGroundRent
             groundRentFrequency
+            mostRecentGroundRentDemandStatus
             rentSubjectToIncrease
               yesNo
               rentReviewFrequency
@@ -616,11 +729,16 @@
             buildingManager
               buildingManagerType
               details
-            hasTenantCompanyDissolved
             isManagingAgentEmployed
+            sellerOwnership
+              yesNo
+              attachments
+            hasTenantCompanyDissolved
+            hasTenantCompanyDissolvedDetails
           serviceCharge
             sellerContributesToServiceCharge
             annualServiceCharge
+            mostRecentServiceChargeDemandStatus
             largeAdditionalExpense
               yesNo
               details
@@ -631,6 +749,8 @@
               yesNo
               details
             dangerousCladdingOrDefects
+              yesNo
+              details
             difficultyInCollectingServiceCharge
               yesNo
               details
@@ -692,6 +812,7 @@
             premiumsPaidUpToDate
               yesNo
               details
+            mostRecentBuildingsInsuranceDemandStatus
             lastDemandPeriod
               from
               to
@@ -709,6 +830,9 @@
               riskAssessments
                 assessmentsCarriedOut
                 urgentWorksRecommended
+                urgentWorksCarriedOut
+                outstandingEnforcementAction
+                dateRemedialActionRequired
             standardTermsAvailable
               yesNo
               details
@@ -815,6 +939,9 @@
               companyAccounts
             managementCompanyAGMMinutes
             enforcementNotices
+          additionalInformation
+            details
+            attachments
           confirmationOfAccuracy
             confirmation
             capacity
@@ -827,11 +954,20 @@
       controlledParking
         yesNo
         annualCostOfPermit
+        costOfPermit
+        costOfPermitFrequency
       vehicleTypeRestriction
         yesNo
         details
+      droppedKerbAccess
+        yesNo
       electricVehicleChargingPoint
         yesNo
+        chargerDetails
+        chargerDetailsAttachments
+        cableCrossesPavement
+          yesNo
+          details
       locatedInUlez
         yesNo
     listingAndConservation
@@ -847,6 +983,7 @@
         yesNo
         workCarriedOut
           yesNo
+          details
           consentsObtained
           attachments
     typeOfConstruction
@@ -1036,6 +1173,10 @@
           yesNo
           attachments
           details
+      nonResidentialPurposes
+        yesNo
+        details
+        attachments
       windowReplacementsSince2002
         yesNo
         details
@@ -1056,6 +1197,25 @@
           yesNo
           attachments
           details
+        workCompleted
+          yesNo
+          details
+        documents
+      extension
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
       hasAddedConservatory
         yesNo
         details
@@ -1073,6 +1233,100 @@
           attachments
           details
         deedRestrictionConsent
+          yesNo
+          attachments
+          details
+        workCompleted
+          yesNo
+          details
+        documents
+      loftConversion
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
+      garageConversion
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
+      removalOfInternalWalls
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
+      removalOfChimneyBreast
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
+      insulation
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
+          yesNo
+          attachments
+          details
+      otherBuildingWorksOrChangesToTheProperty
+        yesNo
+        details
+        workCompleted
+          yesNo
+          details
+        documents
+        planningPermission
+          yesNo
+          attachments
+          details
+        buildingRegApproval
           yesNo
           attachments
           details
@@ -1129,6 +1383,9 @@
         details
         attachments
       japaneseKnotweed
+        knotweedSurveyCarriedOut
+          yesNo
+          attachments
         yesNo
         managementPlanInPlace
         attachments
@@ -1140,6 +1397,18 @@
         yesNo
         details
         attachments
+      wellsDitchesShaft
+        yesNo
+        details
+      damagedOrExposedElectrics
+        yesNo
+        details
+      damageToFlooringOrStaircases
+        yesNo
+        details
+      knownAreasInPoorCondition
+        yesNo
+        details
     fixturesAndFittings
       itemsToRemove
         yesNo
@@ -1356,6 +1625,7 @@
         otherRooms[
           itemName
           isIncludedOrExcluded
+          comments
           price
         ]
       curtainsAndCurtainRails
@@ -1426,6 +1696,7 @@
           otherRooms[
             itemName
             isIncludedOrExcluded
+            comments
             price
           ]
       lightFittings
@@ -1604,11 +1875,15 @@
       solarPanels
         yesNo
         supplier
+        hotWaterOnly
         yearInstalled
         panelsOwnedOutright
           yesNo
           details
           attachments
+          associatedCost
+            frequency
+            amount
         panelProviderLease
           yesNo
           details
@@ -1617,11 +1892,23 @@
         inGoodWorkingOrder
           yesNo
           details
-        isConnectedToNationalGrid
         photovoltaicMeterPanelLocation
           attachments
-        photovoltaicBatteriesLocation
+        maintenanceAgreement
+          yesNo
           attachments
+        photovoltaicBatteries
+          yesNo
+          attachments
+          details
+        nationalGrid
+          yesNo
+          fitOrSegInPlace
+            yesNo
+            fitSegAgreementCopy
+            attachments
+            fitSegAssignmentProcedure
+        installationCertificates
         dateToBeConnected
       heatPump
         yesNo
@@ -1629,6 +1916,8 @@
         supplier
         dateInstalled
         attachments
+        makeModel
+        serviceProviderName
         dateToBeConnected
       otherSources
         yesNo
@@ -1643,6 +1932,9 @@
         mainsWater
           yesNo
           details
+          associatedCost
+            frequency
+            amount
           supplier
           stopcock
             location
@@ -1686,13 +1978,22 @@
               attachments
             plantDrainsIntoWaterway
               yesNo
+              hasInfiltrationSystem
+                yesNo
               dischargeCompliesWithGBR
+            dateDischargeCommenced
+            dateInstalled
             dateReplaced
             dateLastEmptied
-            dateInstalled
+            supplier
+            makeModel
+            serviceProviderName
             dateLastServiced
             attachments
             details
+          associatedCost
+            frequency
+            amount
         surfaceDrainageCharge
           yesNo
           details
@@ -1744,6 +2045,10 @@
           centralHeatingInstalled
           boilerInstallationCertificate
             yesNo
+            boilerInstallationDate
+            attachments
+          replacementOtherThanBoiler
+            yesNo
             attachments
           heatingLastServicedDate
           heatingLastServicedReport
@@ -1752,6 +2057,7 @@
             details
         details
       otherHeatingFeatures[]
+      multipleHeatingSystems
     connectivity
       telephone
         yesNo
@@ -1772,6 +2078,7 @@
           maxUfbbPredictedUp
           maxPredictedDown
           maxPredictedUp
+        providerName
       mobilePhone
         knownSignalIssues
           yesNo
@@ -1809,6 +2116,7 @@
           voDataOutdoorNo4g
           voDataIndoor
           voDataIndoorNo4g
+      otherServices
     insurance
       difficultiesObtainingInsurance
         abnormalRiseInPremiums
@@ -1826,6 +2134,7 @@
       isInsured
       details
       landlordInsuresIfFlat
+      whoInsures
       insuranceClaims
         yesNo
         details
@@ -1833,9 +2142,15 @@
       sharedContributions
         yesNo
         details
+        disagreementOrComplaint
+          yesNo
+          details
       neighbouringLandRights
         yesNo
         details
+        disagreementOrComplaint
+          yesNo
+          details
         attachments
       accessRestrictionAttempts
         yesNo
@@ -1845,6 +2160,9 @@
           yesNo
           details
           attachments
+        privateRightOfWay
+          yesNo
+          details
         rightsOfLight
           yesNo
           details
@@ -1866,8 +2184,20 @@
         otherRights
           yesNo
           details
+        disagreementOrComplaint
+          yesNo
+          details
+      askedOthersToContribute
+        yesNo
+        details
+        disagreementOrComplaint
+          yesNo
+          details
     environmentalIssues
       flooding
+        floodRiskReport
+          hasReportBeenPrepared
+          attachments
         floodRisk
           riskIndicator
           actionAlertRating
@@ -1891,6 +2221,9 @@
         floodDefences
           hasFloodDefences
           details
+      stormFireFloodDamage
+        yesNo
+        details
       radon
         radonRisk
           riskIndicator
@@ -2102,6 +2435,14 @@
         details
         attachments
     additionalInformation
+      consents
+        attachments
+        consentsAttached
+        consentsToFollow
+        consentsNotAvailable
+      furtherInformation
+        details
+        attachments
       restrictionsOnUseNotCompliedWith
         yesNo
         details
@@ -2215,10 +2556,21 @@
       doubleGlazing
         yesNo
         attachments
+        fensaCertificates
+          certificates[
+            certificateId
+            numberOfWindows
+            numberOfDoors
+            certificateIssued
+            workCompleted
+          ]
       electricalRepairOrInstallation
         yesNo
         attachments
       subsidenceWork
+        yesNo
+        attachments
+      insulation
         yesNo
         attachments
       solarPanels
@@ -2232,6 +2584,9 @@
         yesNo
         details
         attachments
+      breachOfTermsOrConditions
+        yesNo
+        details
       titleDefectInsurance
         yesNo
         details
@@ -2287,7 +2642,7 @@
       sellerSignatures[
         name
         signedOn
-        externalIds
+        externalIds{*}
       ]
     localSearches
       localLandCharges[
@@ -3251,7 +3606,714 @@
       fileName
       mimeType
       documentType
-      externalIds
+      externalIds{*}
+      isDeleted
+      summary
+    ]
+    surveys[
+      outside
+        chimneyStacks
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          visibilityRestriction
+          flashings
+          defectsFlag
+          defectsList
+          photos[
+            photoId
+            report
+          ]
+        roofCoverings
+          condition
+          defects
+          advisories
+          notes
+          visibility
+          restriction
+          features
+          mainPitchedCovering
+          mainPitchedFeatures
+          mainFlatCovering
+          mainFlatFeatures
+          additionalPitchedCovering
+          additionalPitchedFeatures
+          additionalDetail
+          additionalFeatures
+          bay
+          bayFeatures
+          dormer
+          dormerFeatures
+          defectsGeneral
+          photos[
+            photoId
+            report
+          ]
+          mainPitchedDefects
+          mainPitchedDefectsDetail
+          mainFlatDefects
+          mainFlatDefectsDetail
+          additionalPitchedDefects
+          additionalPitchedDefectsDetail
+          additionalFlatDefects
+          additionalFlatDefectsDetail
+          bayDefects
+          bayDefectsDetail
+          dormerDefects
+          dormerDefectsDetail
+        rainwaterPipesGutters
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          features
+          gutterDescription
+          downpipeDescription
+          hopperHeadDescription
+          gutterIssues
+          gutterIssueLocation
+          gutterDefect
+          downpipeDefect
+          hopperHeadDefect
+          photos[
+            photoId
+            report
+          ]
+        mainWalls
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          externalElevation
+          construction
+          features
+          dpc
+          structuralMovement
+          movementType
+          movementCause
+          movementStatus
+          otherDefects
+          otherDefectsDescription
+          cladding
+          fireRisk
+          advice
+          extensions
+          movementLocation
+          photos[
+            photoId
+            report
+          ]
+          extension1
+            detail
+            construction
+            dpc
+            defects
+            defectDescription
+            movementType
+            movementCause
+            movementStatus
+          extension2
+            detail
+            construction
+            dpc
+            defects
+            defectDescription
+            movementType
+            movementCause
+            movementStatus
+          extension3
+            detail
+            construction
+            dpc
+            defects
+            defectDescription
+            movementType
+            movementCause
+            movementStatus
+        windows
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          visibilityRestrictions
+          glazingType
+          glazingDescription
+          glazingHeight
+          glazingSafety
+          glazingDefects
+          glazingDefectList
+          photos[
+            photoId
+            report
+          ]
+        outsideDoors
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          glazingDescription
+          glazingType
+          glazingHeight
+          glazingSafety
+          glazingDefects
+          glazingDefectDetails
+          photos[
+            photoId
+            report
+          ]
+        conservatoryPorches
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          conservatory
+          porch
+          restrictions
+          visibility
+          conservatoryWall
+          conservatoryFrame
+          conservatoryGlazing
+          conservatoryRoof
+          conservatorySeparate
+          conservatoryHeating
+          porchWall
+          porchFrame
+          porchGlazing
+          porchRoof
+          porchPitched
+          porchFlat
+          defectsFlag
+          defectLocation
+          conservatoryEconomic
+          conservatoryStructural
+          conservatoryMovement
+          conservatoryMovementCause
+          conservatoryMovementStatus
+          conservatoryDefects
+          conservatoryDefectDetail
+          porchEconomic
+          porchStructural
+          porchMovement
+          porchMovementCause
+          porchMovementStatus
+          porchDefects
+          porchDefectDetail
+          photos[
+            photoId
+            report
+          ]
+        otherJoinery
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          features
+          fasciaDescription
+          bargeboardsDescription
+          soffitsDescription
+          claddingDescription
+          issues
+          issueLocation
+          issueDetail
+          photos[
+            photoId
+            report
+          ]
+        other
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          defectsFlag
+          defectDetail
+          fireSafety
+          photos[
+            photoId
+            report
+          ]
+      inside
+        roofStructure
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          lining
+          insulation
+          firewall
+          features
+          photos
+            photoId
+            report
+          additional1Visibility
+          additional1Restrictions
+          additional1Description
+          additional1Lining
+          additional1Insulation
+          additional1Defects
+          additional1DefectDetail
+          additional2Visibility
+          additional2Restrictions
+          additional2Description
+          additional2Lining
+          additional2Insulation
+          additional2Defects
+          additional2DefectDetail
+          defectDetail
+        ceilings
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          defectDetail
+          integralGarageDefects
+          photos
+            photoId
+            report
+        wallsPartitions
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          construction
+          adequateSupport
+          wallFinish
+          defectsMinor
+          defectsMajor
+          photos
+            photoId
+            report
+        floors
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          generalDefects
+          solidDefects
+          timberDefects
+          photos
+            photoId
+            report
+        fireplaces
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          defectDetail
+          photos
+            photoId
+            report
+        builtinFittings
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          defectDetail
+          advice
+          photos
+            photoId
+            report
+        woodwork
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          doorDescription
+          stairDescription
+          joineryDescription
+          defectsDetail
+          defectsDoorsWindows
+          defectsStairs
+          photos
+            photoId
+            report
+        bathroomFittings
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          restrictions
+          defectDetail
+          photos
+            photoId
+            report
+        other
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          visibility
+          roofConversion
+          cellar
+          commonAreas
+          alarms
+          defectsRoof
+          defectsBasement
+          defectsOther
+          photos
+            photoId
+            report
+      services
+        electricity
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          meter
+          consumerUnit
+          cutOffDevices
+          wiring
+          additionalFeatures
+          supplementary
+          testCertificate
+          defectsPresent
+          defectDetail
+        gasOil
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          meter
+          privateGas
+          tankLocation
+          tankInside
+          tankOutside
+          tankType
+          testCertificate
+          defectsPresent
+          defectDetail
+        water
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          stopTap
+          supply
+          distribution
+          storageTank
+          defectsPresent
+          defectDetail
+        heating
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          extent
+          source
+          emitter
+          pipework
+          controls
+          otherFeatures
+          testCertificate
+          defectsPresent
+          defectDetail
+        waterHeating
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          primarySource
+          supplementarySource
+          storage
+          pipework
+          defectsPresent
+          defectDetail
+        drainage
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          restrictions
+          system
+          privateSystem
+          location
+          runOff
+          features
+          defectsPresent
+          defectDetail
+        commonServices
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos[
+            photoId
+            report
+          ]
+          visibility
+          type
+          defectsPresent
+          defectDetail
+      grounds
+        garage
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos
+            photoId
+            report
+          visibility
+          restrictions
+          wallConstruction
+          roofConstruction
+          location
+          structuralMovement
+          movementType
+          movementStatus
+          hasDefects
+          defectDetail
+        permanentOutbuildings
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos
+            photoId
+            report
+          visibility
+          restrictions
+          type
+          wallConstruction
+          roofConstruction
+          location
+          hasDefects
+          defectDetail
+        other
+          condition
+          inspectionLimitations
+          defects
+          advisories
+          notes
+          photos
+            photoId
+            report
+          visibility
+          restrictions
+          gardens
+          exceed1Acre
+          boundaries
+            fenceDescription
+            fenceIssues
+            fenceDefects
+            wallDescription
+            wallIssues
+            wallDefects
+            hedgeDescription
+            hedgeIssues
+            hedgeDefects
+            otherBoundaryDescription
+          hardscaping
+            drivewayLandscaping
+            driveMaterial
+            driveDefects
+            driveDefectDetail
+            patioMaterial
+            patioDefects
+            patioDefectDetail
+            pathMaterial
+            pathDefects
+            pathDefectDetail
+            deckingMaterial
+            deckingDefects
+            deckingDefectDetail
+          buildingRegs
+          otherFeatures
+          japaneseKnotweed
+          otherDefects
+          otherDefectDetail
+      legalIssues
+        notes
+        regulation
+        guarantees
+        otherMatters
+        rightsOfWay
+      risks
+        buildingRisks
+        groundsRisks
+        peopleRisks
+        otherRisks
+      propertyValuation
+        valuation
+          valuationDiscriminator
+          value
+          valueWords
+          reinstatement
+          reinstatementWords
+          tenure
+          lease
+          areaOfProperty
+        valuationInformation
+          additionalAssumptions
+          considerations
+      declaration
+        surveyorQuals
+        companyAddress
+        phoneNumber
+        faxNumber
+        email
+        website
+        clientName
+      misc
+        photoFront
+          value
+          photoId
+          report
+        areaOfProperty
+          value
+          photoId
+          report
+        reportDate
+        epc
+        agentName
+        access
+        propertyQuestions
+        propertyChanges
+        alterations
+        furnishings
+        floorCoverings
+        propertyType
+        accommodationLocation
+        propertyStyle
+        topography
+        floodingRisk
+        coastalLocation
+        siteRisk
+        highVoltage
+        buildFormat
+        areaDetails
+        groundRentType
+        conservationArea
+        valuationFactor
+        conflict
+        conflictType
+        suspiciousActivity
+        btl
+        photoConsent
+        adjacentCommercial
+        commercialLocation
+        commercialTypeAbove
+        commercialTypeAdjacent
+        separateAccess
+        communal
+        communalFacilities
+        listedBuilding
+        listedClassification
+        exla
+        exNature
+        tenureSource
+        roadType
+        roadMadeUp
+        pedestrian
+        constructionType
+        nonTradType
+        nonTradSystem
+        designatedDefective
+        epcAvailable
+        epcReason
+        epcDiscrepancies
+        epcDiscrepancyDetail
+    ]
+    valuations[
+      valuationId
+      valuationTimestamp
+      capitalValue
+      confidenceLevel
+      confidenceBand
+      rentalValue
+      rentalConfidenceLevel
+      reinstatementCost
+      checkValuationResult
+      instructionType
+      valuationContext
+      valuationType
     ]
   valuationComparisonData
     propertyDetails[
@@ -3293,7 +4355,7 @@
       template
         name
         url
-        externalIds
+        externalIds{*}
         requiredSignatories[
           role
           requiresAll
@@ -3302,13 +4364,13 @@
     signatures[
       name
       signedOn
-      externalIds
+      externalIds{*}
     ]
   ]
   chain
     onwardPurchase[
       transactionId
-      externalIds
+      externalIds{*}
       address
         buildingNumber
         buildingName
@@ -3323,3 +4385,73 @@
       uprn
       sellingAgent
     ]
+  milestones
+    listed
+      expected
+      completed
+    legalForms
+      started
+      completed
+    soldSubjectToContract
+      completed
+    searches
+      started
+      expected
+      completed
+    enquiries
+      started
+      completed
+    exchangeOfContracts
+      expected
+      completed
+    completion
+      started
+      expected
+      completed
+  offers{*}
+    amount
+    currency
+    status
+    inclusions[]
+    exclusions[]
+    conditions[]
+    externalIds{*}
+    buyerCircumstances
+      intendedUse
+      firstTimeBuyer
+      rightToBuy
+      ltdCompanyPurchase
+      numberOfOwners
+      numberOfExpats
+      giftedEquity
+      numberOfGiftedDeposits
+      requiresMortgage
+      helpToBuyEquityLoan
+      armedForcesHelpToBuy
+      numberOfHelpToBuyIsas
+      bridgingFinanceRepresentation
+      depositAmount
+      loanToValue
+      numberOfBorrowers
+      jointProprietorSoleMortgagor
+      soleProprietorJointMortgagor
+      deedOfPostponement
+      separateRepresentation
+      oldestBorrowerAge
+      mortgageTerm
+      adverseCredit
+      employmentType
+      existingMortgagedProperties
+      annualIncome
+      residencyStatus
+      nominatedLender
+  enquiries{*}
+    subject
+    status
+    messages{*}
+      datetime
+      originatorRole
+      destinationRole
+      messageText
+    externalIds{*}
+    resolutionCondition

--- a/src/schemas/v3/overlays/baspi4.json
+++ b/src/schemas/v3/overlays/baspi4.json
@@ -17,7 +17,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -28,6 +27,15 @@
                   "Lender",
                   "Landlord",
                   "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
                 ]
               }
             }
@@ -67,8 +75,29 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi4Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi4Ref": "B1.3.3"
+                      }
+                    },
+                    "required": [
+                      "sellersCapacityDetails",
+                      "attachments"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
                         ]
                       },
                       "sellersCapacityDetails": {
@@ -1144,6 +1173,29 @@
             },
             "electricVehicleChargingPoint": {
               "baspi4Ref": "A1.6.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -1405,7 +1457,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -1445,7 +1499,6 @@
               "required": [
                 "yesNo"
               ],
-              "title": "Are you aware of any remediation required to the property due to building safety?",
               "properties": {
                 "yesNo": {
                   "baspi4Ref": "A1.8.2.1",
@@ -3257,13 +3310,20 @@
                     },
                     "managementPlanInPlace": {
                       "baspi4Ref": "A5.3.2"
-                    },
-                    "attachments": {
-                      "baspi4Ref": "A5.3.3"
                     }
                   },
                   "required": [
                     "managementPlanInPlace"
+                  ],
+                  "oneOf": [
+                    null,
+                    {
+                      "properties": {
+                        "attachments": {
+                          "baspi4Ref": "A5.3.3"
+                        }
+                      }
+                    }
                   ]
                 }
               ],
@@ -3698,9 +3758,6 @@
                         }
                       }
                     },
-                    "isConnectedToNationalGrid": {
-                      "baspi4Ref": "B4.3.6"
-                    },
                     "photovoltaicMeterPanelLocation": {
                       "baspi4Ref": "B4.7",
                       "properties": {
@@ -3712,14 +3769,72 @@
                         }
                       }
                     },
-                    "photovoltaicBatteriesLocation": {
+                    "photovoltaicBatteries": {
                       "baspi4Ref": "B4.8",
-                      "properties": {
-                        "description": {
-                          "baspi4Ref": "4.8.1"
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
                         },
-                        "attachments": {
-                          "baspi4Ref": "4.8.2"
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "description": {
+                              "baspi4Ref": "4.8.1"
+                            },
+                            "attachments": {
+                              "baspi4Ref": "4.8.2"
+                            }
+                          },
+                          "required": [
+                            "description"
+                          ]
+                        }
+                      ]
+                    },
+                    "nationalGrid": {
+                      "baspi4Ref": "B4.3.6",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi4Ref": "B4.3.6"
                         }
                       }
                     }
@@ -3730,7 +3845,7 @@
                     "panelProviderLease",
                     "lastMaintained",
                     "inGoodWorkingOrder",
-                    "isConnectedToNationalGrid"
+                    "nationalGrid"
                   ]
                 },
                 {
@@ -4622,7 +4737,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -4801,6 +4917,35 @@
             },
             "broadband": {
               "baspi4Ref": "A7.1.0.7",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "typeOfConnection"
+              ],
               "properties": {
                 "typeOfConnection": {
                   "baspi4Ref": "A7.1.0.7.2"
@@ -5126,7 +5271,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -5210,7 +5356,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -5663,7 +5810,8 @@
                       "properties": {
                         "yesNo": {
                           "enum": [
-                            "No"
+                            "No",
+                            "Not known"
                           ]
                         }
                       }
@@ -5693,7 +5841,11 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspi4Ref": "A11.1.3.1"
+                      "baspi4Ref": "A11.1.3.1",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
                     }
                   }
                 },
@@ -5720,8 +5872,7 @@
                   "properties": {
                     "riskIndicator": {
                       "enum": [
-                        "No",
-                        "Not known"
+                        "No"
                       ]
                     }
                   }
@@ -6493,7 +6644,8 @@
                     "yesNo": {
                       "enum": [
                         "No",
-                        "Not applicable"
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -6700,7 +6852,11 @@
                       "baspi4Ref": "B4.1.2"
                     },
                     "attachments": {
-                      "baspi4Ref": "B4.1.3"
+                      "baspi4Ref": "B4.1.3",
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
                     }
                   },
                   "required": [
@@ -6758,7 +6914,11 @@
                           "baspi4Ref": "B4.2.3.1"
                         },
                         "attachments": {
-                          "baspi4Ref": "B4.2.3.2"
+                          "baspi4Ref": "B4.2.3.2",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
                         }
                       }
                     }

--- a/src/schemas/v3/overlays/baspi5.json
+++ b/src/schemas/v3/overlays/baspi5.json
@@ -17,7 +17,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -28,6 +27,15 @@
                   "Lender",
                   "Landlord",
                   "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
                 ]
               }
             }
@@ -67,8 +75,29 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "baspi5Ref": "B1.3.2"
+                      },
+                      "attachments": {
+                        "baspi5Ref": "B1.3.3"
+                      }
+                    },
+                    "required": [
+                      "sellersCapacityDetails",
+                      "attachments"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
                         ]
                       },
                       "sellersCapacityDetails": {
@@ -1232,12 +1261,12 @@
                         "Yes"
                       ]
                     },
-                    "annualCostOfPermit": {
+                    "costOfPermit": {
                       "baspi5Ref": "A1.6.0.2.2"
                     }
                   },
                   "required": [
-                    "annualCostOfPermit"
+                    "costOfPermit"
                   ]
                 }
               ],
@@ -1292,6 +1321,29 @@
             },
             "electricVehicleChargingPoint": {
               "baspi5Ref": "A1.6.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -1553,7 +1605,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -1593,7 +1647,6 @@
               "required": [
                 "yesNo"
               ],
-              "title": "Are you aware of any remediation required to the property due to building safety?",
               "properties": {
                 "yesNo": {
                   "baspi5Ref": "A1.8.2.1",
@@ -3408,13 +3461,20 @@
                     },
                     "managementPlanInPlace": {
                       "baspi5Ref": "A5.3.2"
-                    },
-                    "attachments": {
-                      "baspi5Ref": "A5.3.3"
                     }
                   },
                   "required": [
                     "managementPlanInPlace"
+                  ],
+                  "oneOf": [
+                    null,
+                    {
+                      "properties": {
+                        "attachments": {
+                          "baspi5Ref": "A5.3.3"
+                        }
+                      }
+                    }
                   ]
                 }
               ],
@@ -3849,9 +3909,6 @@
                         }
                       }
                     },
-                    "isConnectedToNationalGrid": {
-                      "baspi5Ref": "B4.3.6"
-                    },
                     "photovoltaicMeterPanelLocation": {
                       "baspi5Ref": "B4.7",
                       "properties": {
@@ -3863,14 +3920,72 @@
                         }
                       }
                     },
-                    "photovoltaicBatteriesLocation": {
+                    "photovoltaicBatteries": {
                       "baspi5Ref": "B4.8",
-                      "properties": {
-                        "description": {
-                          "baspi5Ref": "4.8.1"
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
                         },
-                        "attachments": {
-                          "baspi5Ref": "4.8.2"
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "description": {
+                              "baspi5Ref": "4.8.1"
+                            },
+                            "attachments": {
+                              "baspi5Ref": "4.8.2"
+                            }
+                          },
+                          "required": [
+                            "description"
+                          ]
+                        }
+                      ]
+                    },
+                    "nationalGrid": {
+                      "baspi5Ref": "B4.3.6",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "baspi5Ref": "B4.3.6"
                         }
                       }
                     }
@@ -3881,7 +3996,7 @@
                     "panelProviderLease",
                     "lastMaintained",
                     "inGoodWorkingOrder",
-                    "isConnectedToNationalGrid"
+                    "nationalGrid"
                   ]
                 },
                 {
@@ -4773,7 +4888,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -4952,6 +5068,35 @@
             },
             "broadband": {
               "baspi5Ref": "A7.1.0.7",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "typeOfConnection"
+              ],
               "properties": {
                 "typeOfConnection": {
                   "baspi5Ref": "A7.1.0.7.2"
@@ -5277,7 +5422,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -5361,7 +5507,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -5815,7 +5962,8 @@
                       "properties": {
                         "yesNo": {
                           "enum": [
-                            "No"
+                            "No",
+                            "Not known"
                           ]
                         }
                       }
@@ -5845,7 +5993,11 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "baspi5Ref": "A11.1.3.1"
+                      "baspi5Ref": "A11.1.3.1",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
                     }
                   }
                 },
@@ -5886,6 +6038,9 @@
                     }
                   }
                 }
+              ],
+              "required": [
+                "riskIndicator"
               ]
             },
             "otherEnvironmental": {
@@ -5898,8 +6053,7 @@
                   "properties": {
                     "riskIndicator": {
                       "enum": [
-                        "No",
-                        "Not known"
+                        "No"
                       ]
                     }
                   }
@@ -6640,7 +6794,8 @@
                     "yesNo": {
                       "enum": [
                         "No",
-                        "Not applicable"
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -6847,7 +7002,11 @@
                       "baspi5Ref": "B4.1.2"
                     },
                     "attachments": {
-                      "baspi5Ref": "B4.1.3"
+                      "baspi5Ref": "B4.1.3",
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
                     }
                   },
                   "required": [
@@ -6905,7 +7064,11 @@
                           "baspi5Ref": "B4.2.3.1"
                         },
                         "attachments": {
-                          "baspi5Ref": "B4.2.3.2"
+                          "baspi5Ref": "B4.2.3.2",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
                         }
                       }
                     }

--- a/src/schemas/v3/overlays/extensions/ac.json
+++ b/src/schemas/v3/overlays/extensions/ac.json
@@ -1,0 +1,334 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "alterationsAndChanges": {
+          "properties": {
+            "extension": {
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "A1.1.1",
+                  "type": "string"
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "details": {
+                      "ntsRef": "A1.1.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "planningPermission": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.1.3.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.1.3"
+                    },
+                    "buildingRegApproval": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.1.4.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.1.4"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "ntsRef": "A1.1"
+            },
+            "loftConversion": {
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "A1.2.1",
+                  "type": "string"
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "details": {
+                      "ntsRef": "A1.2.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "planningPermission": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.2.3.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.2.3"
+                    },
+                    "buildingRegApproval": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.2.4.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.2.4"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "ntsRef": "A1.2"
+            },
+            "garageConversion": {
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "A1.3.1",
+                  "type": "string"
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "details": {
+                      "ntsRef": "A1.3.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "planningPermission": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.3.3.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.3.3"
+                    },
+                    "buildingRegApproval": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.3.4.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.3.4"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "ntsRef": "A1.3"
+            },
+            "removalOfInternalWalls": {
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "A1.4.1",
+                  "type": "string"
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "details": {
+                      "ntsRef": "A1.4.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "planningPermission": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.4.3.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.4.3"
+                    },
+                    "buildingRegApproval": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.4.4.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.4.4"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "ntsRef": "A1.4"
+            },
+            "changeOfUse": {
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "A1.5.1",
+                  "type": "string"
+                }
+              },
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "details": {
+                      "ntsRef": "A1.5.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "planningPermission": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.5.3.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.5.3"
+                    },
+                    "buildingRegApproval": {
+                      "properties": {
+                        "yesNo": {
+                          "ntsRef": "A1.5.4.1",
+                          "type": "string"
+                        }
+                      },
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "ntsRef": "A1.5.4"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "ntsRef": "A1.5"
+            }
+          },
+          "required": [
+            "extension",
+            "loftConversion",
+            "garageConversion",
+            "removalOfInternalWalls",
+            "changeOfUse"
+          ],
+          "ntsRef": "A1"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/ac.json",
+  "$comment": "Selected alterations and changes fields for SEF25"
+}

--- a/src/schemas/v3/overlays/extensions/as.json
+++ b/src/schemas/v3/overlays/extensions/as.json
@@ -58,12 +58,14 @@
           },
           "required": [
             "containsAsbestos"
-          ]
+          ],
+          "ntsRef": "A5"
         }
       },
       "required": [
         "specialistIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/dk.json
+++ b/src/schemas/v3/overlays/extensions/dk.json
@@ -1,0 +1,33 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "parking": {
+          "properties": {
+            "droppedKerbAccess": {
+              "ntsRef": "K1.1",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "K1.1.1",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "droppedKerbAccess"
+          ],
+          "ntsRef": "B4"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/dk.json",
+  "$comment": "Dropped kerb access to parking"
+}

--- a/src/schemas/v3/overlays/extensions/dr.json
+++ b/src/schemas/v3/overlays/extensions/dr.json
@@ -38,17 +38,15 @@
                       "type": "string",
                       "minLength": 1
                     },
-                    "attachments": {
-                      "ntsRef": "A5.1.3",
-                      "type": "string",
-                      "enum": [
-                        "Attached",
-                        "To follow"
-                      ]
-                    },
                     "yesNo": {
                       "enum": [
                         "Yes"
+                      ]
+                    },
+                    "attachments": {
+                      "enum": [
+                        "Attached",
+                        "To follow"
                       ]
                     }
                   }
@@ -59,12 +57,14 @@
           },
           "required": [
             "dryRotEtcTreatment"
-          ]
+          ],
+          "ntsRef": "A5"
         }
       },
       "required": [
         "specialistIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/er.json
+++ b/src/schemas/v3/overlays/extensions/er.json
@@ -69,12 +69,14 @@
           },
           "required": [
             "ownershipsToBeTransferred"
-          ]
+          ],
+          "ntsRef": "A3"
         }
       },
       "required": [
         "ownership"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/fd.json
+++ b/src/schemas/v3/overlays/extensions/fd.json
@@ -53,17 +53,20 @@
               },
               "required": [
                 "floodDefences"
-              ]
+              ],
+              "ntsRef": "C3.1.1"
             }
           },
           "required": [
             "flooding"
-          ]
+          ],
+          "ntsRef": "C3.1"
         }
       },
       "required": [
         "environmentalIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/hi.json
+++ b/src/schemas/v3/overlays/extensions/hi.json
@@ -22,7 +22,8 @@
                       },
                       "required": [
                         "centralHeatingInstalled"
-                      ]
+                      ],
+                      "ntsRef": "B3.4.3"
                     }
                   },
                   "required": [
@@ -34,12 +35,14 @@
           },
           "required": [
             "heatingSystem"
-          ]
+          ],
+          "ntsRef": "B3.4"
         }
       },
       "required": [
         "heating"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/hs.json
+++ b/src/schemas/v3/overlays/extensions/hs.json
@@ -57,12 +57,14 @@
           },
           "required": [
             "ongoingHealthOrSafetyIssue"
-          ]
+          ],
+          "ntsRef": "A5"
         }
       },
       "required": [
         "specialistIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/ic.json
+++ b/src/schemas/v3/overlays/extensions/ic.json
@@ -1,0 +1,94 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "insurance": {
+          "ntsRef": "I1",
+          "required": [
+            "isInsured"
+          ],
+          "discriminator": {
+            "propertyName": "isInsured"
+          },
+          "properties": {
+            "isInsured": {
+              "ntsRef": "I1.2",
+              "type": "string"
+            }
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "insuranceClaims"
+              ],
+              "properties": {
+                "insuranceClaims": {
+                  "ntsRef": "I1.1",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "I1.1.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "details"
+                      ],
+                      "properties": {
+                        "details": {
+                          "ntsRef": "I1.1.2",
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "isInsured": {
+                  "enum": [
+                    "Yes"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "object"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/ic.json",
+  "$comment": "Insurance claims upfront for SEF25"
+}

--- a/src/schemas/v3/overlays/extensions/jk.json
+++ b/src/schemas/v3/overlays/extensions/jk.json
@@ -33,6 +33,9 @@
                   "required": [
                     "managementPlanInPlace"
                   ],
+                  "discriminator": {
+                    "propertyName": "managementPlanInPlace"
+                  },
                   "properties": {
                     "managementPlanInPlace": {
                       "ntsRef": "A5.3.2",
@@ -47,14 +50,29 @@
                       "enum": [
                         "Yes"
                       ]
-                    },
-                    "attachments": {
-                      "enum": [
-                        "Attached",
-                        "To follow"
-                      ]
                     }
-                  }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               ],
               "type": "object"
@@ -62,12 +80,14 @@
           },
           "required": [
             "japaneseKnotweed"
-          ]
+          ],
+          "ntsRef": "A5"
         }
       },
       "required": [
         "specialistIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/la.json
+++ b/src/schemas/v3/overlays/extensions/la.json
@@ -69,12 +69,14 @@
           },
           "required": [
             "loft"
-          ]
+          ],
+          "ntsRef": "A1.2"
         }
       },
       "required": [
         "typeOfConstruction"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/lc.json
+++ b/src/schemas/v3/overlays/extensions/lc.json
@@ -1,0 +1,76 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "electricity": {
+          "properties": {
+            "solarPanels": {
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "panelsOwnedOutright": {
+                      "oneOf": [
+                        null,
+                        {
+                          "properties": {
+                            "associatedCost": {
+                              "ntsRef": "S1.1",
+                              "required": [
+                                "frequency"
+                              ],
+                              "discriminator": {
+                                "propertyName": "frequency"
+                              },
+                              "properties": {
+                                "frequency": {
+                                  "ntsRef": "S1.1.2",
+                                  "type": "string"
+                                }
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "frequency": {
+                                      "enum": [
+                                        "Not applicable"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "amount": {
+                                      "ntsRef": "S1.1.1",
+                                      "type": "number"
+                                    },
+                                    "frequency": {
+                                      "enum": [
+                                        "Per month",
+                                        "Per year"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "type": "object"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "ntsRef": "B3.1"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/lc.json",
+  "$comment": "Solar panel lease costs"
+}

--- a/src/schemas/v3/overlays/extensions/ma.json
+++ b/src/schemas/v3/overlays/extensions/ma.json
@@ -60,7 +60,8 @@
                         },
                         "required": [
                           "contactDetails"
-                        ]
+                        ],
+                        "ntsRef": "A3.2"
                       }
                     },
                     "required": [
@@ -73,12 +74,14 @@
           },
           "required": [
             "ownershipsToBeTransferred"
-          ]
+          ],
+          "ntsRef": "A3"
         }
       },
       "required": [
         "ownership"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/mc.json
+++ b/src/schemas/v3/overlays/extensions/mc.json
@@ -22,12 +22,14 @@
           },
           "required": [
             "isStandardForm"
-          ]
+          ],
+          "ntsRef": "A1.2"
         }
       },
       "required": [
         "typeOfConstruction"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/mi.json
+++ b/src/schemas/v3/overlays/extensions/mi.json
@@ -1,0 +1,70 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "additionalInformation": {
+          "properties": {
+            "otherMaterialIssue": {
+              "ntsRef": "M1.1",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "M1.1.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "M1.1.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "attachments": {
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "otherMaterialIssue"
+          ],
+          "ntsRef": "M1"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/mi.json",
+  "$comment": "Other material issue upfront for SEF25"
+}

--- a/src/schemas/v3/overlays/extensions/nd.json
+++ b/src/schemas/v3/overlays/extensions/nd.json
@@ -1,0 +1,44 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "notices": {
+          "properties": {
+            "neighbourDevelopment": {
+              "ntsRef": "N1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "type": "object"
+            }
+          },
+          "ntsRef": "C4"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/nd.json",
+  "$comment": "Neighbour development upfront for SEF25"
+}

--- a/src/schemas/v3/overlays/extensions/oa.json
+++ b/src/schemas/v3/overlays/extensions/oa.json
@@ -11,9 +11,11 @@
           },
           "required": [
             "outsideAreas"
-          ]
+          ],
+          "ntsRef": "B5"
         }
-      }
+      },
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/oc.json
+++ b/src/schemas/v3/overlays/extensions/oc.json
@@ -44,9 +44,11 @@
           },
           "required": [
             "otherPropertyInChain"
-          ]
+          ],
+          "ntsRef": "A1.5.7"
         }
-      }
+      },
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/pc.json
+++ b/src/schemas/v3/overlays/extensions/pc.json
@@ -1,0 +1,38 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "parking": {
+          "properties": {
+            "controlledParking": {
+              "oneOf": [
+                null,
+                {
+                  "properties": {
+                    "costOfPermit": {
+                      "ntsRef": "P1.1",
+                      "type": "number"
+                    },
+                    "costOfPermitFrequency": {
+                      "ntsRef": "P1.2",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "costOfPermit",
+                    "costOfPermitFrequency"
+                  ]
+                }
+              ]
+            }
+          },
+          "ntsRef": "B4"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/pc.json",
+  "$comment": "Parking permit cost and frequency"
+}

--- a/src/schemas/v3/overlays/extensions/ph.json
+++ b/src/schemas/v3/overlays/extensions/ph.json
@@ -1,0 +1,195 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "specialistIssues": {
+          "required": [
+            "wellsDitchesShaft",
+            "damagedOrExposedElectrics",
+            "damageToFlooringOrStaircases",
+            "knownAreasInPoorCondition"
+          ],
+          "properties": {
+            "wellsDitchesShaft": {
+              "ntsRef": "H1.1",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "H1.1.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "H1.1.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "damagedOrExposedElectrics": {
+              "ntsRef": "H1.2",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "H1.2.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "H1.2.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "damageToFlooringOrStaircases": {
+              "ntsRef": "H1.3",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "H1.3.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "H1.3.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "knownAreasInPoorCondition": {
+              "ntsRef": "H1.4",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "H1.4.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "H1.4.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/ph.json",
+  "$comment": "Property hazards and known issues"
+}

--- a/src/schemas/v3/overlays/extensions/rw.json
+++ b/src/schemas/v3/overlays/extensions/rw.json
@@ -1,0 +1,69 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "rightsAndInformalArrangements": {
+          "properties": {
+            "rightsOrArrangements": {
+              "properties": {
+                "privateRightOfWay": {
+                  "ntsRef": "R1.1",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "R1.1.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "details"
+                      ],
+                      "properties": {
+                        "details": {
+                          "ntsRef": "R1.1.2",
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "privateRightOfWay"
+              ],
+              "ntsRef": "C2.2.1"
+            }
+          },
+          "ntsRef": "C2.2"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/rw.json",
+  "$comment": "Private right of way"
+}

--- a/src/schemas/v3/overlays/extensions/sb.json
+++ b/src/schemas/v3/overlays/extensions/sb.json
@@ -57,12 +57,14 @@
           },
           "required": [
             "subsidenceOrStructuralFault"
-          ]
+          ],
+          "ntsRef": "A5"
         }
       },
       "required": [
         "specialistIssues"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/sc.json
+++ b/src/schemas/v3/overlays/extensions/sc.json
@@ -1,0 +1,133 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "waterAndDrainage": {
+          "properties": {
+            "water": {
+              "properties": {
+                "mainsWater": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "associatedCost": {
+                          "ntsRef": "U1.1",
+                          "required": [
+                            "frequency"
+                          ],
+                          "discriminator": {
+                            "propertyName": "frequency"
+                          },
+                          "properties": {
+                            "frequency": {
+                              "ntsRef": "U1.1.2",
+                              "type": "string"
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "amount": {
+                                  "ntsRef": "U1.1.1",
+                                  "type": "number"
+                                },
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "associatedCost"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "ntsRef": "B3.2"
+            },
+            "drainage": {
+              "properties": {
+                "mainsFoulDrainage": {
+                  "oneOf": [
+                    null,
+                    null,
+                    {
+                      "properties": {
+                        "associatedCost": {
+                          "ntsRef": "U1.2",
+                          "required": [
+                            "frequency"
+                          ],
+                          "discriminator": {
+                            "propertyName": "frequency"
+                          },
+                          "properties": {
+                            "frequency": {
+                              "ntsRef": "U1.2.2",
+                              "type": "string"
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "amount": {
+                                  "ntsRef": "U1.2.1",
+                                  "type": "number"
+                                },
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "associatedCost"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "ntsRef": "B3.3"
+            }
+          },
+          "ntsRef": "B3.2"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/sc.json",
+  "$comment": "Associated costs for private water and sewerage supply"
+}

--- a/src/schemas/v3/overlays/extensions/sd.json
+++ b/src/schemas/v3/overlays/extensions/sd.json
@@ -1,0 +1,64 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "environmentalIssues": {
+          "properties": {
+            "stormFireFloodDamage": {
+              "ntsRef": "E1.1",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ntsRef": "E1.1.1",
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "required": [
+                    "details"
+                  ],
+                  "properties": {
+                    "details": {
+                      "ntsRef": "E1.1.2",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "stormFireFloodDamage"
+          ],
+          "ntsRef": "C3.1"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/sd.json",
+  "$comment": "Storm, fire or flood damage"
+}

--- a/src/schemas/v3/overlays/extensions/sf.json
+++ b/src/schemas/v3/overlays/extensions/sf.json
@@ -58,12 +58,14 @@
           },
           "required": [
             "sprayFoamInsulation"
-          ]
+          ],
+          "ntsRef": "A1.2"
         }
       },
       "required": [
         "typeOfConstruction"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/sl.json
+++ b/src/schemas/v3/overlays/extensions/sl.json
@@ -52,12 +52,14 @@
           },
           "required": [
             "solarPanels"
-          ]
+          ],
+          "ntsRef": "B3.1"
         }
       },
       "required": [
         "electricity"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/ta.json
+++ b/src/schemas/v3/overlays/extensions/ta.json
@@ -1,0 +1,204 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "parking": {
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.10",
+          "properties": {
+            "controlledParking": {
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.10.2",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ta6ed6CompatRef": "TA6ED6-COMPAT.10.2.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ],
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "heating": {
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4",
+          "properties": {
+            "otherHeatingFeatures": {
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4.other",
+              "items": {
+                "ta6ed6CompatRef": "TA6ED6-COMPAT.11.4.other.item",
+                "enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design",
+                  "Mains gas",
+                  "Electricity",
+                  "Oil",
+                  "LPG",
+                  "Biomass"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "rightsAndInformalArrangements": {
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.9",
+          "properties": {
+            "sharedContributions": {
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.9.2",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "accessRestrictionAttempts": {
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.9.3",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "legalBoundaries": {
+          "ta6ed6CompatRef": "TA6ED6-COMPAT.2",
+          "properties": {
+            "flyingFreehold": {
+              "ta6ed6CompatRef": "TA6ED6-COMPAT.2.4",
+              "required": [
+                "yesNo"
+              ],
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "properties": {
+                "yesNo": {
+                  "ta6ed6CompatRef": "TA6ED6-COMPAT.2.4.1",
+                  "enum": [
+                    "Yes",
+                    "No",
+                    "Not known"
+                  ],
+                  "type": "string"
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "type": "object"
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/ta.json",
+  "$comment": "Compatibility enum ranges for validating shared PDTF state containing TA6 edition 6 answers"
+}

--- a/src/schemas/v3/overlays/extensions/tf.json
+++ b/src/schemas/v3/overlays/extensions/tf.json
@@ -73,7 +73,8 @@
                         },
                         "required": [
                           "serviceCharge"
-                        ]
+                        ],
+                        "ntsRef": "A3.2"
                       }
                     },
                     "required": [
@@ -86,12 +87,14 @@
           },
           "required": [
             "ownershipsToBeTransferred"
-          ]
+          ],
+          "ntsRef": "A3"
         }
       },
       "required": [
         "ownership"
-      ]
+      ],
+      "ntsRef": "0"
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/schemas/v3/overlays/extensions/tr.json
+++ b/src/schemas/v3/overlays/extensions/tr.json
@@ -1,0 +1,74 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "ownership": {
+          "properties": {
+            "ownershipsToBeTransferred": {
+              "items": {
+                "oneOf": [
+                  {
+                    "properties": {
+                      "titleRestrictions": {
+                        "ntsRef": "T1.1",
+                        "required": [
+                          "yesNo"
+                        ],
+                        "discriminator": {
+                          "propertyName": "yesNo"
+                        },
+                        "properties": {
+                          "yesNo": {
+                            "ntsRef": "T1.1.1",
+                            "type": "string"
+                          }
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "No"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "required": [
+                              "details"
+                            ],
+                            "properties": {
+                              "details": {
+                                "ntsRef": "T1.1.2",
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "yesNo": {
+                                "enum": [
+                                  "Yes"
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "titleRestrictions"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ntsRef": "A3"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/tr.json",
+  "$comment": "Title restrictions for freehold properties"
+}

--- a/src/schemas/v3/overlays/extensions/wg.json
+++ b/src/schemas/v3/overlays/extensions/wg.json
@@ -1,0 +1,351 @@
+{
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "guaranteesWarrantiesAndIndemnityInsurances": {
+          "ntsRef": "W1",
+          "required": [
+            "hasValidGuaranteesOrWarranties"
+          ],
+          "discriminator": {
+            "propertyName": "hasValidGuaranteesOrWarranties"
+          },
+          "properties": {
+            "hasValidGuaranteesOrWarranties": {
+              "ntsRef": "W1.0",
+              "type": "string"
+            }
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "centralHeatingAndorPlumbing",
+                "electricalRepairOrInstallation",
+                "subsidenceWork",
+                "otherGuarantees"
+              ],
+              "properties": {
+                "newHomeWarranty": {
+                  "ntsRef": "W1.1",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.1.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "roofingWork": {
+                  "ntsRef": "W1.2",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.2.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dampProofingTreatment": {
+                  "ntsRef": "W1.3",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.3.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "centralHeatingAndorPlumbing": {
+                  "ntsRef": "W1.4",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.4.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "doubleGlazing": {
+                  "ntsRef": "W1.8",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.8.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "electricalRepairOrInstallation": {
+                  "ntsRef": "W1.5",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.5.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "subsidenceWork": {
+                  "ntsRef": "W1.6",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.6.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "otherGuarantees": {
+                  "ntsRef": "W1.7",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "properties": {
+                    "yesNo": {
+                      "ntsRef": "W1.7.1",
+                      "type": "string"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "details"
+                      ],
+                      "properties": {
+                        "details": {
+                          "ntsRef": "W1.7.2",
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "Yes"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "object"
+        }
+      },
+      "ntsRef": "0"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/extensions/wg.json",
+  "$comment": "Warranties and guarantees upfront Y/N for SEF25"
+}

--- a/src/schemas/v3/overlays/fme1.json
+++ b/src/schemas/v3/overlays/fme1.json
@@ -203,20 +203,22 @@
                                           "contact",
                                           "capacity"
                                         ],
-                                        "contact": {
-                                          "required": [
-                                            "nameOrOrganisation",
-                                            "line1",
-                                            "postcode",
-                                            "telephone",
-                                            "emailAddress"
-                                          ],
-                                          "properties": {
-                                            "address": {
-                                              "required": [
-                                                "line1",
-                                                "postcode"
-                                              ]
+                                        "properties": {
+                                          "contact": {
+                                            "required": [
+                                              "nameOrOrganisation",
+                                              "line1",
+                                              "postcode",
+                                              "telephone",
+                                              "emailAddress"
+                                            ],
+                                            "properties": {
+                                              "address": {
+                                                "required": [
+                                                  "line1",
+                                                  "postcode"
+                                                ]
+                                              }
                                             }
                                           }
                                         }

--- a/src/schemas/v3/overlays/lpe1.json
+++ b/src/schemas/v3/overlays/lpe1.json
@@ -282,20 +282,22 @@
                                               "contact",
                                               "capacity"
                                             ],
-                                            "contact": {
-                                              "required": [
-                                                "nameOrOrganisation",
-                                                "line1",
-                                                "postcode",
-                                                "telephone",
-                                                "emailAddress"
-                                              ],
-                                              "properties": {
-                                                "address": {
-                                                  "required": [
-                                                    "line1",
-                                                    "postcode"
-                                                  ]
+                                            "properties": {
+                                              "contact": {
+                                                "required": [
+                                                  "nameOrOrganisation",
+                                                  "line1",
+                                                  "postcode",
+                                                  "telephone",
+                                                  "emailAddress"
+                                                ],
+                                                "properties": {
+                                                  "address": {
+                                                    "required": [
+                                                      "line1",
+                                                      "postcode"
+                                                    ]
+                                                  }
                                                 }
                                               }
                                             }
@@ -381,20 +383,22 @@
                                               "contact",
                                               "capacity"
                                             ],
-                                            "contact": {
-                                              "required": [
-                                                "nameOrOrganisation",
-                                                "line1",
-                                                "postcode",
-                                                "telephone",
-                                                "emailAddress"
-                                              ],
-                                              "properties": {
-                                                "address": {
-                                                  "required": [
-                                                    "line1",
-                                                    "postcode"
-                                                  ]
+                                            "properties": {
+                                              "contact": {
+                                                "required": [
+                                                  "nameOrOrganisation",
+                                                  "line1",
+                                                  "postcode",
+                                                  "telephone",
+                                                  "emailAddress"
+                                                ],
+                                                "properties": {
+                                                  "address": {
+                                                    "required": [
+                                                      "line1",
+                                                      "postcode"
+                                                    ]
+                                                  }
                                                 }
                                               }
                                             }
@@ -436,13 +440,39 @@
                                     }
                                   },
                                   "collectsGroundRent": {
-                                    "lpe1Ref": "1.7"
+                                    "required": [
+                                      "collector"
+                                    ],
+                                    "properties": {
+                                      "collector": {
+                                        "lpe1Ref": "1.7",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable"
+                                        ]
+                                      }
+                                    }
                                   },
                                   "collectsServiceCharges": {
                                     "lpe1Ref": "1.8"
                                   },
                                   "collectsbuildingInsurancePremiums": {
-                                    "lpe1Ref": "1.9"
+                                    "required": [
+                                      "collector"
+                                    ],
+                                    "properties": {
+                                      "collector": {
+                                        "lpe1Ref": "1.9",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable"
+                                        ]
+                                      }
+                                    }
                                   },
                                   "dealsWithDayToDayMaintenanceOfManagedArea": {
                                     "lpe1Ref": "1.11"
@@ -829,58 +859,6 @@
                                     "lpe1Ref": "4.1.1"
                                   },
                                   "largeAdditionalExpense": {
-                                    "required": [
-                                      "yesNo"
-                                    ],
-                                    "oneOf": [
-                                      null,
-                                      {
-                                        "required": [
-                                          "details"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  "problemInServiceChargeLevel": {
-                                    "required": [
-                                      "yesNo"
-                                    ],
-                                    "oneOf": [
-                                      null,
-                                      {
-                                        "required": [
-                                          "details"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  "serviceChargeChallenged": {
-                                    "required": [
-                                      "yesNo"
-                                    ],
-                                    "oneOf": [
-                                      null,
-                                      {
-                                        "required": [
-                                          "details"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  "difficultyInCollectingServiceCharge": {
-                                    "required": [
-                                      "yesNo"
-                                    ],
-                                    "oneOf": [
-                                      null,
-                                      {
-                                        "required": [
-                                          "details"
-                                        ]
-                                      }
-                                    ]
-                                  },
-                                  "serviceChargeOwed": {
                                     "required": [
                                       "yesNo"
                                     ],
@@ -1301,11 +1279,6 @@
                                 "required": [
                                   "annualServiceCharge",
                                   "largeAdditionalExpense",
-                                  "problemInServiceChargeLevel",
-                                  "serviceChargeChallenged",
-                                  "dangerousCladdingOrDefects",
-                                  "difficultyInCollectingServiceCharge",
-                                  "serviceChargeOwed",
                                   "propertiesContributingToMaintenanceOfManagedArea",
                                   "adHocExpenses",
                                   "serviceChargePaidUpToDate",
@@ -1526,7 +1499,7 @@
                                               "assessmentsCarriedOut": {
                                                 "enum": [
                                                   "Fire risk assessment",
-                                                  "External Wall fire risk assessment",
+                                                  "External wall fire risk assessment",
                                                   "Both"
                                                 ]
                                               },

--- a/src/schemas/v3/overlays/nts.json
+++ b/src/schemas/v3/overlays/nts.json
@@ -631,6 +631,29 @@
             },
             "electricVehicleChargingPoint": {
               "ntsRef": "B4.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -873,7 +896,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -1713,7 +1738,25 @@
               }
             },
             "otherHeatingFeatures": {
-              "ntsRef": "B3.4.2"
+              "ntsRef": "B3.4.2",
+              "items": {
+                "enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ]
+              }
             }
           }
         },
@@ -1745,6 +1788,32 @@
             },
             "broadband": {
               "ntsRef": "B3.5",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "typeOfConnection"
               ],

--- a/src/schemas/v3/overlays/nts2.json
+++ b/src/schemas/v3/overlays/nts2.json
@@ -787,6 +787,29 @@
             },
             "electricVehicleChargingPoint": {
               "nts2Ref": "B4.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -1037,7 +1060,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -1378,9 +1403,6 @@
                     },
                     "details": {
                       "nts2Ref": "A5.1.2"
-                    },
-                    "attachments": {
-                      "nts2Ref": "A5.1.3"
                     }
                   },
                   "required": [
@@ -2221,7 +2243,25 @@
               }
             },
             "otherHeatingFeatures": {
-              "nts2Ref": "B3.4.2"
+              "nts2Ref": "B3.4.2",
+              "items": {
+                "enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ]
+              }
             }
           }
         },
@@ -2253,6 +2293,32 @@
             },
             "broadband": {
               "nts2Ref": "B3.5",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "typeOfConnection"
               ],

--- a/src/schemas/v3/overlays/ntsl.json
+++ b/src/schemas/v3/overlays/ntsl.json
@@ -292,6 +292,29 @@
             },
             "electricVehicleChargingPoint": {
               "ntslRef": "B4.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -534,7 +557,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -1374,7 +1399,25 @@
               }
             },
             "otherHeatingFeatures": {
-              "ntslRef": "B3.4.2"
+              "ntslRef": "B3.4.2",
+              "items": {
+                "enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ]
+              }
             }
           }
         },
@@ -1406,6 +1449,32 @@
             },
             "broadband": {
               "ntslRef": "B3.5",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "typeOfConnection"
               ],

--- a/src/schemas/v3/overlays/ntsl2.json
+++ b/src/schemas/v3/overlays/ntsl2.json
@@ -313,6 +313,29 @@
             },
             "electricVehicleChargingPoint": {
               "ntsl2Ref": "B4.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "yesNo"
               ],
@@ -563,7 +586,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -897,9 +922,6 @@
                     },
                     "details": {
                       "ntsl2Ref": "A5.1.2"
-                    },
-                    "attachments": {
-                      "ntsl2Ref": "A5.1.3"
                     }
                   },
                   "required": [
@@ -1740,7 +1762,25 @@
               }
             },
             "otherHeatingFeatures": {
-              "ntsl2Ref": "B3.4.2"
+              "ntsl2Ref": "B3.4.2",
+              "items": {
+                "enum": [
+                  "None",
+                  "Air conditioning",
+                  "Double glazing",
+                  "Triple glazing",
+                  "Night storage",
+                  "Solar water",
+                  "Underfloor heating",
+                  "Wood burner",
+                  "Aga/Rayburn",
+                  "Open fire",
+                  "Ground source heat pump",
+                  "Air source heat pump",
+                  "Solar thermal",
+                  "Passive House design"
+                ]
+              }
             }
           }
         },
@@ -1772,6 +1812,32 @@
             },
             "broadband": {
               "ntsl2Ref": "B3.5",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
               "required": [
                 "typeOfConnection"
               ],

--- a/src/schemas/v3/overlays/piq.json
+++ b/src/schemas/v3/overlays/piq.json
@@ -13,7 +13,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -24,6 +23,15 @@
                   "Lender",
                   "Landlord",
                   "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
                 ]
               }
             }
@@ -57,8 +65,19 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
                         ]
                       }
                     }
@@ -1614,7 +1633,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -1735,6 +1755,32 @@
             },
             "broadband": {
               "piqRef": "A7.1.15",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ],
               "properties": {
                 "typeOfConnection": {
                   "piqRef": "A7.1.16"
@@ -1903,7 +1949,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -1971,7 +2018,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -2295,8 +2343,7 @@
                   "properties": {
                     "riskIndicator": {
                       "enum": [
-                        "No",
-                        "Not known"
+                        "No"
                       ]
                     }
                   }

--- a/src/schemas/v3/overlays/rds.json
+++ b/src/schemas/v3/overlays/rds.json
@@ -6,6 +6,7 @@
       "items": {
         "oneOf": [
           null,
+          null,
           {
             "properties": {
               "sellersCapacity": {
@@ -33,8 +34,22 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "rdsRef": "Participants/OtherDocumentation"
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
                         ]
                       },
                       "sellersCapacityDetails": {
@@ -1475,14 +1490,60 @@
                         }
                       ]
                     },
-                    "isConnectedToNationalGrid": {
-                      "rdsRef": "Objects/isExternallyConnected=yes|no|true|false,Connection,Objects/ExternalConnection"
-                    },
                     "photovoltaicMeterPanelLocation": {
                       "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?"
                     },
-                    "photovoltaicBatteriesLocation": {
-                      "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?"
+                    "photovoltaicBatteries": {
+                      "rdsRef": "Objects/class='meters|valve|stopcock'&access=?&accessLocation=?",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "nationalGrid": {
+                      "rdsRef": "Objects/isExternallyConnected=yes|no|true|false,Connection,Objects/ExternalConnection",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -1885,7 +1946,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -1982,7 +2044,33 @@
               ]
             },
             "broadband": {
-              "rdsRef": "Services/Internet"
+              "rdsRef": "Services/Internet",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    }
+                  }
+                }
+              ]
             }
           }
         },
@@ -2041,7 +2129,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -2093,7 +2182,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -2485,8 +2575,7 @@
                   "properties": {
                     "riskIndicator": {
                       "enum": [
-                        "No",
-                        "Not known"
+                        "No"
                       ]
                     }
                   }
@@ -2922,7 +3011,8 @@
                     "yesNo": {
                       "enum": [
                         "No",
-                        "Not applicable"
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -3275,6 +3365,32 @@
                   ]
                 },
                 "subsidenceWork": {
+                  "rdsRef": "Certificates",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "insulation": {
                   "rdsRef": "Certificates",
                   "discriminator": {
                     "propertyName": "yesNo"

--- a/src/schemas/v3/overlays/sef25.json
+++ b/src/schemas/v3/overlays/sef25.json
@@ -1,0 +1,1653 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/sef25.json",
+  "properties": {
+    "propertyPack": {
+      "properties": {
+        "ownership": {
+          "sef25Ref": "T1",
+          "properties": {
+            "ownershipsToBeTransferred": {
+              "items": {
+                "oneOf": [
+                  {
+                    "required": [
+                      "titleRestrictions"
+                    ],
+                    "properties": {
+                      "titleRestrictions": {
+                        "sef25Ref": "T1.1",
+                        "discriminator": {
+                          "propertyName": "yesNo"
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "No"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "Yes"
+                                ]
+                              },
+                              "details": {
+                                "sef25Ref": "T1.1.2"
+                              }
+                            },
+                            "required": [
+                              "details"
+                            ]
+                          }
+                        ],
+                        "required": [
+                          "yesNo"
+                        ],
+                        "properties": {
+                          "yesNo": {
+                            "sef25Ref": "T1.1.1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "parking": {
+          "sef25Ref": "K1",
+          "required": [
+            "droppedKerbAccess"
+          ],
+          "properties": {
+            "controlledParking": {
+              "oneOf": [
+                null,
+                {
+                  "required": [
+                    "costOfPermit",
+                    "costOfPermitFrequency"
+                  ],
+                  "properties": {
+                    "costOfPermit": {
+                      "sef25Ref": "P1.1"
+                    },
+                    "costOfPermitFrequency": {
+                      "sef25Ref": "P1.2"
+                    }
+                  }
+                }
+              ]
+            },
+            "droppedKerbAccess": {
+              "sef25Ref": "K1.1",
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "K1.1.1"
+                }
+              }
+            }
+          }
+        },
+        "alterationsAndChanges": {
+          "sef25Ref": "A1",
+          "required": [
+            "extension",
+            "loftConversion",
+            "garageConversion",
+            "removalOfInternalWalls",
+            "changeOfUse"
+          ],
+          "properties": {
+            "changeOfUse": {
+              "sef25Ref": "A1.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "A1.5.2"
+                    },
+                    "buildingRegApproval": {
+                      "sef25Ref": "A1.5.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.5.4.1"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "sef25Ref": "A1.5.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.5.3.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "A1.5.1"
+                }
+              }
+            },
+            "extension": {
+              "sef25Ref": "A1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "A1.1.2"
+                    },
+                    "planningPermission": {
+                      "sef25Ref": "A1.1.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.1.3.1"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "sef25Ref": "A1.1.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.1.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "A1.1.1"
+                }
+              }
+            },
+            "loftConversion": {
+              "sef25Ref": "A1.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "A1.2.2"
+                    },
+                    "planningPermission": {
+                      "sef25Ref": "A1.2.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.2.3.1"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "sef25Ref": "A1.2.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.2.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "A1.2.1"
+                }
+              }
+            },
+            "garageConversion": {
+              "sef25Ref": "A1.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "A1.3.2"
+                    },
+                    "planningPermission": {
+                      "sef25Ref": "A1.3.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.3.3.1"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "sef25Ref": "A1.3.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.3.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "A1.3.1"
+                }
+              }
+            },
+            "removalOfInternalWalls": {
+              "sef25Ref": "A1.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "A1.4.2"
+                    },
+                    "planningPermission": {
+                      "sef25Ref": "A1.4.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.4.3.1"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "sef25Ref": "A1.4.4",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "sef25Ref": "A1.4.4.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "planningPermission",
+                    "buildingRegApproval"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "A1.4.1"
+                }
+              }
+            }
+          }
+        },
+        "notices": {
+          "sef25Ref": "N1",
+          "properties": {
+            "neighbourDevelopment": {
+              "sef25Ref": "N1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "specialistIssues": {
+          "required": [
+            "wellsDitchesShaft",
+            "damagedOrExposedElectrics",
+            "damageToFlooringOrStaircases",
+            "knownAreasInPoorCondition"
+          ],
+          "properties": {
+            "wellsDitchesShaft": {
+              "sef25Ref": "H1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.1.1"
+                }
+              }
+            },
+            "damagedOrExposedElectrics": {
+              "sef25Ref": "H1.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.2.1"
+                }
+              }
+            },
+            "damageToFlooringOrStaircases": {
+              "sef25Ref": "H1.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.3.1"
+                }
+              }
+            },
+            "knownAreasInPoorCondition": {
+              "sef25Ref": "H1.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "H1.4.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "H1.4.1"
+                }
+              }
+            }
+          }
+        },
+        "electricity": {
+          "sef25Ref": "S1",
+          "properties": {
+            "solarPanels": {
+              "sef25Ref": "S1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "panelsOwnedOutright": {
+                      "sef25Ref": "S1.1",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "associatedCost": {
+                              "sef25Ref": "S1.1",
+                              "discriminator": {
+                                "propertyName": "frequency"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "frequency": {
+                                      "enum": [
+                                        "Not applicable"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "frequency": {
+                                      "enum": [
+                                        "Per month",
+                                        "Per year"
+                                      ]
+                                    },
+                                    "amount": {
+                                      "sef25Ref": "S1.1.1"
+                                    }
+                                  }
+                                }
+                              ],
+                              "required": [
+                                "frequency"
+                              ],
+                              "properties": {
+                                "frequency": {
+                                  "sef25Ref": "S1.1.2"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "waterAndDrainage": {
+          "properties": {
+            "water": {
+              "properties": {
+                "mainsWater": {
+                  "oneOf": [
+                    {
+                      "required": [
+                        "associatedCost"
+                      ],
+                      "properties": {
+                        "associatedCost": {
+                          "sef25Ref": "U1.1",
+                          "discriminator": {
+                            "propertyName": "frequency"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                },
+                                "amount": {
+                                  "sef25Ref": "U1.1.1"
+                                }
+                              }
+                            }
+                          ],
+                          "required": [
+                            "frequency"
+                          ],
+                          "properties": {
+                            "frequency": {
+                              "sef25Ref": "U1.1.2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "drainage": {
+              "properties": {
+                "mainsFoulDrainage": {
+                  "oneOf": [
+                    null,
+                    null,
+                    {
+                      "required": [
+                        "associatedCost"
+                      ],
+                      "properties": {
+                        "associatedCost": {
+                          "sef25Ref": "U1.2",
+                          "discriminator": {
+                            "propertyName": "frequency"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                },
+                                "amount": {
+                                  "sef25Ref": "U1.2.1"
+                                }
+                              }
+                            }
+                          ],
+                          "required": [
+                            "frequency"
+                          ],
+                          "properties": {
+                            "frequency": {
+                              "sef25Ref": "U1.2.2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "insurance": {
+          "sef25Ref": "I1",
+          "discriminator": {
+            "propertyName": "isInsured"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "insuranceClaims": {
+                  "sef25Ref": "I1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "sef25Ref": "I1.1.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "I1.1.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "insuranceClaims"
+              ]
+            }
+          ],
+          "required": [
+            "isInsured"
+          ],
+          "properties": {
+            "isInsured": {
+              "sef25Ref": "I1.2"
+            }
+          }
+        },
+        "rightsAndInformalArrangements": {
+          "sef25Ref": "R1",
+          "properties": {
+            "rightsOrArrangements": {
+              "sef25Ref": "R1",
+              "required": [
+                "privateRightOfWay"
+              ],
+              "properties": {
+                "privateRightOfWay": {
+                  "sef25Ref": "R1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "sef25Ref": "R1.1.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "R1.1.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "environmentalIssues": {
+          "sef25Ref": "E1",
+          "required": [
+            "stormFireFloodDamage"
+          ],
+          "properties": {
+            "flooding": {
+              "properties": {
+                "historicalFlooding": {
+                  "properties": {
+                    "hasBeenFlooded": {
+                      "sef25Ref": "E1.2"
+                    }
+                  }
+                }
+              }
+            },
+            "stormFireFloodDamage": {
+              "sef25Ref": "E1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "E1.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "E1.1.1"
+                }
+              }
+            }
+          }
+        },
+        "additionalInformation": {
+          "sef25Ref": "M1",
+          "required": [
+            "otherMaterialIssue"
+          ],
+          "properties": {
+            "otherMaterialIssue": {
+              "sef25Ref": "M1.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "sef25Ref": "M1.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "sef25Ref": "M1.1.1"
+                }
+              }
+            }
+          }
+        },
+        "guaranteesWarrantiesAndIndemnityInsurances": {
+          "sef25Ref": "W1",
+          "discriminator": {
+            "propertyName": "hasValidGuaranteesOrWarranties"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "newHomeWarranty": {
+                  "sef25Ref": "W1.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.1.1"
+                    }
+                  }
+                },
+                "roofingWork": {
+                  "sef25Ref": "W1.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.2.1"
+                    }
+                  }
+                },
+                "dampProofingTreatment": {
+                  "sef25Ref": "W1.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.3.1"
+                    }
+                  }
+                },
+                "centralHeatingAndorPlumbing": {
+                  "sef25Ref": "W1.4",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.4.1"
+                    }
+                  }
+                },
+                "doubleGlazing": {
+                  "sef25Ref": "W1.8",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.8.1"
+                    }
+                  }
+                },
+                "electricalRepairOrInstallation": {
+                  "sef25Ref": "W1.5",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.5.1"
+                    }
+                  }
+                },
+                "subsidenceWork": {
+                  "sef25Ref": "W1.6",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.6.1"
+                    }
+                  }
+                },
+                "otherGuarantees": {
+                  "sef25Ref": "W1.7",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "sef25Ref": "W1.7.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "sef25Ref": "W1.7.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "centralHeatingAndorPlumbing",
+                "electricalRepairOrInstallation",
+                "subsidenceWork",
+                "otherGuarantees"
+              ]
+            }
+          ],
+          "required": [
+            "hasValidGuaranteesOrWarranties"
+          ],
+          "properties": {
+            "hasValidGuaranteesOrWarranties": {
+              "sef25Ref": "W1.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/v3/overlays/ta10.json
+++ b/src/schemas/v3/overlays/ta10.json
@@ -1498,15 +1498,6 @@
                             }
                           }
                         }
-                      },
-                      {
-                        "properties": {
-                          "isIncludedOrExcluded": {
-                            "enum": [
-                              "None"
-                            ]
-                          }
-                        }
                       }
                     ],
                     "required": [
@@ -2266,6 +2257,9 @@
                             "enum": [
                               "Included"
                             ]
+                          },
+                          "comments": {
+                            "ta10Ref": "4.8c"
                           }
                         }
                       },
@@ -2278,6 +2272,9 @@
                           },
                           "price": {
                             "ta10Ref": "4.8b"
+                          },
+                          "comments": {
+                            "ta10Ref": "4.8c"
                           }
                         }
                       }
@@ -2967,6 +2964,9 @@
                                 "enum": [
                                   "Included"
                                 ]
+                              },
+                              "comments": {
+                                "ta10Ref": "5.19c"
                               }
                             }
                           },
@@ -2979,6 +2979,9 @@
                               },
                               "price": {
                                 "ta10Ref": "5.19b"
+                              },
+                              "comments": {
+                                "ta10Ref": "5.19c"
                               }
                             }
                           }

--- a/src/schemas/v3/overlays/ta6.json
+++ b/src/schemas/v3/overlays/ta6.json
@@ -135,15 +135,11 @@
                         "Yes"
                       ]
                     },
-                    "details": {
-                      "ta6Ref": "4.7a2"
-                    },
                     "attachments": {
-                      "ta6Ref": "4.7a3"
+                      "ta6Ref": "4.7a2"
                     }
                   },
                   "required": [
-                    "details",
                     "attachments"
                   ]
                 }
@@ -180,15 +176,11 @@
                         "Yes"
                       ]
                     },
-                    "details": {
-                      "ta6Ref": "4.7b2"
-                    },
                     "attachments": {
-                      "ta6Ref": "4.7b3"
+                      "ta6Ref": "4.7b2"
                     }
                   },
                   "required": [
-                    "details",
                     "attachments"
                   ]
                 }
@@ -1413,6 +1405,7 @@
           }
         },
         "specialistIssues": {
+          "ta6Ref": "7.8",
           "required": [
             "japaneseKnotweed"
           ],
@@ -1442,24 +1435,33 @@
                     },
                     "managementPlanInPlace": {
                       "ta6Ref": "7.8.2"
-                    },
-                    "attachments": {
-                      "ta6Ref": "7.8.3"
                     }
                   },
                   "required": [
-                    "managementPlanInPlace",
-                    "attachments"
+                    "managementPlanInPlace"
+                  ],
+                  "oneOf": [
+                    null,
+                    {
+                      "required": [
+                        "attachments"
+                      ],
+                      "properties": {
+                        "attachments": {
+                          "ta6Ref": "7.8.3"
+                        }
+                      }
+                    }
                   ]
                 }
               ],
               "required": [
                 "yesNo"
               ],
-              "title": "Is the property affected by Japanese knotweed?",
               "properties": {
                 "yesNo": {
-                  "ta6Ref": "7.8.1"
+                  "ta6Ref": "7.8.1",
+                  "title": "Is the property affected by Japanese knotweed?"
                 }
               }
             }
@@ -1661,7 +1663,11 @@
               ],
               "properties": {
                 "yesNo": {
-                  "ta6Ref": "4.6"
+                  "ta6Ref": "4.6",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
                 }
               }
             }
@@ -2056,7 +2062,10 @@
                             }
                           }
                         }
-                      }
+                      },
+                      "required": [
+                        "offMainsDrainageSystem"
+                      ]
                     }
                   ],
                   "required": [
@@ -2254,7 +2263,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -2274,7 +2284,11 @@
                           ],
                           "properties": {
                             "yesNo": {
-                              "ta6Ref": "12.3c1"
+                              "ta6Ref": "12.3c1",
+                              "enum": [
+                                "Yes",
+                                "No"
+                              ]
                             }
                           }
                         }
@@ -2704,7 +2718,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -2784,7 +2799,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -3128,11 +3144,52 @@
           ],
           "properties": {
             "flooding": {
-              "ta6Ref": "7.1.0",
+              "ta6Ref": "7",
               "required": [
+                "floodRiskReport",
                 "historicalFlooding"
               ],
               "properties": {
+                "floodRiskReport": {
+                  "ta6Ref": "7.3",
+                  "discriminator": {
+                    "propertyName": "hasReportBeenPrepared"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6Ref": "7.3.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "hasReportBeenPrepared"
+                  ],
+                  "properties": {
+                    "hasReportBeenPrepared": {
+                      "ta6Ref": "7.3.1"
+                    }
+                  }
+                },
                 "historicalFlooding": {
                   "ta6Ref": "7.1",
                   "discriminator": {
@@ -3197,7 +3254,8 @@
                       "properties": {
                         "yesNo": {
                           "enum": [
-                            "No"
+                            "No",
+                            "Not known"
                           ]
                         }
                       }
@@ -3227,7 +3285,11 @@
                   ],
                   "properties": {
                     "yesNo": {
-                      "ta6Ref": "7.4.1"
+                      "ta6Ref": "7.4.1",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
                     }
                   }
                 },
@@ -3414,7 +3476,7 @@
               "required": [
                 "yesNo"
               ],
-              "title": "Is the seller aware of any boundary feature having been moved in the last 10 years or during the seller’s period of ownership if longer?",
+              "title": "Is the seller aware of any boundary feature having been moved in the last 10 years or during the seller's period of ownership if longer?",
               "properties": {
                 "yesNo": {
                   "ta6Ref": "1.3.1"
@@ -3456,7 +3518,7 @@
               "required": [
                 "yesNo"
               ],
-              "title": "During the seller’s ownership, has any adjacent land or property been purchased by the seller?",
+              "title": "During the seller's ownership, has any adjacent land or property been purchased by the seller?",
               "properties": {
                 "yesNo": {
                   "ta6Ref": "1.4.1"
@@ -3474,7 +3536,8 @@
                     "yesNo": {
                       "enum": [
                         "No",
-                        "Not applicable"
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -3550,7 +3613,7 @@
               "required": [
                 "yesNo"
               ],
-              "title": "Do any drains, pipes or wires serving the property cross any neighbour’s property?",
+              "title": "Do any drains, pipes or wires serving the property cross any neighbour's property?",
               "properties": {
                 "yesNo": {
                   "ta6Ref": "8.7.1"
@@ -3678,7 +3741,11 @@
                       "ta6Ref": "12.1.2"
                     },
                     "attachments": {
-                      "ta6Ref": "12.1.3"
+                      "ta6Ref": "12.1.3",
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
                     }
                   },
                   "required": [
@@ -3730,7 +3797,11 @@
                           "ta6Ref": "12.2.2a.1"
                         },
                         "attachments": {
-                          "ta6Ref": "12.2.2a.2"
+                          "ta6Ref": "12.2.2a.2",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
                         }
                       }
                     }

--- a/src/schemas/v3/overlays/ta6ed6.json
+++ b/src/schemas/v3/overlays/ta6ed6.json
@@ -1,0 +1,6539 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/ta6ed6.json",
+  "required": [
+    "participants",
+    "propertyPack"
+  ],
+  "properties": {
+    "participants": {
+      "ta6ed6Ref": "1",
+      "items": {
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller's Conveyancer",
+                  "Prospective Buyer",
+                  "Buyer's Conveyancer",
+                  "Estate Agent",
+                  "Buyer's Agent",
+                  "Surveyor",
+                  "Mortgage Broker",
+                  "Lender",
+                  "Landlord",
+                  "Tenant"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
+                ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Seller"
+                ]
+              },
+              "sellersCapacity": {
+                "ta6ed6Ref": "1.4",
+                "discriminator": {
+                  "propertyName": "capacity"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Legal Owner",
+                          "Mortgagee in Possession"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Personal Representative for a Deceased Owner",
+                          "Under Power of Attorney",
+                          "Trustee",
+                          "Assistant",
+                          "Other"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
+                        ]
+                      },
+                      "companyName": {
+                        "ta6ed6Ref": "1.6.1"
+                      },
+                      "companyNumber": {
+                        "ta6ed6Ref": "1.6.2"
+                      },
+                      "countryOfIncorporation": {
+                        "ta6ed6Ref": "1.6.3"
+                      }
+                    }
+                  }
+                ],
+                "required": [
+                  "capacity"
+                ],
+                "properties": {
+                  "capacity": {
+                    "ta6ed6Ref": "1.4"
+                  }
+                }
+              },
+              "dateBecameOwnerOrAuthority": {
+                "ta6ed6Ref": "1.5"
+              }
+            },
+            "required": [
+              "sellersCapacity",
+              "dateBecameOwnerOrAuthority"
+            ]
+          }
+        ],
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "ta6ed6Ref": "1"
+          }
+        }
+      }
+    },
+    "propertyPack": {
+      "required": [
+        "address",
+        "parking",
+        "disputesAndComplaints",
+        "alterationsAndChanges",
+        "listingAndConservation",
+        "notices",
+        "specialistIssues",
+        "waterAndDrainage",
+        "electricity",
+        "heating",
+        "connectivity",
+        "insurance",
+        "rightsAndInformalArrangements",
+        "environmentalIssues",
+        "legalBoundaries",
+        "servicesCrossing",
+        "electricalWorks",
+        "guaranteesWarrantiesAndIndemnityInsurances",
+        "occupiers",
+        "completionAndMoving",
+        "confirmationOfAccuracyByOwners",
+        "additionalInformation"
+      ],
+      "properties": {
+        "address": {
+          "ta6ed6Ref": "1.1",
+          "required": [
+            "line1",
+            "postcode"
+          ],
+          "properties": {
+            "line1": {
+              "ta6ed6Ref": "1.1.1"
+            },
+            "line2": {
+              "ta6ed6Ref": "1.1.2"
+            },
+            "line3": {
+              "ta6ed6Ref": "1.1.3"
+            },
+            "town": {
+              "ta6ed6Ref": "1.1.4"
+            },
+            "postcode": {
+              "ta6ed6Ref": "1.1.5"
+            }
+          }
+        },
+        "uprn": {
+          "ta6ed6Ref": "1.2",
+          "description": "Unique Property Reference Number (digits)"
+        },
+        "parking": {
+          "ta6ed6Ref": "10",
+          "required": [
+            "parkingArrangements",
+            "controlledParking",
+            "electricVehicleChargingPoint"
+          ],
+          "properties": {
+            "parkingArrangements": {
+              "ta6ed6Ref": "10.1"
+            },
+            "controlledParking": {
+              "ta6ed6Ref": "10.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Is a permit required for on-road parking?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "10.2.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "electricVehicleChargingPoint": {
+              "ta6ed6Ref": "10.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "chargerDetails": {
+                      "ta6ed6Ref": "10.3a"
+                    },
+                    "chargerDetailsAttachments": {
+                      "ta6ed6Ref": "10.3a1"
+                    },
+                    "cableCrossesPavement": {
+                      "ta6ed6Ref": "10.3b",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "10.3b2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "10.3b1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "chargerDetails",
+                    "cableCrossesPavement"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "10.3.1"
+                }
+              }
+            }
+          }
+        },
+        "listingAndConservation": {
+          "ta6ed6Ref": "5.7",
+          "required": [
+            "isListed",
+            "isConservationArea",
+            "hasTreePreservationOrder"
+          ],
+          "title": "Listed buildings and conservation area",
+          "properties": {
+            "isListed": {
+              "ta6ed6Ref": "5.7",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Is the property (or any part of it) listed?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.7.1"
+                }
+              }
+            },
+            "isConservationArea": {
+              "ta6ed6Ref": "5.8",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Is the property (or any part of it) in a conservation area?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.8.1"
+                }
+              }
+            },
+            "hasTreePreservationOrder": {
+              "ta6ed6Ref": "5.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "workCarriedOut": {
+                      "ta6ed6Ref": "5.9a",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.9a2"
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.9a3",
+                              "title": "Provide a copy of the TPO along with any relevant documents"
+                            }
+                          },
+                          "required": [
+                            "details",
+                            "attachments"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "title": "Are you aware of any works carried out on those trees?",
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.9a1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "workCarriedOut"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are any trees on or overhanging the property subject to a tree preservation order (TPO)?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.9.1"
+                }
+              }
+            }
+          }
+        },
+        "energyEfficiency": {
+          "ta6ed6Ref": "8",
+          "properties": {
+            "greenDealLoan": {
+              "ta6ed6Ref": "8.5",
+              "required": [
+                "hasGreenDealLoan"
+              ],
+              "properties": {
+                "hasGreenDealLoan": {
+                  "ta6ed6Ref": "8.5.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "8.5.1b"
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "8.5.1c"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "8.5.1a"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "disputesAndComplaints": {
+          "ta6ed6Ref": "3",
+          "required": [
+            "hasDisputesAndComplaints",
+            "leadingToDisputesAndComplaints"
+          ],
+          "properties": {
+            "hasDisputesAndComplaints": {
+              "ta6ed6Ref": "3.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "3.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of any disputes or complaints about the property or a property nearby?",
+              "description": "If yes, give details such as when this took place and who was involved:",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "3.1.1"
+                }
+              }
+            },
+            "leadingToDisputesAndComplaints": {
+              "ta6ed6Ref": "3.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "3.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of anything that might lead to a dispute about the property or a property nearby?",
+              "description": "If yes, please give details:",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "3.2.1"
+                }
+              }
+            }
+          }
+        },
+        "alterationsAndChanges": {
+          "ta6ed6Ref": "5",
+          "required": [
+            "windowReplacementsSince2002",
+            "hasAddedConservatory",
+            "extension",
+            "loftConversion",
+            "garageConversion",
+            "removalOfInternalWalls",
+            "removalOfChimneyBreast",
+            "insulation",
+            "otherBuildingWorksOrChangesToTheProperty",
+            "nonResidentialPurposes",
+            "planningPermissionBreaches",
+            "unresolvedPlanningIssues"
+          ],
+          "properties": {
+            "nonResidentialPurposes": {
+              "ta6ed6Ref": "5.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.3.2"
+                    },
+                    "attachments": {
+                      "ta6ed6Ref": "5.3.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.3.1"
+                }
+              }
+            },
+            "windowReplacementsSince2002": {
+              "ta6ed6Ref": "5.1a",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1a(a)"
+                    },
+                    "yearCompleted": {
+                      "ta6ed6Ref": "5.1a"
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1a(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1a(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1a(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(e)"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1a(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1a(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1a(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(d)"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "ta6ed6Ref": "5.1a(f)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(f)"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "ta6ed6Ref": "5.1a(g)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(g)"
+                        }
+                      }
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1a(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1a(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1a(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1a(c)"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1a"
+                }
+              }
+            },
+            "extension": {
+              "ta6ed6Ref": "5.1b",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1b(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1b(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1b(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1b(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1b(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1b(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1b(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1b(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1b(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1b"
+                }
+              }
+            },
+            "hasAddedConservatory": {
+              "ta6ed6Ref": "5.1c",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1c(a)"
+                    },
+                    "yearCompleted": {
+                      "ta6ed6Ref": "5.1c"
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1c(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1c(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1c(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(e)"
+                        }
+                      }
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1c(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1c(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1c(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(d)"
+                        }
+                      }
+                    },
+                    "listedBuildingConsent": {
+                      "ta6ed6Ref": "5.1c(f)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(f)"
+                        }
+                      }
+                    },
+                    "deedRestrictionConsent": {
+                      "ta6ed6Ref": "5.1c(g)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(g)"
+                        }
+                      }
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1c(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1c(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1c(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1c(c)"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1c"
+                }
+              }
+            },
+            "loftConversion": {
+              "ta6ed6Ref": "5.1d",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1d(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1d(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1d(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1d(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1d(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1d(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1d(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1d(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1d(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1d"
+                }
+              }
+            },
+            "garageConversion": {
+              "ta6ed6Ref": "5.1e",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1e(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1e(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1e(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1e(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1e(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1e(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1e(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1e(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1e(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1e"
+                }
+              }
+            },
+            "removalOfInternalWalls": {
+              "ta6ed6Ref": "5.1f",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1f(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1f(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1f(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1f(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1f(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1f(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1f(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1f(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1f(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1f"
+                }
+              }
+            },
+            "removalOfChimneyBreast": {
+              "ta6ed6Ref": "5.1g",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1g(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1g(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1g(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1g(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1g(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1g(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1g(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1g(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1g(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1g"
+                }
+              }
+            },
+            "insulation": {
+              "ta6ed6Ref": "5.1h",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1h(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1h(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1h(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1h(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1h(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1h(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1h(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1h(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1h(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1h"
+                }
+              }
+            },
+            "otherBuildingWorksOrChangesToTheProperty": {
+              "ta6ed6Ref": "5.1i",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.1i(a)"
+                    },
+                    "workCompleted": {
+                      "ta6ed6Ref": "5.1i(b)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(b)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(b)"
+                        }
+                      }
+                    },
+                    "documents": {
+                      "ta6ed6Ref": "5.1i(c)"
+                    },
+                    "planningPermission": {
+                      "ta6ed6Ref": "5.1i(d)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1i(d)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(d)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(d)"
+                        }
+                      }
+                    },
+                    "buildingRegApproval": {
+                      "ta6ed6Ref": "5.1i(e)",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.1i(e)"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.1i(e)"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.1i(e)"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.1i"
+                }
+              }
+            },
+            "planningPermissionBreaches": {
+              "ta6ed6Ref": "5.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.4.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.4.1"
+                }
+              }
+            },
+            "unresolvedPlanningIssues": {
+              "ta6ed6Ref": "5.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "5.5.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.5.1"
+                }
+              }
+            }
+          }
+        },
+        "notices": {
+          "ta6ed6Ref": "4",
+          "required": [
+            "otherNotices",
+            "neighbourDevelopment",
+            "planningApplication"
+          ],
+          "title": "Notices",
+          "properties": {
+            "neighbourDevelopment": {
+              "ta6ed6Ref": "4.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "4.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "4.2.1"
+                }
+              }
+            },
+            "planningApplication": {
+              "ta6ed6Ref": "4.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "4.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "4.3.1"
+                }
+              }
+            },
+            "partyWallAct": {
+              "ta6ed6Ref": "2.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "2.5.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "2.5.1"
+                }
+              }
+            },
+            "otherNotices": {
+              "ta6ed6Ref": "4.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "4.1.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "4.1.1"
+                }
+              }
+            }
+          }
+        },
+        "specialistIssues": {
+          "ta6ed6Ref": "8.6",
+          "required": [
+            "japaneseKnotweed"
+          ],
+          "properties": {
+            "japaneseKnotweed": {
+              "ta6ed6Ref": "8.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "managementPlanInPlace": {
+                      "ta6ed6Ref": "8.6.2"
+                    }
+                  },
+                  "required": [
+                    "managementPlanInPlace"
+                  ],
+                  "oneOf": [
+                    null,
+                    {
+                      "required": [
+                        "attachments"
+                      ],
+                      "properties": {
+                        "attachments": {
+                          "ta6ed6Ref": "8.6.3"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo",
+                "knotweedSurveyCarriedOut"
+              ],
+              "properties": {
+                "knotweedSurveyCarriedOut": {
+                  "ta6ed6Ref": "8.7",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "8.7.2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "8.7.1"
+                    }
+                  }
+                },
+                "yesNo": {
+                  "ta6ed6Ref": "8.6.1"
+                }
+              }
+            }
+          }
+        },
+        "electricity": {
+          "ta6ed6Ref": "12.1",
+          "required": [
+            "mainsElectricity"
+          ],
+          "properties": {
+            "mainsElectricity": {
+              "ta6ed6Ref": "12.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "ta6ed6Ref": "12.1.2"
+                    },
+                    "electricityMeter": {
+                      "ta6ed6Ref": "12.1.3",
+                      "required": [
+                        "location",
+                        "mpan"
+                      ],
+                      "properties": {
+                        "location": {
+                          "ta6ed6Ref": "12.1.3"
+                        },
+                        "mpan": {
+                          "ta6ed6Ref": "12.1.4",
+                          "description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked 'Supply Number'. It's 21 digits long and begins with 'S'. You'll only need the last 12 or 13 digits."
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "supplier",
+                    "electricityMeter"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "12.1.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "solarPanels": {
+              "ta6ed6Ref": "5.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "hotWaterOnly": {
+                      "ta6ed6Ref": "5.6a"
+                    },
+                    "yearInstalled": {
+                      "ta6ed6Ref": "5.6b"
+                    },
+                    "panelsOwnedOutright": {
+                      "ta6ed6Ref": "5.6c",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6c"
+                        }
+                      }
+                    },
+                    "panelProviderLease": {
+                      "ta6ed6Ref": "5.6d",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.6d2"
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6d1"
+                        }
+                      }
+                    },
+                    "maintenanceAgreement": {
+                      "ta6ed6Ref": "5.6e",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "5.6e2"
+                            }
+                          },
+                          "required": [
+                            "attachments"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6e1"
+                        }
+                      }
+                    },
+                    "photovoltaicBatteries": {
+                      "ta6ed6Ref": "5.6f",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "description": {
+                              "ta6ed6Ref": "5.6f1"
+                            },
+                            "details": {
+                              "ta6ed6Ref": "5.6f2"
+                            }
+                          },
+                          "required": [
+                            "description",
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6f"
+                        }
+                      }
+                    },
+                    "nationalGrid": {
+                      "ta6ed6Ref": "5.6g",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "fitOrSegInPlace": {
+                              "ta6ed6Ref": "5.6g1",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "fitSegAgreementCopy": {
+                                      "ta6ed6Ref": "5.6g2"
+                                    },
+                                    "attachments": {
+                                      "ta6ed6Ref": "5.6g3"
+                                    },
+                                    "fitSegAssignmentProcedure": {
+                                      "ta6ed6Ref": "5.6g4"
+                                    }
+                                  }
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "5.6g1a"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "5.6g"
+                        }
+                      }
+                    },
+                    "installationCertificates": {
+                      "ta6ed6Ref": "5.6h"
+                    }
+                  },
+                  "required": [
+                    "hotWaterOnly",
+                    "yearInstalled",
+                    "panelsOwnedOutright",
+                    "panelProviderLease",
+                    "maintenanceAgreement",
+                    "photovoltaicBatteries",
+                    "nationalGrid",
+                    "installationCertificates"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "5.6",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "heatPump": {
+              "ta6ed6Ref": "12.6",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "ta6ed6Ref": "12.6.2",
+                      "title": "Provider name"
+                    },
+                    "makeModel": {
+                      "ta6ed6Ref": "12.6.3"
+                    },
+                    "serviceProviderName": {
+                      "ta6ed6Ref": "12.6.4"
+                    }
+                  },
+                  "required": [
+                    "supplier",
+                    "makeModel",
+                    "serviceProviderName"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Shared ground / air source heat pumps",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "12.6.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "waterAndDrainage": {
+          "ta6ed6Ref": "11",
+          "required": [
+            "water",
+            "drainage"
+          ],
+          "properties": {
+            "water": {
+              "ta6ed6Ref": "12.3",
+              "required": [
+                "mainsWater"
+              ],
+              "properties": {
+                "mainsWater": {
+                  "ta6ed6Ref": "12.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "supplier": {
+                          "ta6ed6Ref": "12.3.2"
+                        },
+                        "stopcock": {
+                          "ta6ed6Ref": "12.3.3",
+                          "required": [
+                            "location"
+                          ],
+                          "properties": {
+                            "location": {
+                              "ta6ed6Ref": "12.3.3"
+                            }
+                          }
+                        },
+                        "waterMeter": {
+                          "ta6ed6Ref": "12.3.4",
+                          "discriminator": {
+                            "propertyName": "isSupplyMetered"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "isSupplyMetered": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "isSupplyMetered": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "location": {
+                                  "ta6ed6Ref": "12.3.4"
+                                }
+                              },
+                              "required": [
+                                "location"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "isSupplyMetered"
+                          ],
+                          "properties": {
+                            "isSupplyMetered": {
+                              "ta6ed6Ref": "12.3.4"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "supplier",
+                        "stopcock",
+                        "waterMeter"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "12.3.1",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "drainage": {
+              "ta6ed6Ref": "11.5",
+              "required": [
+                "mainsFoulDrainage",
+                "mainsSurfaceWaterDrainage"
+              ],
+              "title": "Drains and sewers",
+              "properties": {
+                "mainsSurfaceWaterDrainage": {
+                  "ta6ed6Ref": "11.5b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "11.5b",
+                      "enum": [
+                        "Yes",
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                "mainsFoulDrainage": {
+                  "ta6ed6Ref": "11.5a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "supplier": {
+                          "ta6ed6Ref": "12.4.2",
+                          "title": "Provider's name"
+                        }
+                      },
+                      "required": [
+                        "supplier"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "To be connected"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        },
+                        "offMainsDrainageSystem": {
+                          "ta6ed6Ref": "11.6",
+                          "discriminator": {
+                            "propertyName": "offMainsDrainageSystemType"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Sustainable Drainage System"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Septic tank"
+                                  ]
+                                },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a"
+                                },
+                                "dateInstalled": {
+                                  "ta6ed6Ref": "11.7b"
+                                },
+                                "dateReplaced": {
+                                  "ta6ed6Ref": "11.7c"
+                                },
+                                "dateLastEmptied": {
+                                  "ta6ed6Ref": "11.7d"
+                                }
+                              },
+                              "required": [
+                                "dateDischargeCommenced",
+                                "dateInstalled",
+                                "dateLastEmptied"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Cesspit"
+                                  ]
+                                },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a"
+                                },
+                                "dateInstalled": {
+                                  "ta6ed6Ref": "11.7b"
+                                },
+                                "dateReplaced": {
+                                  "ta6ed6Ref": "11.7c"
+                                },
+                                "dateLastEmptied": {
+                                  "ta6ed6Ref": "11.7d"
+                                }
+                              },
+                              "required": [
+                                "dateDischargeCommenced",
+                                "dateLastEmptied",
+                                "dateInstalled"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Sewerage treatment plant"
+                                  ]
+                                },
+                                "dateDischargeCommenced": {
+                                  "ta6ed6Ref": "11.7a"
+                                },
+                                "supplier": {
+                                  "ta6ed6Ref": "12.5.2"
+                                },
+                                "makeModel": {
+                                  "ta6ed6Ref": "12.5.3"
+                                },
+                                "serviceProviderName": {
+                                  "ta6ed6Ref": "12.5.4"
+                                },
+                                "dateInstalled": {
+                                  "ta6ed6Ref": "11.7b"
+                                },
+                                "dateReplaced": {
+                                  "ta6ed6Ref": "11.7c"
+                                },
+                                "dateLastServiced": {
+                                  "ta6ed6Ref": "11.7e"
+                                }
+                              },
+                              "required": [
+                                "dateDischargeCommenced",
+                                "dateInstalled",
+                                "dateLastServiced",
+                                "supplier",
+                                "makeModel",
+                                "serviceProviderName"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "offMainsDrainageSystemType": {
+                                  "enum": [
+                                    "Other",
+                                    "Not known"
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "required": [
+                            "offMainsDrainageSystemType",
+                            "otherConnectedProperties",
+                            "plantOnOtherLand",
+                            "plantRegistered",
+                            "plantDrainsIntoWaterway"
+                          ],
+                          "properties": {
+                            "offMainsDrainageSystemType": {
+                              "ta6ed6Ref": "11.6",
+                              "enum": [
+                                "Septic tank",
+                                "Cesspit",
+                                "Sewerage treatment plant",
+                                "Other"
+                              ]
+                            },
+                            "otherConnectedProperties": {
+                              "ta6ed6Ref": "11.7h",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "details": {
+                                      "ta6ed6Ref": "11.7h",
+                                      "title": "Give details about how many properties share the system, the arrangements for jointly managing it and how the costs are shared"
+                                    }
+                                  },
+                                  "required": [
+                                    "details"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "11.7h"
+                                }
+                              }
+                            },
+                            "plantOnOtherLand": {
+                              "ta6ed6Ref": "11.7i",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "attachments": {
+                                      "ta6ed6Ref": "11.7i"
+                                    }
+                                  },
+                                  "required": [
+                                    "attachments"
+                                  ]
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "11.7i"
+                                }
+                              }
+                            },
+                            "plantRegistered": {
+                              "ta6ed6Ref": "11.7j",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "11.7j"
+                                }
+                              }
+                            },
+                            "plantDrainsIntoWaterway": {
+                              "ta6ed6Ref": "11.7f",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No, the effluent is discharged through a soakaway system."
+                                      ]
+                                    },
+                                    "hasInfiltrationSystem": {
+                                      "ta6ed6Ref": "11.7g",
+                                      "required": [
+                                        "yesNo"
+                                      ],
+                                      "properties": {
+                                        "yesNo": {
+                                          "ta6ed6Ref": "11.7g"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "title": "Does the sewerage system discharge to the ground or to surface water?",
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "11.7f"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "offMainsDrainageSystem"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "11.5a1",
+                      "enum": [
+                        "Yes",
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "heating": {
+          "ta6ed6Ref": "11.4",
+          "required": [
+            "heatingSystem",
+            "otherHeatingFeatures",
+            "multipleHeatingSystems"
+          ],
+          "properties": {
+            "heatingSystem": {
+              "ta6ed6Ref": "11.4",
+              "discriminator": {
+                "propertyName": "heatingType"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "None",
+                        "Room heaters only"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "Central heating"
+                      ]
+                    },
+                    "centralHeatingDetails": {
+                      "ta6ed6Ref": "11.4.1",
+                      "required": [
+                        "centralHeatingFuel",
+                        "centralHeatingInstalled",
+                        "boilerInstallationCertificate",
+                        "replacementOtherThanBoiler",
+                        "heatingLastServicedDate",
+                        "heatingLastServicedReport",
+                        "heatingInGoodWorkingOrder"
+                      ],
+                      "properties": {
+                        "centralHeatingFuel": {
+                          "ta6ed6Ref": "11.4.2",
+                          "discriminator": {
+                            "propertyName": "centralHeatingFuelType"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Mains gas"
+                                  ]
+                                },
+                                "supplier": {
+                                  "ta6ed6Ref": "12.2.2",
+                                  "title": "Provider"
+                                },
+                                "gasMeter": {
+                                  "ta6ed6Ref": "12.2.3",
+                                  "required": [
+                                    "location",
+                                    "mprn"
+                                  ],
+                                  "properties": {
+                                    "location": {
+                                      "ta6ed6Ref": "12.2.3"
+                                    },
+                                    "mprn": {
+                                      "ta6ed6Ref": "12.2.4"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "supplier",
+                                "gasMeter"
+                              ]
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Electricity"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Oil",
+                                    "LPG",
+                                    "Biomass"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "centralHeatingFuelType": {
+                                  "enum": [
+                                    "Other"
+                                  ]
+                                },
+                                "otherCentralHeatingFuelType": {
+                                  "ta6ed6Ref": "11.4.2.2"
+                                }
+                              },
+                              "required": [
+                                "otherCentralHeatingFuelType"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "centralHeatingFuelType"
+                          ],
+                          "properties": {
+                            "centralHeatingFuelType": {
+                              "ta6ed6Ref": "11.4.2.1"
+                            }
+                          }
+                        },
+                        "centralHeatingInstalled": {
+                          "ta6ed6Ref": "11.4a"
+                        },
+                        "boilerInstallationCertificate": {
+                          "ta6ed6Ref": "11.4b",
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "boilerInstallationDate": {
+                                  "ta6ed6Ref": "11.4b2"
+                                },
+                                "attachments": {
+                                  "ta6ed6Ref": "11.4d1",
+                                  "title": "Supply compliance certificates or documentation for the installation (such as a building regulation completion certificate)."
+                                }
+                              },
+                              "required": [
+                                "boilerInstallationDate",
+                                "attachments"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "yesNo"
+                          ],
+                          "title": "Is a boiler (of any kind) installed?",
+                          "properties": {
+                            "yesNo": {
+                              "ta6ed6Ref": "11.4b1"
+                            }
+                          }
+                        },
+                        "replacementOtherThanBoiler": {
+                          "ta6ed6Ref": "11.4c",
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No",
+                                    "Not known"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "attachments": {
+                                  "ta6ed6Ref": "11.4d2"
+                                }
+                              },
+                              "required": [
+                                "attachments"
+                              ]
+                            }
+                          ],
+                          "required": [
+                            "yesNo"
+                          ],
+                          "properties": {
+                            "yesNo": {
+                              "ta6ed6Ref": "11.4c1"
+                            }
+                          }
+                        },
+                        "heatingLastServicedDate": {
+                          "ta6ed6Ref": "11.4g1"
+                        },
+                        "heatingLastServicedReport": {
+                          "ta6ed6Ref": "11.4g2",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        },
+                        "heatingInGoodWorkingOrder": {
+                          "ta6ed6Ref": "11.4f",
+                          "discriminator": {
+                            "propertyName": "yesNo"
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes",
+                                    "Not known"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No"
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "required": [
+                            "yesNo"
+                          ],
+                          "title": "Is the boiler and heating system working?",
+                          "properties": {
+                            "yesNo": {
+                              "ta6ed6Ref": "11.4f1"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "centralHeatingDetails"
+                  ]
+                },
+                {
+                  "properties": {
+                    "heatingType": {
+                      "enum": [
+                        "Communal heating system"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "heatingType"
+              ],
+              "properties": {
+                "heatingType": {
+                  "ta6ed6Ref": "11.4.1"
+                }
+              }
+            },
+            "otherHeatingFeatures": {
+              "ta6ed6Ref": "11.4",
+              "title": "Other heating types"
+            },
+            "multipleHeatingSystems": {
+              "ta6ed6Ref": "11.4h"
+            }
+          }
+        },
+        "connectivity": {
+          "ta6ed6Ref": "12",
+          "required": [
+            "telephone",
+            "broadband"
+          ],
+          "properties": {
+            "telephone": {
+              "ta6ed6Ref": "12.7",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "supplier": {
+                      "ta6ed6Ref": "12.7.2"
+                    }
+                  },
+                  "required": [
+                    "supplier"
+                  ]
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "To be connected"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "12.7.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "broadband": {
+              "ta6ed6Ref": "12.8",
+              "discriminator": {
+                "propertyName": "typeOfConnection"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    },
+                    "providerName": {
+                      "ta6ed6Ref": "12.8.2"
+                    }
+                  },
+                  "required": [
+                    "providerName"
+                  ]
+                }
+              ],
+              "required": [
+                "typeOfConnection"
+              ],
+              "properties": {
+                "typeOfConnection": {
+                  "ta6ed6Ref": "12.8.1"
+                }
+              }
+            },
+            "otherServices": {
+              "ta6ed6Ref": "12.9.1"
+            }
+          }
+        },
+        "insurance": {
+          "ta6ed6Ref": "7",
+          "discriminator": {
+            "propertyName": "isInsured"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "No"
+                  ]
+                },
+                "whoInsures": {
+                  "ta6ed6Ref": "7.1.1"
+                }
+              },
+              "required": [
+                "whoInsures"
+              ]
+            },
+            {
+              "properties": {
+                "isInsured": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "insuranceClaims": {
+                  "ta6ed6Ref": "7.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "7.3.2",
+                          "title": "Give details, including the date(s) of any claim(s) and how they were resolved"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "title": "Have you made any buildings insurance claims?",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "7.3.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "insuranceClaims"
+              ]
+            }
+          ],
+          "required": [
+            "isInsured",
+            "difficultiesObtainingInsurance"
+          ],
+          "properties": {
+            "difficultiesObtainingInsurance": {
+              "ta6ed6Ref": "7.2",
+              "required": [
+                "abnormalRiseInPremiums",
+                "subjectToHighExcesses",
+                "subjectToUnusualConditions",
+                "refused"
+              ],
+              "title": "Are you aware of the property insurance ever being difficult to obtain or subject to special conditions?",
+              "properties": {
+                "abnormalRiseInPremiums": {
+                  "ta6ed6Ref": "7.2a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "7.2a2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "7.2a1"
+                    }
+                  }
+                },
+                "subjectToHighExcesses": {
+                  "ta6ed6Ref": "7.2b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "7.2b2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "7.2b1"
+                    }
+                  }
+                },
+                "subjectToUnusualConditions": {
+                  "ta6ed6Ref": "7.2c",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "7.2c2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "7.2c1"
+                    }
+                  }
+                },
+                "refused": {
+                  "ta6ed6Ref": "7.2d",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "7.2d2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "7.2d1"
+                    }
+                  }
+                }
+              }
+            },
+            "isInsured": {
+              "ta6ed6Ref": "7.1",
+              "title": "Do you insure the property?"
+            }
+          }
+        },
+        "rightsAndInformalArrangements": {
+          "ta6ed6Ref": "9",
+          "required": [
+            "neighbouringLandRights",
+            "sharedContributions",
+            "rightsOrArrangements",
+            "askedOthersToContribute"
+          ],
+          "properties": {
+            "sharedContributions": {
+              "ta6ed6Ref": "9.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.2.2",
+                      "title": "Please give details of how much, how often and who you pay:"
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "9.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.3.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "disagreementOrComplaint"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Have you been asked to contribute towards the cost of the jointly used facilities?",
+              "description": "If yes, give details of how much, how often and who you pay:",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.2.1"
+                }
+              }
+            },
+            "neighbouringLandRights": {
+              "ta6ed6Ref": "9.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.1.2",
+                      "title": "Please give details"
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.3",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "9.3.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.3.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "disagreementOrComplaint"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Do you exercise any rights or arrangements over any other properties?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.1.1"
+                }
+              }
+            },
+            "accessRestrictionAttempts": {
+              "properties": {
+                "yesNo": {
+                  "enum": [
+                    "Yes",
+                    "No",
+                    "Not known"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "rightsOrArrangements": {
+              "ta6ed6Ref": "9.4",
+              "required": [
+                "publicRightOfWay",
+                "rightsOfLight",
+                "rightsOfSupport",
+                "rightsCreatedThroughCustom",
+                "minesAndMinerals",
+                "churchChancel",
+                "rightsToTakeFromLand",
+                "otherRights",
+                "disagreementOrComplaint"
+              ],
+              "properties": {
+                "publicRightOfWay": {
+                  "ta6ed6Ref": "9.4.1",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4.1.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4.1.1"
+                    }
+                  }
+                },
+                "rightsOfLight": {
+                  "ta6ed6Ref": "9.4a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4a2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4a1"
+                    }
+                  }
+                },
+                "rightsOfSupport": {
+                  "ta6ed6Ref": "9.4b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4b2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4b1"
+                    }
+                  }
+                },
+                "rightsCreatedThroughCustom": {
+                  "ta6ed6Ref": "9.4c",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4c2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4c1"
+                    }
+                  }
+                },
+                "rightsToTakeFromLand": {
+                  "ta6ed6Ref": "9.4d",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4d2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4d1"
+                    }
+                  }
+                },
+                "minesAndMinerals": {
+                  "ta6ed6Ref": "9.4e",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4e2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4e1"
+                    }
+                  }
+                },
+                "churchChancel": {
+                  "ta6ed6Ref": "9.4f",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4f2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4f1"
+                    }
+                  }
+                },
+                "otherRights": {
+                  "ta6ed6Ref": "9.4g",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.4g2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.4g1"
+                    }
+                  }
+                },
+                "disagreementOrComplaint": {
+                  "ta6ed6Ref": "9.6",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "9.6.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "9.6.1"
+                    }
+                  }
+                }
+              }
+            },
+            "askedOthersToContribute": {
+              "ta6ed6Ref": "9.5",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.5.2"
+                    },
+                    "disagreementOrComplaint": {
+                      "ta6ed6Ref": "9.6",
+                      "discriminator": {
+                        "propertyName": "yesNo"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "9.6.2"
+                            }
+                          },
+                          "required": [
+                            "details"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "9.6.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "disagreementOrComplaint"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.5.1"
+                }
+              }
+            }
+          }
+        },
+        "environmentalIssues": {
+          "ta6ed6Ref": "8",
+          "required": [
+            "flooding",
+            "radon"
+          ],
+          "properties": {
+            "flooding": {
+              "ta6ed6Ref": "8",
+              "required": [
+                "historicalFlooding",
+                "floodDefences"
+              ],
+              "properties": {
+                "historicalFlooding": {
+                  "ta6ed6Ref": "8.1",
+                  "discriminator": {
+                    "propertyName": "hasBeenFlooded"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasBeenFlooded": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasBeenFlooded": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "typeOfFlooding": {
+                          "ta6ed6Ref": "8.1",
+                          "title": "If yes, what type of flooding took place?"
+                        },
+                        "details": {
+                          "ta6ed6Ref": "8.1.2",
+                          "title": "Give details about the date(s) any flooding occurred and which parts flooded:"
+                        }
+                      },
+                      "required": [
+                        "typeOfFlooding",
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "hasBeenFlooded"
+                  ],
+                  "title": "Are you aware of the property or any part of it ever being flooded?",
+                  "description": "If yes, what type of flooding took place?",
+                  "properties": {
+                    "hasBeenFlooded": {
+                      "ta6ed6Ref": "8.1.1"
+                    }
+                  }
+                },
+                "floodDefences": {
+                  "ta6ed6Ref": "8.2",
+                  "discriminator": {
+                    "propertyName": "hasFloodDefences"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasFloodDefences": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasFloodDefences": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "8.2.2",
+                          "title": "Please give details:"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "hasFloodDefences"
+                  ],
+                  "title": "Are you aware of any defences installed at the property to prevent flooding?",
+                  "description": "If yes, please give details:",
+                  "properties": {
+                    "hasFloodDefences": {
+                      "ta6ed6Ref": "8.2.1"
+                    }
+                  }
+                }
+              }
+            },
+            "radon": {
+              "ta6ed6Ref": "8.3",
+              "required": [
+                "remedialMeasuresOnConstruction",
+                "radonTest"
+              ],
+              "properties": {
+                "radonTest": {
+                  "ta6ed6Ref": "8.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "8.3.1a"
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "8.3.1b"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "8.3.1"
+                    }
+                  }
+                },
+                "remedialMeasuresOnConstruction": {
+                  "ta6ed6Ref": "8.4",
+                  "required": [
+                    "yesNo"
+                  ],
+                  "description": "Measures could have been undertaken during construction or while adding an extension.",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "8.4.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalInformation": {
+          "ta6ed6Ref": "15",
+          "required": [
+            "consents",
+            "furtherInformation"
+          ],
+          "properties": {
+            "consents": {
+              "ta6ed6Ref": "15.1",
+              "properties": {
+                "attachments": {
+                  "ta6ed6Ref": "15.1.1"
+                },
+                "consentsAttached": {
+                  "ta6ed6Ref": "15.1.2",
+                  "minLength": 1
+                },
+                "consentsToFollow": {
+                  "ta6ed6Ref": "15.1.3",
+                  "minLength": 1
+                },
+                "consentsNotAvailable": {
+                  "ta6ed6Ref": "15.1.4",
+                  "minLength": 1
+                }
+              }
+            },
+            "furtherInformation": {
+              "ta6ed6Ref": "15.2",
+              "properties": {
+                "details": {
+                  "ta6ed6Ref": "15.2.1",
+                  "minLength": 1
+                },
+                "attachments": {
+                  "ta6ed6Ref": "15.2.2"
+                }
+              }
+            }
+          }
+        },
+        "legalBoundaries": {
+          "ta6ed6Ref": "2",
+          "required": [
+            "ownership",
+            "haveBoundaryFeaturesMoved",
+            "flyingFreehold"
+          ],
+          "properties": {
+            "ownership": {
+              "ta6ed6Ref": "2",
+              "discriminator": {
+                "propertyName": "areBoundariesUniform"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "uniformBoundaries": {
+                      "ta6ed6Ref": "2.1",
+                      "required": [
+                        "left",
+                        "right",
+                        "rear",
+                        "front"
+                      ],
+                      "properties": {
+                        "left": {
+                          "ta6ed6Ref": "2.1a"
+                        },
+                        "right": {
+                          "ta6ed6Ref": "2.1b"
+                        },
+                        "rear": {
+                          "ta6ed6Ref": "2.1c"
+                        },
+                        "front": {
+                          "ta6ed6Ref": "2.1d"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "No"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "2.2.1"
+                    },
+                    "attachments": {
+                      "ta6ed6Ref": "2.2"
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "attachments"
+                  ]
+                },
+                {
+                  "properties": {
+                    "areBoundariesUniform": {
+                      "enum": [
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "areBoundariesUniform"
+              ],
+              "properties": {
+                "areBoundariesUniform": {
+                  "ta6ed6Ref": "2.1"
+                }
+              }
+            },
+            "haveBoundaryFeaturesMoved": {
+              "ta6ed6Ref": "2.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "2.3.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of any boundary feature being moved, any adjacent land being added to the property, or any neighbour taking over or building on any part of your property?",
+              "description": "If yes, please give details:",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "2.3.1",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
+            "flyingFreehold": {
+              "ta6ed6Ref": "2.4",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "2.4.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Does any part of the property or any building on the property overhang or project under the boundary of the neighbouring property or road? For example, cellars under the pavement, overhanging eaves or covered walkways.",
+              "description": "If yes, please give details:",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "2.4.1",
+                  "enum": [
+                    "Yes",
+                    "No",
+                    "Not known"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "servicesCrossing": {
+          "ta6ed6Ref": "9",
+          "required": [
+            "pipesWiresCablesDrainsToProperty",
+            "pipesWiresCablesDrainsFromProperty",
+            "formalOrInformalAgreements"
+          ],
+          "properties": {
+            "pipesWiresCablesDrainsToProperty": {
+              "ta6ed6Ref": "9.7",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.7.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of any drains, pipes or wires serving the property that cross any other property?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.7.1"
+                }
+              }
+            },
+            "pipesWiresCablesDrainsFromProperty": {
+              "ta6ed6Ref": "9.8",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.8.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Are you aware of any drains, pipes or wires leading to any other property that cross the property?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.8.1"
+                }
+              }
+            },
+            "formalOrInformalAgreements": {
+              "ta6ed6Ref": "9.9",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "9.9.2"
+                    },
+                    "attachments": {
+                      "ta6ed6Ref": "9.9.3"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Is there any agreement or arrangement about drains, pipes or wires?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "9.9.1"
+                }
+              }
+            }
+          }
+        },
+        "electricalWorks": {
+          "ta6ed6Ref": "11",
+          "required": [
+            "testedByQualifiedElectrician",
+            "electricalWorkSince2005"
+          ],
+          "properties": {
+            "testedByQualifiedElectrician": {
+              "ta6ed6Ref": "11.3",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "yearTested": {
+                      "ta6ed6Ref": "11.3"
+                    },
+                    "attachments": {
+                      "ta6ed6Ref": "11.3",
+                      "title": "Please supply a copy of the EICR"
+                    }
+                  },
+                  "required": [
+                    "yearTested",
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "11.3"
+                }
+              }
+            },
+            "electricalWorkSince2005": {
+              "ta6ed6Ref": "11.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "yearWorkCarriedOut": {
+                      "ta6ed6Ref": "11.2"
+                    },
+                    "details": {
+                      "ta6ed6Ref": "11.1"
+                    },
+                    "suppliedCertificate": {
+                      "ta6ed6Ref": "11.2",
+                      "required": [
+                        "attachments"
+                      ],
+                      "title": "Please supply any certificates for electrical installation work",
+                      "properties": {
+                        "attachments": {
+                          "ta6ed6Ref": "11.2"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "details",
+                    "suppliedCertificate"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "11.1"
+                }
+              }
+            }
+          }
+        },
+        "guaranteesWarrantiesAndIndemnityInsurances": {
+          "ta6ed6Ref": "6",
+          "discriminator": {
+            "propertyName": "hasValidGuaranteesOrWarranties"
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "No"
+                  ]
+                }
+              }
+            },
+            {
+              "properties": {
+                "hasValidGuaranteesOrWarranties": {
+                  "enum": [
+                    "Yes"
+                  ]
+                },
+                "newHomeWarranty": {
+                  "ta6ed6Ref": "6.1a",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1a3"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1a1"
+                    }
+                  }
+                },
+                "roofingWork": {
+                  "ta6ed6Ref": "6.1e",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1e2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1e1"
+                    }
+                  }
+                },
+                "dampProofingTreatment": {
+                  "ta6ed6Ref": "6.1b",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1b2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1b1"
+                    }
+                  }
+                },
+                "timberRotOrInfestationTreatment": {
+                  "ta6ed6Ref": "6.1c",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1c2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1c1"
+                    }
+                  }
+                },
+                "centralHeatingAndorPlumbing": {
+                  "ta6ed6Ref": "6.1f",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1f2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "title": "Boiler or heating systems",
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1f1"
+                    }
+                  }
+                },
+                "doubleGlazing": {
+                  "ta6ed6Ref": "6.1d",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1d2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1d1"
+                    }
+                  }
+                },
+                "subsidenceWork": {
+                  "ta6ed6Ref": "6.1g",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1g2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1g1"
+                    }
+                  }
+                },
+                "insulation": {
+                  "ta6ed6Ref": "6.1h",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1h2"
+                        }
+                      },
+                      "required": [
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1h1"
+                    }
+                  }
+                },
+                "otherGuarantees": {
+                  "ta6ed6Ref": "6.1i",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "6.1i2"
+                        },
+                        "attachments": {
+                          "ta6ed6Ref": "6.1i3"
+                        }
+                      },
+                      "required": [
+                        "details",
+                        "attachments"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.1i1"
+                    }
+                  }
+                },
+                "outstandingClaimsOrApplications": {
+                  "ta6ed6Ref": "6.2",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "6.2.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.2.1"
+                    }
+                  }
+                },
+                "breachOfTermsOrConditions": {
+                  "ta6ed6Ref": "6.3",
+                  "discriminator": {
+                    "propertyName": "yesNo"
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "ta6ed6Ref": "6.3.2"
+                        }
+                      },
+                      "required": [
+                        "details"
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "yesNo"
+                  ],
+                  "properties": {
+                    "yesNo": {
+                      "ta6ed6Ref": "6.3.1"
+                    }
+                  }
+                }
+              },
+              "required": [
+                "newHomeWarranty",
+                "roofingWork",
+                "dampProofingTreatment",
+                "timberRotOrInfestationTreatment",
+                "centralHeatingAndorPlumbing",
+                "doubleGlazing",
+                "subsidenceWork",
+                "insulation",
+                "otherGuarantees",
+                "outstandingClaimsOrApplications",
+                "breachOfTermsOrConditions"
+              ]
+            }
+          ],
+          "required": [
+            "hasValidGuaranteesOrWarranties"
+          ],
+          "properties": {
+            "hasValidGuaranteesOrWarranties": {
+              "ta6ed6Ref": "6.1"
+            }
+          }
+        },
+        "occupiers": {
+          "ta6ed6Ref": "13",
+          "required": [
+            "sellerLivesAtProperty",
+            "othersAged17OrOver"
+          ],
+          "properties": {
+            "sellerLivesAtProperty": {
+              "ta6ed6Ref": "13.3",
+              "required": [
+                "yesNo"
+              ],
+              "title": "Do you live at the property?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "13.3.1"
+                }
+              }
+            },
+            "othersAged17OrOver": {
+              "ta6ed6Ref": "13.4",
+              "discriminator": {
+                "propertyName": "hasOthersAged17OrOver"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "hasOthersAged17OrOver": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "hasOthersAged17OrOver": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "aged17OrOverNames": {
+                      "ta6ed6Ref": "13.4a",
+                      "title": "(a) state the full names of any occupiers (other than the sellers) aged 17 or over:"
+                    },
+                    "aged17OrOverTenantsOrLodgers": {
+                      "ta6ed6Ref": "13.4b",
+                      "required": [
+                        "yesNo"
+                      ],
+                      "properties": {
+                        "yesNo": {
+                          "ta6ed6Ref": "13.4b1"
+                        }
+                      }
+                    },
+                    "vacantPossession": {
+                      "ta6ed6Ref": "13.5",
+                      "discriminator": {
+                        "propertyName": "soldWithVacantPossession"
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "soldWithVacantPossession": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "ta6ed6Ref": "13.7a",
+                              "title": "Please provide details (e.g. the property is sold let to tenants)"
+                            },
+                            "attachments": {
+                              "ta6ed6Ref": "13.7b"
+                            }
+                          },
+                          "required": [
+                            "details",
+                            "attachments"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "soldWithVacantPossession": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "aged17OrOverAgreedToLeave": {
+                              "ta6ed6Ref": "13.6a",
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "13.6a"
+                                }
+                              }
+                            },
+                            "aged17OrOverWillSignToConfirmWillVacate": {
+                              "ta6ed6Ref": "13.6b",
+                              "discriminator": {
+                                "propertyName": "yesNo"
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ],
+                              "required": [
+                                "yesNo"
+                              ],
+                              "properties": {
+                                "yesNo": {
+                                  "ta6ed6Ref": "13.6b1"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "aged17OrOverAgreedToLeave",
+                            "aged17OrOverWillSignToConfirmWillVacate"
+                          ]
+                        }
+                      ],
+                      "required": [
+                        "soldWithVacantPossession"
+                      ],
+                      "properties": {
+                        "soldWithVacantPossession": {
+                          "ta6ed6Ref": "13.5.1"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "aged17OrOverNames",
+                    "aged17OrOverTenantsOrLodgers"
+                  ]
+                }
+              ],
+              "required": [
+                "hasOthersAged17OrOver"
+              ],
+              "properties": {
+                "hasOthersAged17OrOver": {
+                  "ta6ed6Ref": "13.4"
+                }
+              }
+            }
+          }
+        },
+        "completionAndMoving": {
+          "ta6ed6Ref": "14",
+          "required": [
+            "sellerWillEnsure",
+            "sufficientToRepayAllMortgages"
+          ],
+          "properties": {
+            "sellerWillEnsure": {
+              "ta6ed6Ref": "14.2",
+              "required": [
+                "removeRubbish",
+                "replaceLightFittings",
+                "takeReasonableCare",
+                "leaveKeys"
+              ],
+              "title": "Will you ensure that before or on completion:",
+              "properties": {
+                "removeRubbish": {
+                  "ta6ed6Ref": "14.2a",
+                  "title": "All rubbish is removed from the property (including from the loft, garden, outbuildings, garages and sheds) and that the property will be left in a clean and tidy condition?"
+                },
+                "replaceLightFittings": {
+                  "ta6ed6Ref": "14.2b",
+                  "title": "If light fittings are removed, the fittings will be replaced with ceiling rose, flex, bulb holder and bulb?"
+                },
+                "takeReasonableCare": {
+                  "ta6ed6Ref": "14.2c",
+                  "title": "Reasonable care will be taken when removing any other fittings or contents?"
+                },
+                "leaveKeys": {
+                  "ta6ed6Ref": "14.2d",
+                  "title": "Keys to all windows and doors and details of codes for alarms and any other equipment will be left at the property or with the estate agent?"
+                }
+              }
+            },
+            "otherPropertyInChain": {
+              "ta6ed6Ref": "13.1",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "13.1"
+                }
+              }
+            },
+            "moveRestrictionDates": {
+              "ta6ed6Ref": "13.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "ta6ed6Ref": "13.2.2"
+                    }
+                  },
+                  "required": [
+                    "details"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "13.2.1"
+                }
+              }
+            },
+            "sufficientToRepayAllMortgages": {
+              "ta6ed6Ref": "14.1",
+              "required": [
+                "yesNo"
+              ],
+              "title": "Will the sale price be sufficient to pay off on completion all mortgages and charges secured on the property?",
+              "properties": {
+                "yesNo": {
+                  "ta6ed6Ref": "14.1.1"
+                }
+              }
+            }
+          }
+        },
+        "confirmationOfAccuracyByOwners": {
+          "ta6ed6Ref": "16",
+          "required": [
+            "confirmInformationIsAccurate"
+          ],
+          "properties": {
+            "confirmInformationIsAccurate": {
+              "ta6ed6Ref": "15.3.1"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/v3/overlays/ta7.json
+++ b/src/schemas/v3/overlays/ta7.json
@@ -68,6 +68,7 @@
                       },
                       "leaseholdInformation": {
                         "required": [
+                          "typeOfLeasehold",
                           "sharedOwnership",
                           "leaseTerm",
                           "contactDetails",
@@ -84,6 +85,49 @@
                           "confirmationOfAccuracy"
                         ],
                         "properties": {
+                          "typeOfLeasehold": {
+                            "ta7Ref": "1.1",
+                            "discriminator": {
+                              "propertyName": "leaseholdType"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Flat",
+                                      "Shared ownership",
+                                      "Long leasehold house",
+                                      "Maisonette",
+                                      "Leasehold garage"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Other"
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "required": [
+                              "leaseholdType"
+                            ],
+                            "properties": {
+                              "leaseholdType": {
+                                "ta7Ref": "1.1.1",
+                                "enum": [
+                                  "Flat",
+                                  "Shared ownership",
+                                  "Long leasehold house"
+                                ]
+                              }
+                            }
+                          },
                           "sharedOwnership": {
                             "required": [
                               "isSharedOwnership"
@@ -381,6 +425,30 @@
                           },
                           "ownershipAndManagement": {
                             "ta7Ref": "2",
+                            "discriminator": {
+                              "propertyName": "hasTenantCompanyDissolved"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "No",
+                                      "Not applicable"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
                             "required": [
                               "freeholdOwner",
                               "hasHeadlease",
@@ -475,11 +543,11 @@
                                   }
                                 }
                               },
-                              "hasTenantCompanyDissolved": {
-                                "ta7Ref": "2.4"
-                              },
                               "isManagingAgentEmployed": {
                                 "ta7Ref": "2.5"
+                              },
+                              "hasTenantCompanyDissolved": {
+                                "ta7Ref": "2.4"
                               }
                             }
                           },
@@ -610,7 +678,10 @@
                                           "details": {
                                             "ta7Ref": "5.7.2"
                                           }
-                                        }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
                                       }
                                     ],
                                     "required": [
@@ -623,7 +694,44 @@
                                     }
                                   },
                                   "dangerousCladdingOrDefects": {
-                                    "ta7Ref": "5.8"
+                                    "ta7Ref": "5.8",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "ta7Ref": "5.8.2"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7Ref": "5.8.1"
+                                      }
+                                    }
                                   },
                                   "difficultyInCollectingServiceCharge": {
                                     "ta7Ref": "5.9",
@@ -690,7 +798,10 @@
                                           "details": {
                                             "ta7Ref": "5.10.2"
                                           }
-                                        }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
                                       }
                                     ],
                                     "required": [
@@ -788,7 +899,11 @@
                                 ],
                                 "properties": {
                                   "yesNo": {
-                                    "ta7Ref": "8.1.1"
+                                    "ta7Ref": "8.1.1",
+                                    "enum": [
+                                      "Yes",
+                                      "No"
+                                    ]
                                   }
                                 }
                               },
@@ -828,7 +943,11 @@
                                 ],
                                 "properties": {
                                   "yesNo": {
-                                    "ta7Ref": "8.2.1"
+                                    "ta7Ref": "8.2.1",
+                                    "enum": [
+                                      "Yes",
+                                      "No"
+                                    ]
                                   }
                                 }
                               }
@@ -1355,12 +1474,7 @@
                 "ta7Ref": "1",
                 "required": [
                   "ownershipType"
-                ],
-                "properties": {
-                  "ownershipType": {
-                    "ta7Ref": "1.1"
-                  }
-                }
+                ]
               }
             }
           }
@@ -1390,26 +1504,14 @@
                         "Yes"
                       ]
                     },
-                    "details": {
-                      "ta7Ref": "11.1.2",
-                      "title": "Please provide details of the remediation works proposed and evidence of any carried out."
-                    },
-                    "workAlreadyDone": {
-                      "ta7Ref": "11.1.2"
-                    },
-                    "workToBeDone": {
-                      "ta7Ref": "11.1.2"
-                    },
-                    "potentialCost": {
-                      "ta7Ref": "11.1.2"
-                    },
-                    "abilityToResideAtProperty": {
-                      "ta7Ref": "11.1.2"
-                    },
                     "attachments": {
-                      "ta7Ref": "11.1.3"
+                      "ta7Ref": "11.1.3",
+                      "title": "Please attach details of the remediation works proposed and evidence of any carried out."
                     }
-                  }
+                  },
+                  "required": [
+                    "attachments"
+                  ]
                 }
               ],
               "required": [

--- a/src/schemas/v3/overlays/ta7ed5.json
+++ b/src/schemas/v3/overlays/ta7ed5.json
@@ -1,0 +1,1551 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://trust.propdata.org.uk/schemas/v3/overlays/ta7ed5.json",
+  "properties": {
+    "propertyPack": {
+      "required": [
+        "address",
+        "ownership"
+      ],
+      "properties": {
+        "address": {
+          "ta7ed5Ref": "1.1",
+          "properties": {
+            "line1": {
+              "ta7ed5Ref": "1.1.1"
+            },
+            "line2": {
+              "ta7ed5Ref": "1.1.1"
+            },
+            "line3": {
+              "ta7ed5Ref": "1.1.1"
+            },
+            "town": {
+              "ta7ed5Ref": "1.1.1"
+            },
+            "postcode": {
+              "ta7ed5Ref": "1.1.2"
+            }
+          }
+        },
+        "uprn": {
+          "ta7ed5Ref": "1.1.3"
+        },
+        "ownership": {
+          "ta7ed5Ref": "2",
+          "required": [
+            "ownershipsToBeTransferred"
+          ],
+          "properties": {
+            "ownershipsToBeTransferred": {
+              "ta7ed5Ref": "2",
+              "items": {
+                "discriminator": {
+                  "propertyName": "ownershipType"
+                },
+                "oneOf": [
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Freehold"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Managed Freehold",
+                          "Commonhold"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Leasehold"
+                        ]
+                      },
+                      "leaseholdInformation": {
+                        "ta7ed5Ref": "2",
+                        "required": [
+                          "typeOfLeasehold",
+                          "contactDetails",
+                          "consents",
+                          "groundRent",
+                          "ownershipAndManagement",
+                          "serviceCharge",
+                          "disputes",
+                          "buildingSafetyAct",
+                          "enfranchisement",
+                          "requiredDocuments",
+                          "additionalInformation",
+                          "confirmationOfAccuracy"
+                        ],
+                        "properties": {
+                          "typeOfLeasehold": {
+                            "ta7ed5Ref": "2.1",
+                            "discriminator": {
+                              "propertyName": "leaseholdType"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Flat",
+                                      "Shared ownership",
+                                      "Long leasehold house",
+                                      "Maisonette",
+                                      "Leasehold garage"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Other"
+                                    ]
+                                  },
+                                  "otherLeaseholdType": {
+                                    "ta7ed5Ref": "2.1.2"
+                                  }
+                                },
+                                "required": [
+                                  "otherLeaseholdType"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "leaseholdType"
+                            ],
+                            "properties": {
+                              "leaseholdType": {
+                                "ta7ed5Ref": "2.1.1",
+                                "title": "What is the type of property included in the lease?"
+                              }
+                            }
+                          },
+                          "contactDetails": {
+                            "ta7ed5Ref": "3",
+                            "required": [
+                              "contacts",
+                              "serviceContactAssignments"
+                            ],
+                            "properties": {
+                              "contacts": {
+                                "ta7ed5Ref": "3",
+                                "properties": {
+                                  "landlord": {
+                                    "ta7ed5Ref": "3.1.1",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.1",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.1.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.1.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.1.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.1.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.1.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "managementCompany": {
+                                    "ta7ed5Ref": "3.1.2",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.2",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.2.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.2.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.2.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.2.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.2.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "rightToManageCompany": {
+                                    "ta7ed5Ref": "3.1.3",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.3",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.3.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.3.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.3.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.3.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.3.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "freeholder": {
+                                    "ta7ed5Ref": "3.1.4",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.4",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.4.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.4.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.4.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.4.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.4.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "headLeaseHolder": {
+                                    "ta7ed5Ref": "3.1.5",
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "3.1.5",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "3.1.5.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "3.1.5.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "3.1.5.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "3.1.5.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "3.1.5.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "managingAgent": {
+                                    "ta7ed5Ref": "4.1",
+                                    "required": [
+                                      "contact"
+                                    ],
+                                    "properties": {
+                                      "contact": {
+                                        "ta7ed5Ref": "4.1.2",
+                                        "required": [
+                                          "nameOrOrganisation",
+                                          "address",
+                                          "emailAddress"
+                                        ],
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "ta7ed5Ref": "4.1.2.1"
+                                          },
+                                          "address": {
+                                            "ta7ed5Ref": "4.1.2.2",
+                                            "properties": {
+                                              "line1": {
+                                                "ta7ed5Ref": "4.1.2.2"
+                                              },
+                                              "postcode": {
+                                                "ta7ed5Ref": "4.1.2.2"
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "ta7ed5Ref": "4.1.2.3"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "serviceContactAssignments": {
+                                "ta7ed5Ref": "4",
+                                "required": [
+                                  "collectsGroundRent",
+                                  "collectsbuildingInsurancePremiums"
+                                ],
+                                "properties": {
+                                  "collectsGroundRent": {
+                                    "ta7ed5Ref": "4.3",
+                                    "discriminator": {
+                                      "propertyName": "collector"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Other"
+                                            ]
+                                          },
+                                          "otherCollector": {
+                                            "ta7ed5Ref": "4.3.3"
+                                          }
+                                        },
+                                        "required": [
+                                          "otherCollector"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "collector"
+                                    ],
+                                    "properties": {
+                                      "collector": {
+                                        "ta7ed5Ref": "4.3.2",
+                                        "title": "Who collects the ground rent?",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Other"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "collectsbuildingInsurancePremiums": {
+                                    "ta7ed5Ref": "4.2",
+                                    "discriminator": {
+                                      "propertyName": "collector"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable",
+                                              "Freeholder",
+                                              "Head Leaseholder",
+                                              "Seller"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Other"
+                                            ]
+                                          },
+                                          "otherCollector": {
+                                            "ta7ed5Ref": "4.2.3"
+                                          }
+                                        },
+                                        "required": [
+                                          "otherCollector"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "collector"
+                                    ],
+                                    "properties": {
+                                      "collector": {
+                                        "ta7ed5Ref": "4.2.2",
+                                        "enum": [
+                                          "Freeholder",
+                                          "Landlord",
+                                          "Management Company",
+                                          "Head Leaseholder",
+                                          "Seller",
+                                          "Other"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "consents": {
+                            "ta7ed5Ref": "8",
+                            "required": [
+                              "changesInTermOfLease",
+                              "landlordConsents"
+                            ],
+                            "properties": {
+                              "changesInTermOfLease": {
+                                "ta7ed5Ref": "8.1",
+                                "discriminator": {
+                                  "propertyName": "isSellerAwareOfChanges"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfChanges": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfChanges": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "8.1.2",
+                                        "title": "Please supply further details and any documents relating to the variation:"
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "8.1.3"
+                                      }
+                                    },
+                                    "required": [
+                                      "details"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "isSellerAwareOfChanges"
+                                ],
+                                "properties": {
+                                  "isSellerAwareOfChanges": {
+                                    "ta7ed5Ref": "8.1.1"
+                                  }
+                                }
+                              },
+                              "landlordConsents": {
+                                "ta7ed5Ref": "8.2",
+                                "discriminator": {
+                                  "propertyName": "isSellerAwareOfLandlordConsents"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "8.2.2"
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "8.2.3"
+                                      }
+                                    },
+                                    "required": [
+                                      "details",
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "isSellerAwareOfLandlordConsents"
+                                ],
+                                "properties": {
+                                  "isSellerAwareOfLandlordConsents": {
+                                    "ta7ed5Ref": "8.2.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "groundRent": {
+                            "ta7ed5Ref": "2.2",
+                            "discriminator": {
+                              "propertyName": "isGroundRentPayable"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "isGroundRentPayable": {
+                                    "enum": [
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "isGroundRentPayable": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "mostRecentGroundRentDemandStatus": {
+                                    "ta7ed5Ref": "2.2a"
+                                  }
+                                },
+                                "required": [
+                                  "mostRecentGroundRentDemandStatus"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "isGroundRentPayable"
+                            ],
+                            "properties": {
+                              "isGroundRentPayable": {
+                                "ta7ed5Ref": "2.2"
+                              }
+                            }
+                          },
+                          "ownershipAndManagement": {
+                            "ta7ed5Ref": "4",
+                            "discriminator": {
+                              "propertyName": "hasTenantCompanyDissolved"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "No",
+                                      "Not applicable"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "hasTenantCompanyDissolvedDetails": {
+                                    "ta7ed5Ref": "4.5.2"
+                                  }
+                                },
+                                "required": [
+                                  "hasTenantCompanyDissolvedDetails"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "isManagingAgentEmployed",
+                              "sellerOwnership",
+                              "hasTenantCompanyDissolved"
+                            ],
+                            "properties": {
+                              "isManagingAgentEmployed": {
+                                "ta7ed5Ref": "4.1.1",
+                                "title": "Is a managing agent appointed to manage the building and collect service charges?",
+                                "enum": [
+                                  "Yes",
+                                  "No",
+                                  "Not applicable"
+                                ]
+                              },
+                              "sellerOwnership": {
+                                "ta7ed5Ref": "4.4",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "4.4.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "4.4.1"
+                                  }
+                                }
+                              },
+                              "hasTenantCompanyDissolved": {
+                                "ta7ed5Ref": "4.5.1",
+                                "title": "Are you aware of any company responsible for managing the building having been dissolved or struck off the register at Companies House?",
+                                "enum": [
+                                  "Yes",
+                                  "No",
+                                  "Not applicable"
+                                ]
+                              }
+                            }
+                          },
+                          "serviceCharge": {
+                            "ta7ed5Ref": "2.2",
+                            "discriminator": {
+                              "propertyName": "sellerContributesToServiceCharge"
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "sellerContributesToServiceCharge": {
+                                    "enum": [
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "sellerContributesToServiceCharge": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "mostRecentServiceChargeDemandStatus": {
+                                    "ta7ed5Ref": "2.2b"
+                                  },
+                                  "largeAdditionalExpense": {
+                                    "ta7ed5Ref": "5.4",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "ta7ed5Ref": "5.4.2"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7ed5Ref": "5.4.1"
+                                      }
+                                    }
+                                  },
+                                  "problemInServiceChargeLevel": {
+                                    "ta7ed5Ref": "5.6",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "ta7ed5Ref": "5.6.2"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7ed5Ref": "5.6.1"
+                                      }
+                                    }
+                                  },
+                                  "serviceChargeChallenged": {
+                                    "ta7ed5Ref": "5.5",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "ta7ed5Ref": "5.5.2"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7ed5Ref": "5.5.1"
+                                      }
+                                    }
+                                  },
+                                  "dangerousCladdingOrDefects": {
+                                    "ta7ed5Ref": "11.1",
+                                    "discriminator": {
+                                      "propertyName": "yesNo"
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "ta7ed5Ref": "11.1.2"
+                                          }
+                                        },
+                                        "required": [
+                                          "details"
+                                        ]
+                                      }
+                                    ],
+                                    "required": [
+                                      "yesNo"
+                                    ],
+                                    "title": "Are you aware of the existence or suspected existence in the building of cladding or any defects that may create a building safety risk?",
+                                    "properties": {
+                                      "yesNo": {
+                                        "ta7ed5Ref": "11.1.1"
+                                      }
+                                    }
+                                  },
+                                  "lastDecoratedPeriod": {
+                                    "ta7ed5Ref": "5",
+                                    "properties": {
+                                      "externally": {
+                                        "ta7ed5Ref": "5.1",
+                                        "properties": {
+                                          "year": {
+                                            "ta7ed5Ref": "5.1.1"
+                                          }
+                                        }
+                                      },
+                                      "internally": {
+                                        "ta7ed5Ref": "5.2",
+                                        "properties": {
+                                          "year": {
+                                            "ta7ed5Ref": "5.2.1"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "mostRecentServiceChargeDemandStatus",
+                                  "largeAdditionalExpense",
+                                  "problemInServiceChargeLevel",
+                                  "serviceChargeChallenged",
+                                  "dangerousCladdingOrDefects",
+                                  "lastDecoratedPeriod"
+                                ]
+                              }
+                            ],
+                            "required": [
+                              "sellerContributesToServiceCharge"
+                            ],
+                            "properties": {
+                              "sellerContributesToServiceCharge": {
+                                "ta7ed5Ref": "5.3"
+                              }
+                            }
+                          },
+                          "buildingsInsurance": {
+                            "ta7ed5Ref": "2.2",
+                            "required": [
+                              "mostRecentBuildingsInsuranceDemandStatus"
+                            ],
+                            "properties": {
+                              "mostRecentBuildingsInsuranceDemandStatus": {
+                                "ta7ed5Ref": "2.2c"
+                              }
+                            }
+                          },
+                          "disputes": {
+                            "ta7ed5Ref": "10",
+                            "required": [
+                              "sellerReceivedComplaint",
+                              "sellerSentComplaint"
+                            ],
+                            "properties": {
+                              "sellerReceivedComplaint": {
+                                "ta7ed5Ref": "10.1",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "10.1.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "details"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Are you aware of any complaint received from the landlord, the management company or any neighbour about anything you have or have not done?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "10.1.1"
+                                  }
+                                }
+                              },
+                              "sellerSentComplaint": {
+                                "ta7ed5Ref": "10.2",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "10.2.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "details"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Are you aware of any complaint made to or about the landlord, the management company, or any neighbour?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "10.2.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "buildingSafetyAct": {
+                            "ta7ed5Ref": "11",
+                            "required": [
+                              "isLeaseQualifying",
+                              "landlordNotifiedOfSale",
+                              "deedOfCertificateServed",
+                              "landlordsCertificateServed"
+                            ],
+                            "properties": {
+                              "isLeaseQualifying": {
+                                "ta7ed5Ref": "11.3",
+                                "title": "Is the property within a relevant building (11 metres or more in height or at least 5 storeys and contains at least 2 dwellings) and is not leaseholder-owned?",
+                                "enum": [
+                                  "Yes",
+                                  "No",
+                                  "Not known"
+                                ]
+                              },
+                              "deedOfCertificateServed": {
+                                "ta7ed5Ref": "11.4",
+                                "discriminator": {
+                                  "propertyName": "yesNoNotApplicable"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "Not applicable",
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "11.4.2",
+                                        "title": "Please supply a copy of the leaseholder deed of certificate and the accompanying evidence."
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNoNotApplicable"
+                                ],
+                                "title": "Is there a leaseholder deed of certificate for the property?",
+                                "properties": {
+                                  "yesNoNotApplicable": {
+                                    "ta7ed5Ref": "11.4.1"
+                                  }
+                                }
+                              },
+                              "landlordNotifiedOfSale": {
+                                "ta7ed5Ref": "11.5",
+                                "title": "Has the landlord been notified of your intention to sell the property?",
+                                "enum": [
+                                  "Yes",
+                                  "No",
+                                  "Not known"
+                                ]
+                              },
+                              "landlordsCertificateServed": {
+                                "ta7ed5Ref": "11.6",
+                                "discriminator": {
+                                  "propertyName": "yesNoNotApplicable"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "Not applicable",
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNoNotApplicable": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "11.6.2",
+                                        "title": "Please supply a copy of the landlord’s certificate and the accompanying evidence."
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNoNotApplicable"
+                                ],
+                                "title": "Have you received a landlord’s certificate and the accompanying evidence?",
+                                "properties": {
+                                  "yesNoNotApplicable": {
+                                    "ta7ed5Ref": "11.6.1",
+                                    "enum": [
+                                      "Yes",
+                                      "No"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "alterations": {
+                            "ta7ed5Ref": "9",
+                            "required": [
+                              "sellerAwareOfAlterations"
+                            ],
+                            "properties": {
+                              "sellerAwareOfAlterations": {
+                                "ta7ed5Ref": "9.1",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "ta7ed5Ref": "9.2"
+                                      },
+                                      "landlordConsentObtained": {
+                                        "ta7ed5Ref": "9.3",
+                                        "discriminator": {
+                                          "propertyName": "yesNo"
+                                        },
+                                        "oneOf": [
+                                          {
+                                            "properties": {
+                                              "yesNo": {
+                                                "enum": [
+                                                  "No",
+                                                  "Not known",
+                                                  "Not required"
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "properties": {
+                                              "yesNo": {
+                                                "enum": [
+                                                  "Yes"
+                                                ]
+                                              },
+                                              "attachments": {
+                                                "ta7ed5Ref": "9.3.2"
+                                              }
+                                            },
+                                            "required": [
+                                              "attachments"
+                                            ]
+                                          }
+                                        ],
+                                        "required": [
+                                          "yesNo"
+                                        ],
+                                        "properties": {
+                                          "yesNo": {
+                                            "ta7ed5Ref": "9.3.1"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "details",
+                                      "landlordConsentObtained"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "9.1.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "enfranchisement": {
+                            "ta7ed5Ref": "7",
+                            "required": [
+                              "sellerServedNoticeOnLandlord",
+                              "sellerAwareOfNoticeOfCollectivePurchase",
+                              "sellerAwareOfResponse"
+                            ],
+                            "properties": {
+                              "sellerServedNoticeOnLandlord": {
+                                "ta7ed5Ref": "7.1",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known",
+                                          "Not required"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "7.1.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Have you served on the landlord a notice stating your wish to buy the freehold or be granted an extended lease?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "7.1.1"
+                                  }
+                                }
+                              },
+                              "sellerAwareOfNoticeOfCollectivePurchase": {
+                                "ta7ed5Ref": "7.2",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known",
+                                          "Not required"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "7.2.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Are you aware of the service of any notice relating to the possible collective purchase of the freehold of the building or part of it by a group of tenants?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "7.2.1"
+                                  }
+                                }
+                              },
+                              "sellerAwareOfResponse": {
+                                "ta7ed5Ref": "7.3",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known",
+                                          "Not required"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "7.3.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "7.3.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "requiredDocuments": {
+                            "ta7ed5Ref": "6",
+                            "required": [
+                              "noticeOfSale",
+                              "noticeOfBuildingCondition"
+                            ],
+                            "properties": {
+                              "noticeOfSale": {
+                                "ta7ed5Ref": "6.1",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "6.1.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Have you received a notice that the landlord wants to sell the building?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "6.1.1"
+                                  }
+                                }
+                              },
+                              "noticeOfBuildingCondition": {
+                                "ta7ed5Ref": "6.2",
+                                "discriminator": {
+                                  "propertyName": "yesNo"
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "ta7ed5Ref": "6.2.2"
+                                      }
+                                    },
+                                    "required": [
+                                      "attachments"
+                                    ]
+                                  }
+                                ],
+                                "required": [
+                                  "yesNo"
+                                ],
+                                "title": "Have you received any other notice about the building, its use, its condition or its repair and maintenance?",
+                                "properties": {
+                                  "yesNo": {
+                                    "ta7ed5Ref": "6.2.1"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "additionalInformation": {
+                            "ta7ed5Ref": "12",
+                            "required": [
+                              "attachments"
+                            ],
+                            "properties": {
+                              "details": {
+                                "ta7ed5Ref": "12.1"
+                              },
+                              "attachments": {
+                                "ta7ed5Ref": "12.2"
+                              }
+                            }
+                          },
+                          "confirmationOfAccuracy": {
+                            "ta7ed5Ref": "13",
+                            "required": [
+                              "confirmation"
+                            ],
+                            "properties": {
+                              "confirmation": {
+                                "ta7ed5Ref": "13.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "required": [
+                      "leaseholdInformation"
+                    ]
+                  },
+                  {
+                    "properties": {
+                      "ownershipType": {
+                        "enum": [
+                          "Other"
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "ta7ed5Ref": "2",
+                "required": [
+                  "ownershipType"
+                ],
+                "properties": {
+                  "ownershipType": {
+                    "ta7ed5Ref": "2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "typeOfConstruction": {
+          "ta7ed5Ref": "11",
+          "required": [
+            "buildingSafety"
+          ],
+          "properties": {
+            "buildingSafety": {
+              "ta7ed5Ref": "11.2",
+              "discriminator": {
+                "propertyName": "yesNo"
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "attachments": {
+                      "ta7ed5Ref": "11.2.2",
+                      "title": "Please provide details of the remediation works proposed and evidence of any carried out."
+                    }
+                  },
+                  "required": [
+                    "attachments"
+                  ]
+                }
+              ],
+              "required": [
+                "yesNo"
+              ],
+              "title": "Have any remediation works on the building been proposed or carried out?",
+              "properties": {
+                "yesNo": {
+                  "ta7ed5Ref": "11.2.1",
+                  "enum": [
+                    "Yes",
+                    "No",
+                    "Not known"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/v3/pdtf-transaction.json
+++ b/src/schemas/v3/pdtf-transaction.json
@@ -13,7 +13,28 @@
       "type": "string"
     },
     "externalIds": {
-      "type": "object"
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                ".*": {}
+              }
+            }
+          ]
+        }
+      }
     },
     "status": {
       "type": "string",
@@ -122,7 +143,7 @@
                 "title": "Address 2",
                 "type": "string"
               },
-              "line 3": {
+              "line3": {
                 "title": "Address 3",
                 "type": "string"
               },
@@ -181,7 +202,28 @@
             ]
           },
           "externalIds": {
-            "type": "object"
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {}
+                    }
+                  }
+                ]
+              }
+            }
           },
           "participantStatus": {
             "type": "string",
@@ -198,6 +240,17 @@
               "identity": {
                 "type": "object",
                 "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
                   "result": {
                     "type": "string",
                     "enum": [
@@ -233,6 +286,63 @@
               "antiMoneyLaundering": {
                 "type": "object",
                 "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
+                  "result": {
+                    "type": "string",
+                    "enum": [
+                      "pass",
+                      "fail",
+                      "consider"
+                    ]
+                  },
+                  "reports": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "reportName": {
+                          "type": "string"
+                        },
+                        "result": {
+                          "type": "string",
+                          "enum": [
+                            "pass",
+                            "fail",
+                            "consider"
+                          ]
+                        },
+                        "details": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "sourceOfFunds": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Requested",
+                      "In progress",
+                      "User tasks complete",
+                      "Report available",
+                      "Complete",
+                      "Cancelled"
+                    ]
+                  },
                   "result": {
                     "type": "string",
                     "enum": [
@@ -273,7 +383,6 @@
             "properties": {
               "role": {
                 "enum": [
-                  "Buyer",
                   "Seller's Conveyancer",
                   "Prospective Buyer",
                   "Buyer's Conveyancer",
@@ -285,6 +394,20 @@
                   "Landlord",
                   "Tenant"
                 ]
+              }
+            }
+          },
+          {
+            "properties": {
+              "role": {
+                "enum": [
+                  "Buyer"
+                ]
+              },
+              "offerId": {
+                "title": "Reference to an offer in the offers object",
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
               }
             }
           },
@@ -307,6 +430,9 @@
                       "Personal Representative for a Deceased Owner",
                       "Under Power of Attorney",
                       "Mortgagee in Possession",
+                      "Company Director",
+                      "Company Secretary",
+                      "Trustee",
                       "Assistant",
                       "Other"
                     ]
@@ -342,6 +468,7 @@
                         "enum": [
                           "Personal Representative for a Deceased Owner",
                           "Under Power of Attorney",
+                          "Trustee",
                           "Assistant",
                           "Other"
                         ]
@@ -359,8 +486,47 @@
                         ]
                       }
                     }
+                  },
+                  {
+                    "properties": {
+                      "capacity": {
+                        "enum": [
+                          "Company Director",
+                          "Company Secretary"
+                        ]
+                      },
+                      "sellersCapacityDetails": {
+                        "title": "Please provide details and provide any probate, grant of representation or power of attorney ",
+                        "type": "string"
+                      },
+                      "attachments": {
+                        "title": "Attachments",
+                        "type": "string",
+                        "enum": [
+                          "Attached",
+                          "To follow"
+                        ]
+                      },
+                      "companyName": {
+                        "title": "Company name",
+                        "type": "string"
+                      },
+                      "companyNumber": {
+                        "title": "Company number",
+                        "type": "string"
+                      },
+                      "countryOfIncorporation": {
+                        "title": "Country of incorporation",
+                        "type": "string"
+                      }
+                    }
                   }
                 ]
+              },
+              "dateBecameOwnerOrAuthority": {
+                "title": "Date the seller became owner or was authorised to sell",
+                "type": "string",
+                "format": "date"
               }
             }
           }
@@ -1395,6 +1561,18 @@
               "description": "This may differ from the number of legal owners, for example if the property is being sold by executors of a deceased owner",
               "type": "integer"
             },
+            "outstandingMortgage": {
+              "title": "Are there any outstanding mortgages on the property?",
+              "type": "string",
+              "enum": [
+                "Yes",
+                "No"
+              ]
+            },
+            "existingLender": {
+              "title": "What is the name of the existing lender?",
+              "type": "string"
+            },
             "hasHelpToBuyEquityLoan": {
               "title": "Is the property being sold with a Help to Buy equity loan outstanding?",
               "type": "string",
@@ -1438,7 +1616,6 @@
                   "ownershipType": {
                     "title": "What type of ownership is the property?",
                     "description": "A Managed Freehold is any freehold where there are shared amenities, the maintenance of which you pay for through an estate rentcharge, service charge, informal or formal contribution. Choose Leasehold if your property is under a Shared Ownership arrangement.",
-                    "nts2Description": "",
                     "type": "string",
                     "enum": [
                       "Freehold",
@@ -1495,6 +1672,45 @@
                               "amount": {
                                 "title": "Amount payable annually",
                                 "type": "number"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "titleRestrictions": {
+                        "title": "Are there any known restrictions on the title?",
+                        "type": "object",
+                        "properties": {
+                          "yesNo": {
+                            "type": "string",
+                            "title": "",
+                            "enum": [
+                              "Yes",
+                              "No"
+                            ]
+                          }
+                        },
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "No"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "properties": {
+                              "yesNo": {
+                                "enum": [
+                                  "Yes"
+                                ]
+                              },
+                              "details": {
+                                "title": "Details",
+                                "type": "string",
+                                "minLength": 1
                               }
                             }
                           }
@@ -2115,60 +2331,60 @@
                                               "true",
                                               "false"
                                             ]
-                                          }
-                                        },
-                                        "contact": {
-                                          "type": "object",
-                                          "properties": {
-                                            "nameOrOrganisation": {
-                                              "title": "Name or organisation",
-                                              "type": "string",
-                                              "minLength": 1
-                                            },
-                                            "address": {
-                                              "title": "Address",
-                                              "type": "object",
-                                              "properties": {
-                                                "line1": {
-                                                  "title": "Address line 1",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "line2": {
-                                                  "title": "Address line 2",
-                                                  "type": "string"
-                                                },
-                                                "line3": {
-                                                  "title": "Address line 3",
-                                                  "type": "string"
-                                                },
-                                                "town": {
-                                                  "title": "Town",
-                                                  "type": "string"
-                                                },
-                                                "postcode": {
-                                                  "title": "Postcode",
-                                                  "type": "string",
-                                                  "minLength": 1
+                                          },
+                                          "contact": {
+                                            "type": "object",
+                                            "properties": {
+                                              "nameOrOrganisation": {
+                                                "title": "Name or organisation",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "address": {
+                                                "title": "Address",
+                                                "type": "object",
+                                                "properties": {
+                                                  "line1": {
+                                                    "title": "Address line 1",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "line2": {
+                                                    "title": "Address line 2",
+                                                    "type": "string"
+                                                  },
+                                                  "line3": {
+                                                    "title": "Address line 3",
+                                                    "type": "string"
+                                                  },
+                                                  "town": {
+                                                    "title": "Town",
+                                                    "type": "string"
+                                                  },
+                                                  "postcode": {
+                                                    "title": "Postcode",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  }
                                                 }
+                                              },
+                                              "telephone": {
+                                                "title": "Telephone",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "emailAddress": {
+                                                "title": "Email address",
+                                                "type": "string",
+                                                "format": "email"
                                               }
-                                            },
-                                            "telephone": {
-                                              "title": "Telephone",
-                                              "type": "string",
-                                              "minLength": 1
-                                            },
-                                            "emailAddress": {
-                                              "title": "Email address",
-                                              "type": "string",
-                                              "format": "email"
                                             }
+                                          },
+                                          "capacity": {
+                                            "title": "Capacity (e.g. Management Company's lawyer)",
+                                            "type": "string",
+                                            "minLength": 1
                                           }
-                                        },
-                                        "capacity": {
-                                          "title": "Capacity (e.g. Management Company's lawyer)",
-                                          "type": "string",
-                                          "minLength": 1
                                         }
                                       }
                                     ]
@@ -2389,7 +2605,7 @@
                               },
                               "hasFixedRentcharge": {
                                 "type": "string",
-                                "title": "If there is also a ‘fixed’ Rentcharge, please confirm the amount and explain why."
+                                "title": "If there is also a 'fixed' Rentcharge, please confirm the amount and explain why."
                               },
                               "largeAdditionalExpense": {
                                 "title": "Does the seller know of any expense (e.g. the cost of redecoration of outside or communal areas not usually incurred annually) likely to be shown in the service charge accounts within the next three years?",
@@ -2534,7 +2750,7 @@
                                         ]
                                       },
                                       "details": {
-                                        "title": "If No, provide details as to why not",
+                                        "title": "Provide details as to why not",
                                         "type": "string"
                                       }
                                     }
@@ -3462,19 +3678,12 @@
                           },
                           "confirmation": {
                             "title": "Confirmation",
-                            "description": "By checking the box you are .",
                             "type": "object",
                             "properties": {
                               "response": {
                                 "title": "Declaration",
-                                "description": "I/we confirm that I am the person authorised to provide the information which I have completed in it on behalf of those parties which I have selected from the list, and that a buyer may rely on the information which I have supplied without applying to any other party except where I have left a section blank because I do not have the authority to provide the information",
-                                "confirmation": {
-                                  "type": "string",
-                                  "enum": [
-                                    "true",
-                                    "false"
-                                  ]
-                                }
+                                "type": "boolean",
+                                "description": "I/we confirm that I am the person authorised to provide the information which I have completed in it on behalf of those parties which I have selected from the list, and that a buyer may rely on the information which I have supplied without applying to any other party except where I have left a section blank because I do not have the authority to provide the information"
                               },
                               "capacity": {
                                 "title": "Please tick as applicable below, to confirm the capacity in which the answers are given.",
@@ -3503,6 +3712,54 @@
                         "title": "Leasehold information",
                         "type": "object",
                         "properties": {
+                          "typeOfLeasehold": {
+                            "title": "Type of leasehold property",
+                            "type": "object",
+                            "properties": {
+                              "leaseholdType": {
+                                "title": "What type of leasehold property does the seller own?",
+                                "description": "'Flat'includes maisonette and apartment.",
+                                "type": "string",
+                                "enum": [
+                                  "Flat",
+                                  "Shared ownership",
+                                  "Long leasehold house",
+                                  "Maisonette",
+                                  "Leasehold garage",
+                                  "Other"
+                                ]
+                              }
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Flat",
+                                      "Shared ownership",
+                                      "Long leasehold house",
+                                      "Maisonette",
+                                      "Leasehold garage"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "leaseholdType": {
+                                    "enum": [
+                                      "Other"
+                                    ]
+                                  },
+                                  "otherLeaseholdType": {
+                                    "title": "Please give details",
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                }
+                              }
+                            ]
+                          },
                           "sharedOwnership": {
                             "type": "object",
                             "properties": {
@@ -3843,9 +4100,171 @@
                                       }
                                     }
                                   },
+                                  "rightToManageCompany": {
+                                    "title": "Right to manage company",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "freeholder": {
+                                    "title": "Freeholder where different from the landlord",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "headLeaseHolder": {
+                                    "title": "Head leaseholder (if applicable)",
+                                    "type": "object",
+                                    "properties": {
+                                      "contact": {
+                                        "type": "object",
+                                        "properties": {
+                                          "nameOrOrganisation": {
+                                            "title": "Name or organisation",
+                                            "type": "string",
+                                            "minLength": 1
+                                          },
+                                          "address": {
+                                            "title": "Address",
+                                            "type": "object",
+                                            "properties": {
+                                              "line1": {
+                                                "title": "Address line 1",
+                                                "type": "string",
+                                                "minLength": 1
+                                              },
+                                              "line2": {
+                                                "title": "Address line 2",
+                                                "type": "string"
+                                              },
+                                              "line3": {
+                                                "title": "Address line 3",
+                                                "type": "string"
+                                              },
+                                              "town": {
+                                                "title": "Town",
+                                                "type": "string"
+                                              },
+                                              "postcode": {
+                                                "title": "Postcode",
+                                                "type": "string",
+                                                "minLength": 1
+                                              }
+                                            }
+                                          },
+                                          "emailAddress": {
+                                            "title": "Email address",
+                                            "type": "string",
+                                            "format": "email"
+                                          },
+                                          "telephone": {
+                                            "title": "Telephone",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
                                   "managingAgent": {
                                     "title": "Managing Agent",
-                                    "description": "A managing agent may be employed by the landlord or by the tenants’ management company to collect the rent and/or manage the building.",
+                                    "description": "A managing agent may be employed by the landlord or by the tenants' management company to collect the rent and/or manage the building.",
                                     "type": "object",
                                     "properties": {
                                       "contact": {
@@ -4274,60 +4693,60 @@
                                                   "true",
                                                   "false"
                                                 ]
-                                              }
-                                            },
-                                            "contact": {
-                                              "type": "object",
-                                              "properties": {
-                                                "nameOrOrganisation": {
-                                                  "title": "Name or organisation",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "address": {
-                                                  "title": "Address",
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "line1": {
-                                                      "title": "Address line 1",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    },
-                                                    "line2": {
-                                                      "title": "Address line 2",
-                                                      "type": "string"
-                                                    },
-                                                    "line3": {
-                                                      "title": "Address line 3",
-                                                      "type": "string"
-                                                    },
-                                                    "town": {
-                                                      "title": "Town",
-                                                      "type": "string"
-                                                    },
-                                                    "postcode": {
-                                                      "title": "Postcode",
-                                                      "type": "string",
-                                                      "minLength": 1
+                                              },
+                                              "contact": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "nameOrOrganisation": {
+                                                    "title": "Name or organisation",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "address": {
+                                                    "title": "Address",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "line1": {
+                                                        "title": "Address line 1",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "line2": {
+                                                        "title": "Address line 2",
+                                                        "type": "string"
+                                                      },
+                                                      "line3": {
+                                                        "title": "Address line 3",
+                                                        "type": "string"
+                                                      },
+                                                      "town": {
+                                                        "title": "Town",
+                                                        "type": "string"
+                                                      },
+                                                      "postcode": {
+                                                        "title": "Postcode",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
                                                     }
+                                                  },
+                                                  "telephone": {
+                                                    "title": "Telephone",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "emailAddress": {
+                                                    "title": "Email address",
+                                                    "type": "string",
+                                                    "format": "email"
                                                   }
-                                                },
-                                                "telephone": {
-                                                  "title": "Telephone",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "emailAddress": {
-                                                  "title": "Email address",
-                                                  "type": "string",
-                                                  "format": "email"
                                                 }
+                                              },
+                                              "capacity": {
+                                                "title": "Capacity (e.g. Landlord's lawyer)",
+                                                "type": "string",
+                                                "minLength": 1
                                               }
-                                            },
-                                            "capacity": {
-                                              "title": "Capacity (e.g. Landlord's lawyer)",
-                                              "type": "string",
-                                              "minLength": 1
                                             }
                                           }
                                         ]
@@ -4553,60 +4972,60 @@
                                                   "true",
                                                   "false"
                                                 ]
-                                              }
-                                            },
-                                            "contact": {
-                                              "type": "object",
-                                              "properties": {
-                                                "nameOrOrganisation": {
-                                                  "title": "Name or organisation",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "address": {
-                                                  "title": "Address",
-                                                  "type": "object",
-                                                  "properties": {
-                                                    "line1": {
-                                                      "title": "Address line 1",
-                                                      "type": "string",
-                                                      "minLength": 1
-                                                    },
-                                                    "line2": {
-                                                      "title": "Address line 2",
-                                                      "type": "string"
-                                                    },
-                                                    "line3": {
-                                                      "title": "Address line 3",
-                                                      "type": "string"
-                                                    },
-                                                    "town": {
-                                                      "title": "Town",
-                                                      "type": "string"
-                                                    },
-                                                    "postcode": {
-                                                      "title": "Postcode",
-                                                      "type": "string",
-                                                      "minLength": 1
+                                              },
+                                              "contact": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "nameOrOrganisation": {
+                                                    "title": "Name or organisation",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "address": {
+                                                    "title": "Address",
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "line1": {
+                                                        "title": "Address line 1",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      },
+                                                      "line2": {
+                                                        "title": "Address line 2",
+                                                        "type": "string"
+                                                      },
+                                                      "line3": {
+                                                        "title": "Address line 3",
+                                                        "type": "string"
+                                                      },
+                                                      "town": {
+                                                        "title": "Town",
+                                                        "type": "string"
+                                                      },
+                                                      "postcode": {
+                                                        "title": "Postcode",
+                                                        "type": "string",
+                                                        "minLength": 1
+                                                      }
                                                     }
+                                                  },
+                                                  "telephone": {
+                                                    "title": "Telephone",
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                  },
+                                                  "emailAddress": {
+                                                    "title": "Email address",
+                                                    "type": "string",
+                                                    "format": "email"
                                                   }
-                                                },
-                                                "telephone": {
-                                                  "title": "Telephone",
-                                                  "type": "string",
-                                                  "minLength": 1
-                                                },
-                                                "emailAddress": {
-                                                  "title": "Email address",
-                                                  "type": "string",
-                                                  "format": "email"
                                                 }
+                                              },
+                                              "capacity": {
+                                                "title": "Capacity (e.g. Management Company's lawyer)",
+                                                "type": "string",
+                                                "minLength": 1
                                               }
-                                            },
-                                            "capacity": {
-                                              "title": "Capacity (e.g. Management Company's lawyer)",
-                                              "type": "string",
-                                              "minLength": 1
                                             }
                                           }
                                         ]
@@ -4654,12 +5073,47 @@
                                   },
                                   "collectsGroundRent": {
                                     "title": "Who collects the Ground Rent?",
-                                    "type": "string",
-                                    "enum": [
-                                      "Landlord",
-                                      "Management Company",
-                                      "Managing Agent",
-                                      "Not applicable"
+                                    "type": "object",
+                                    "properties": {
+                                      "collector": {
+                                        "title": "Who collects the Ground Rent?",
+                                        "type": "string",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable",
+                                          "Other"
+                                        ]
+                                      }
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Other"
+                                            ]
+                                          },
+                                          "otherCollector": {
+                                            "title": "Please specify who",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
                                     ]
                                   },
                                   "collectsServiceCharges": {
@@ -4675,12 +5129,53 @@
                                   },
                                   "collectsbuildingInsurancePremiums": {
                                     "title": "Who collects the building insurance premiums?",
-                                    "type": "string",
-                                    "enum": [
-                                      "Landlord",
-                                      "Management Company",
-                                      "Managing Agent",
-                                      "Not applicable"
+                                    "type": "object",
+                                    "properties": {
+                                      "collector": {
+                                        "title": "Who collects the building insurance premiums?",
+                                        "type": "string",
+                                        "enum": [
+                                          "Landlord",
+                                          "Management Company",
+                                          "Managing Agent",
+                                          "Not applicable",
+                                          "Freeholder",
+                                          "Head Leaseholder",
+                                          "Seller",
+                                          "Other"
+                                        ]
+                                      }
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Landlord",
+                                              "Management Company",
+                                              "Managing Agent",
+                                              "Not applicable",
+                                              "Freeholder",
+                                              "Head Leaseholder",
+                                              "Seller"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "collector": {
+                                            "enum": [
+                                              "Other"
+                                            ]
+                                          },
+                                          "otherCollector": {
+                                            "title": "Please specify who",
+                                            "type": "string",
+                                            "minLength": 1
+                                          }
+                                        }
+                                      }
                                     ]
                                   },
                                   "dealsWithDayToDayMaintenanceOfManagedArea": {
@@ -4843,6 +5338,52 @@
                                           "Attached",
                                           "To follow",
                                           "Lost"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "landlordConsents": {
+                                "title": "Are you aware of the landlord giving any formal or informal consents required by the lease?",
+                                "type": "object",
+                                "properties": {
+                                  "isSellerAwareOfLandlordConsents": {
+                                    "title": "",
+                                    "type": "string",
+                                    "enum": [
+                                      "Yes",
+                                      "No"
+                                    ]
+                                  }
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": [
+                                          "No"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "isSellerAwareOfLandlordConsents": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "details": {
+                                        "title": "Please supply the consent or if the consent was not in writing, please give details:",
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "attachments": {
+                                        "type": "string",
+                                        "enum": [
+                                          "Attached",
+                                          "To follow"
                                         ]
                                       }
                                     }
@@ -5061,6 +5602,15 @@
                                     "title": "How regularly is the rent paid? (e.g. annually)",
                                     "type": "string"
                                   },
+                                  "mostRecentGroundRentDemandStatus": {
+                                    "title": "Please provide the most recent payment demands payable under the lease for ground rent",
+                                    "type": "string",
+                                    "enum": [
+                                      "Attached",
+                                      "To follow",
+                                      "Not applicable"
+                                    ]
+                                  },
                                   "rentSubjectToIncrease": {
                                     "type": "object",
                                     "title": "Is the ground rent subject to increase?",
@@ -5261,23 +5811,95 @@
                                   }
                                 ]
                               },
-                              "hasTenantCompanyDissolved": {
-                                "title": "Has any tenants’ management company been dissolved or struck off the register at Companies House?",
-                                "type": "string",
-                                "enum": [
-                                  "Yes",
-                                  "No"
-                                ]
-                              },
                               "isManagingAgentEmployed": {
                                 "title": "Does the landlord, tenants’ management company or Right to Manage company employ a managing agent to collect rent or manage the building?",
                                 "type": "string",
                                 "enum": [
                                   "Yes",
-                                  "No"
+                                  "No",
+                                  "Not applicable"
+                                ]
+                              },
+                              "sellerOwnership": {
+                                "title": "Seller Ownership Details",
+                                "type": "object",
+                                "properties": {
+                                  "yesNo": {
+                                    "title": "Does the seller alone, or jointly with others, own the freehold, any headlease or a management company named in the lease?",
+                                    "type": "string",
+                                    "enum": [
+                                      "Yes",
+                                      "No",
+                                      "Not known"
+                                    ]
+                                  }
+                                },
+                                "oneOf": [
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "No",
+                                          "Not known"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "properties": {
+                                      "yesNo": {
+                                        "enum": [
+                                          "Yes"
+                                        ]
+                                      },
+                                      "attachments": {
+                                        "title": "If yes, supply evidence of your ownership or share certificate for membership of the organisation that is responsible for the management of the building.",
+                                        "type": "string",
+                                        "enum": [
+                                          "Attached",
+                                          "To follow",
+                                          "Not available"
+                                        ]
+                                      }
+                                    }
+                                  }
+                                ]
+                              },
+                              "hasTenantCompanyDissolved": {
+                                "title": "Has any tenants' management company been dissolved or struck off the register at Companies House?",
+                                "type": "string",
+                                "enum": [
+                                  "Yes",
+                                  "No",
+                                  "Not applicable"
                                 ]
                               }
-                            }
+                            },
+                            "oneOf": [
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "No",
+                                      "Not applicable"
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "properties": {
+                                  "hasTenantCompanyDissolved": {
+                                    "enum": [
+                                      "Yes"
+                                    ]
+                                  },
+                                  "hasTenantCompanyDissolvedDetails": {
+                                    "title": "Please provide details",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            ]
                           },
                           "serviceCharge": {
                             "title": "Service Charge",
@@ -5312,6 +5934,15 @@
                                   "annualServiceCharge": {
                                     "title": "Amount of current annual service charge (£)",
                                     "type": "number"
+                                  },
+                                  "mostRecentServiceChargeDemandStatus": {
+                                    "title": "Please provide the most recent payment demands payable under the lease for service charge",
+                                    "type": "string",
+                                    "enum": [
+                                      "Attached",
+                                      "To follow",
+                                      "Not applicable"
+                                    ]
                                   },
                                   "largeAdditionalExpense": {
                                     "title": "Does the seller know of any expense (e.g. the cost of redecoration of outside or communal areas not usually incurred annually) likely to be shown in the service charge accounts within the next three years?",
@@ -5429,10 +6060,40 @@
                                   },
                                   "dangerousCladdingOrDefects": {
                                     "title": "Does the seller know of the existence or suspected existence in the building of dangerous cladding or any other defects that create a building safety risk?",
-                                    "type": "string",
-                                    "enum": [
-                                      "Yes",
-                                      "No"
+                                    "type": "object",
+                                    "properties": {
+                                      "yesNo": {
+                                        "type": "string",
+                                        "title": "",
+                                        "enum": [
+                                          "Yes",
+                                          "No"
+                                        ]
+                                      }
+                                    },
+                                    "oneOf": [
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "No"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "properties": {
+                                          "yesNo": {
+                                            "enum": [
+                                              "Yes"
+                                            ]
+                                          },
+                                          "details": {
+                                            "title": "Please give details:",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
                                     ]
                                   },
                                   "difficultyInCollectingServiceCharge": {
@@ -6108,6 +6769,15 @@
                                   }
                                 ]
                               },
+                              "mostRecentBuildingsInsuranceDemandStatus": {
+                                "title": "Most recent buildings insurance payment demand",
+                                "type": "string",
+                                "enum": [
+                                  "Attached",
+                                  "To follow",
+                                  "Not applicable"
+                                ]
+                              },
                               "lastDemandPeriod": {
                                 "title": "What period is covered by the last demand?",
                                 "type": "object",
@@ -6298,7 +6968,7 @@
                                               "assessmentsCarriedOut": {
                                                 "enum": [
                                                   "Fire risk assessment",
-                                                  "External Wall fire risk assessment",
+                                                  "External wall fire risk assessment",
                                                   "Both"
                                                 ]
                                               },
@@ -6516,7 +7186,8 @@
                                     "title": "",
                                     "enum": [
                                       "Yes",
-                                      "No"
+                                      "No",
+                                      "Not known"
                                     ]
                                   }
                                 },
@@ -6525,7 +7196,8 @@
                                     "properties": {
                                       "yesNo": {
                                         "enum": [
-                                          "No"
+                                          "No",
+                                          "Not known"
                                         ]
                                       }
                                     }
@@ -6555,7 +7227,8 @@
                                     "title": "",
                                     "enum": [
                                       "Yes",
-                                      "No"
+                                      "No",
+                                      "Not known"
                                     ]
                                   }
                                 },
@@ -6564,7 +7237,8 @@
                                     "properties": {
                                       "yesNo": {
                                         "enum": [
-                                          "No"
+                                          "No",
+                                          "Not known"
                                         ]
                                       }
                                     }
@@ -6688,7 +7362,8 @@
                                 "type": "string",
                                 "enum": [
                                   "Yes",
-                                  "No"
+                                  "No",
+                                  "Not known"
                                 ]
                               },
                               "deedOfCertificateServed": {
@@ -6748,7 +7423,8 @@
                                 "type": "string",
                                 "enum": [
                                   "Yes",
-                                  "No"
+                                  "No",
+                                  "Not known"
                                 ]
                               },
                               "landlordsCertificateServed": {
@@ -7543,7 +8219,7 @@
                                 ]
                               },
                               "managementCompanyDocuments": {
-                                "title": "If a landlord is a company controlled by the tenants and/or if a tenants’ management company or Right to Manage company is managing the building, please supply a copy of:",
+                                "title": "If a landlord is a company controlled by the tenants and/or if a tenants' management company or Right to Manage company is managing the building, please supply a copy of:",
                                 "type": "object",
                                 "required": [
                                   "memorandumAndArticles",
@@ -7591,6 +8267,27 @@
                               },
                               "enforcementNotices": {
                                 "title": "Known enforcement notices served on the landlord or accountable person (where the building is residential and is at least 18 meters or 7 storeys).",
+                                "type": "string",
+                                "enum": [
+                                  "Attached",
+                                  "To follow",
+                                  "Not applicable"
+                                ]
+                              }
+                            }
+                          },
+                          "additionalInformation": {
+                            "title": "Additional information about any of your answers",
+                            "description": "If there is any further information about any of your answers on this form, provide details below and/or supply additional documents.",
+                            "type": "object",
+                            "properties": {
+                              "details": {
+                                "title": "Details",
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "attachments": {
+                                "title": "Attachments",
                                 "type": "string",
                                 "enum": [
                                   "Attached",
@@ -7717,8 +8414,21 @@
                       ]
                     },
                     "annualCostOfPermit": {
-                      "title": "Annual cost of permit (£)",
+                      "title": "Annual cost of permit (£) (deprecated, retained for backwards compatibility — use costOfPermit + costOfPermitFrequency)",
                       "type": "number"
+                    },
+                    "costOfPermit": {
+                      "title": "Cost of permit (£)",
+                      "type": "number"
+                    },
+                    "costOfPermitFrequency": {
+                      "title": "Payment frequency",
+                      "type": "string",
+                      "enum": [
+                        "Per month",
+                        "Per year",
+                        "Not applicable"
+                      ]
                     }
                   }
                 }
@@ -7763,6 +8473,20 @@
                 }
               ]
             },
+            "droppedKerbAccess": {
+              "title": "Is there a dropped kerb access to parking?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              }
+            },
             "electricVehicleChargingPoint": {
               "title": "Is there an electric vehicle charging point belonging to the property?",
               "type": "object",
@@ -7775,7 +8499,78 @@
                     "No"
                   ]
                 }
-              }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "chargerDetails": {
+                      "title": "Specify the type of EV charger, connector and its location and provide building regulation approvals:",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "chargerDetailsAttachments": {
+                      "title": "Attachments",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
+                    },
+                    "cableCrossesPavement": {
+                      "title": "Does an EV charging cable have to cross the public pavement?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "title": "Specify any relevant local authority licence or terms and conditions",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
             },
             "locatedInUlez": {
               "title": "Is the property and/or parking located in an Ultra Low Emission Zone (ULEZ)?",
@@ -7957,6 +8752,11 @@
                                 "Yes"
                               ]
                             },
+                            "details": {
+                              "title": "Give details",
+                              "type": "string",
+                              "minLength": 1
+                            },
                             "consentsObtained": {
                               "title": "Were the relevant consents obtained?",
                               "type": "string",
@@ -8040,7 +8840,7 @@
               ]
             },
             "buildingSafety": {
-              "title": "Are you aware of any building safety issues?",
+              "title": "Are you aware of any remediation required to the property due to building safety?",
               "description": "For example issues related to unsafe cladding, integrity of building materials used in construction (e.g. asbestos), risk of collapse (e.g. damaged roofs or structural failures), at-risk wooden decking for external structures (including balconies), lack of emergency lighting where required or insufficient fire/smoke alarm systems",
               "type": "object",
               "properties": {
@@ -8050,7 +8850,8 @@
                   "enum": [
                     "Yes",
                     "No",
-                    "Not applicable"
+                    "Not applicable",
+                    "Not known"
                   ]
                 }
               },
@@ -8059,7 +8860,9 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -8098,7 +8901,6 @@
                     },
                     "attachments": {
                       "title": "Attachments",
-                      "description": "Please attach evidence in support of the above",
                       "type": "string",
                       "enum": [
                         "Attached",
@@ -8711,7 +9513,6 @@
             "hasDisputesAndComplaints": {
               "title": "Have any disputes or complaints occurred, regarding this property, a property nearby, or their use?",
               "description": "E.g boundary disagreement, noise, trespass etc",
-              "ta6Description": "",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -9273,6 +10074,54 @@
                 }
               ]
             },
+            "nonResidentialPurposes": {
+              "title": "Is any part of the property used exclusively for non-residential purposes?",
+              "description": "If yes, give details and supply a copy of any relevant planning permission:",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Please give details",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "attachments": {
+                      "title": "Please supply a copy of any relevant planning permission",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
             "windowReplacementsSince2002": {
               "title": "Since 1st April 2002 has replacement of any windows, roof windows, roof lights, glazed doors taken place?",
               "type": "object",
@@ -9463,6 +10312,239 @@
                     },
                     "deedRestrictionConsent": {
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of documents",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "extension": {
+              "title": "Extension",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
@@ -9704,6 +10786,1164 @@
                     },
                     "deedRestrictionConsent": {
                       "title": "Was any consent under a restriction in the deeds obtained? E.g. if your deeds require consent from someone else to alter or extend the property",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of documents",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "loftConversion": {
+              "title": "Loft conversion",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "garageConversion": {
+              "title": "Garage conversion",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "removalOfInternalWalls": {
+              "title": "Removal of internal walls",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "removalOfChimneyBreast": {
+              "title": "Removal of chimney breast",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "insulation": {
+              "title": "Insulation",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "otherBuildingWorksOrChangesToTheProperty": {
+              "title": "Other building works or changes to the property",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details of the work and the date it was carried out, or state not known",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "workCompleted": {
+                      "title": "Has all this work been completed?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            },
+                            "details": {
+                              "title": "Give details of what remains to be completed",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "documents": {
+                      "title": "Supply copies of the planning permissions, building regulations approvals, completion certificates or competent person certificates for the work if you have them",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
+                    },
+                    "planningPermission": {
+                      "title": "Was planning permission obtained?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "title": "",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not required"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Please provide a copy of the documents",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not required"
+                              ]
+                            },
+                            "details": {
+                              "title": "Please outline the reasons why",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "buildingRegApproval": {
+                      "title": "Was building regulation approval and a completion certificate obtained?",
                       "type": "object",
                       "properties": {
                         "yesNo": {
@@ -10349,12 +12589,56 @@
               ]
             },
             "japaneseKnotweed": {
-              "title": "To your knowledge, is the property or neighbouring land, affected by Japanese knotweed or other invasive species?",
+              "title": "Japanese Knotweed",
               "type": "object",
               "properties": {
+                "knotweedSurveyCarriedOut": {
+                  "title": "Has a Japanese knotweed survey been carried out in relation to the property?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "title": "Provide a copy of the survey.",
+                          "type": "string",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
                 "yesNo": {
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, is the property or neighbouring land, affected by Japanese knotweed or other invasive species?",
                   "enum": [
                     "Yes",
                     "No",
@@ -10388,16 +12672,37 @@
                         "No",
                         "Not known"
                       ]
-                    },
-                    "attachments": {
-                      "title": "Please supply a copy with any insurance cover linked to the plan.",
-                      "type": "string",
-                      "enum": [
-                        "Attached",
-                        "To follow"
-                      ]
                     }
-                  }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "managementPlanInPlace": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "title": "Please supply a copy with any insurance cover linked to the plan.",
+                          "type": "string",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        }
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -10494,12 +12799,168 @@
                   }
                 }
               ]
+            },
+            "wellsDitchesShaft": {
+              "title": "Are there any wells, ditches, or shafts at the property?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "damagedOrExposedElectrics": {
+              "title": "Are there any damaged or exposed electrics at the property?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "damageToFlooringOrStaircases": {
+              "title": "Is there any damage to flooring and/or staircases?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
+            "knownAreasInPoorCondition": {
+              "title": "Are there any known areas in poor condition (internal or external)?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Give details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
             }
           }
         },
         "fixturesAndFittings": {
           "title": "Fixtures and Fittings",
-          "description": "This is so a buyer’s offer can take into account whether you are taking something of value or leaving extra items.  A full list will need to be completed after the sale is agreed.",
+          "description": "This is so a buyer's offer can take into account whether you are taking something of value or leaving extra items.  A full list will need to be completed after the sale is agreed.",
           "type": "object",
           "properties": {
             "itemsToRemove": {
@@ -12151,15 +14612,6 @@
                             }
                           }
                         }
-                      },
-                      {
-                        "properties": {
-                          "isIncludedOrExcluded": {
-                            "enum": [
-                              "None"
-                            ]
-                          }
-                        }
                       }
                     ]
                   }
@@ -12950,6 +15402,10 @@
                             "enum": [
                               "Included"
                             ]
+                          },
+                          "comments": {
+                            "title": "Comments",
+                            "type": "string"
                           }
                         }
                       },
@@ -12963,6 +15419,10 @@
                           "price": {
                             "title": "Price",
                             "type": "number"
+                          },
+                          "comments": {
+                            "title": "Comments",
+                            "type": "string"
                           }
                         }
                       }
@@ -13680,6 +16140,10 @@
                                 "enum": [
                                   "Included"
                                 ]
+                              },
+                              "comments": {
+                                "title": "Comments",
+                                "type": "string"
                               }
                             }
                           },
@@ -13693,6 +16157,10 @@
                               "price": {
                                 "title": "Price",
                                 "type": "number"
+                              },
+                              "comments": {
+                                "title": "Comments",
+                                "type": "string"
                               }
                             }
                           }
@@ -15475,8 +17943,8 @@
                         },
                         "mpan": {
                           "title": "Meter Point Administration Number (MPAN)",
-                          "description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked ‘Supply Number’. It’s 21 digits long and begins with ‘S’. You’ll only need the last 12 or 13 digits.",
-                          "type": "integer"
+                          "description": "Your MPAN is on your electricity or dual fuel bill, usually in a box marked 'Supply Number'. It's 21 digits long and begins with 'S'. You'll only need the last 12 or 13 digits.",
+                          "type": "string"
                         }
                       }
                     }
@@ -15537,6 +18005,14 @@
                       "title": "Supplier",
                       "type": "string"
                     },
+                    "hotWaterOnly": {
+                      "title": "Is the system used only to provide hot water or heating and not to generate electricity?",
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    },
                     "yearInstalled": {
                       "title": "What year were they installed?",
                       "type": "integer"
@@ -15582,6 +18058,49 @@
                               "enum": [
                                 "Attached",
                                 "To follow"
+                              ]
+                            },
+                            "associatedCost": {
+                              "title": "Associated costs of leased solar panels",
+                              "type": "object",
+                              "properties": {
+                                "frequency": {
+                                  "title": "Payment frequency if costs are associated",
+                                  "type": "string",
+                                  "enum": [
+                                    "Per month",
+                                    "Per year",
+                                    "Not applicable"
+                                  ]
+                                }
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "frequency": {
+                                      "enum": [
+                                        "Not applicable"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "frequency": {
+                                      "enum": [
+                                        "Per month",
+                                        "Per year"
+                                      ]
+                                    },
+                                    "amount": {
+                                      "title": "Associated costs of leased solar panels if any (£)",
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "amount"
+                                  ]
+                                }
                               ]
                             }
                           }
@@ -15679,15 +18198,6 @@
                         }
                       ]
                     },
-                    "isConnectedToNationalGrid": {
-                      "title": "Is the system connected to the National Grid e.g. for feed-in tariffs (FiT) or Smart Export Guarantee (SEG)",
-                      "type": "string",
-                      "enum": [
-                        "Yes (FiT)",
-                        "Yes (SEG)",
-                        "No"
-                      ]
-                    },
                     "photovoltaicMeterPanelLocation": {
                       "title": "Location of photovoltaic panel meter (if any)",
                       "type": "object",
@@ -15707,24 +18217,206 @@
                         }
                       }
                     },
-                    "photovoltaicBatteriesLocation": {
-                      "title": "Location of photovoltaic batteries (if any)",
+                    "maintenanceAgreement": {
+                      "title": "Do you have a maintenance agreement in place for the system?",
                       "type": "object",
                       "properties": {
-                        "description": {
-                          "title": "Describe the location of the batteries",
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "attachments": {
-                          "title": "Photograph of batteries location",
+                        "yesNo": {
+                          "title": "",
                           "type": "string",
                           "enum": [
-                            "Attached",
-                            "To follow"
+                            "Yes",
+                            "No"
                           ]
                         }
-                      }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "attachments": {
+                              "title": "Supply a copy of the agreement.",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "photovoltaicBatteries": {
+                      "title": "Photovoltaic batteries",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "title": "",
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "yesNo"
+                      ],
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "description": {
+                              "title": "Describe the location of the batteries",
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "attachments": {
+                              "title": "Photograph of batteries location",
+                              "type": "string",
+                              "enum": [
+                                "Attached",
+                                "To follow"
+                              ]
+                            },
+                            "details": {
+                              "title": "Provide the make, model and storage capacity in kWh of the battery:",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "nationalGrid": {
+                      "title": "Is the system connected to the National Grid?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "title": "",
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "fitOrSegInPlace": {
+                              "title": "Is there a Feed-in Tariff (FIT) or Smart Export Guarantee (SEG) in place?",
+                              "type": "object",
+                              "properties": {
+                                "yesNo": {
+                                  "title": "",
+                                  "type": "string",
+                                  "enum": [
+                                    "Yes",
+                                    "No"
+                                  ]
+                                }
+                              },
+                              "oneOf": [
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "No"
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "properties": {
+                                    "yesNo": {
+                                      "enum": [
+                                        "Yes"
+                                      ]
+                                    },
+                                    "fitSegAgreementCopy": {
+                                      "title": "Supply a copy of the agreement.",
+                                      "type": "string",
+                                      "enum": [
+                                        "Attached",
+                                        "To follow"
+                                      ]
+                                    },
+                                    "attachments": {
+                                      "title": "Provide a copy of the electricity bill showing the credit paid for the generation.",
+                                      "type": "string",
+                                      "enum": [
+                                        "Attached",
+                                        "To follow"
+                                      ]
+                                    },
+                                    "fitSegAssignmentProcedure": {
+                                      "title": "Provide details of the procedure for assigning the benefit of the FIT or SEG agreement on completion of the purchase to the buyer.",
+                                      "type": "string",
+                                      "enum": [
+                                        "Attached",
+                                        "To follow"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "required": [
+                        "yesNo"
+                      ]
+                    },
+                    "installationCertificates": {
+                      "title": "Provide a copy of the building regulations completion certificate or compliance certificate (e.g. MCS) for the installation of the system.",
+                      "type": "string",
+                      "enum": [
+                        "Attached",
+                        "To follow",
+                        "Not available"
+                      ]
                     }
                   }
                 },
@@ -15800,6 +18492,14 @@
                         "To follow",
                         "Not applicable"
                       ]
+                    },
+                    "makeModel": {
+                      "title": "Make/model",
+                      "type": "string"
+                    },
+                    "serviceProviderName": {
+                      "title": "Service provider name",
+                      "type": "string"
                     }
                   }
                 },
@@ -15947,6 +18647,49 @@
                           "description": "e.g. Private well, borehole, springs etc.",
                           "type": "string",
                           "minLength": 1
+                        },
+                        "associatedCost": {
+                          "title": "Please provide the associated costs for water supply",
+                          "type": "object",
+                          "properties": {
+                            "frequency": {
+                              "title": "Payment frequency if costs are associated",
+                              "type": "string",
+                              "enum": [
+                                "Per month",
+                                "Per year",
+                                "Not applicable"
+                              ]
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                },
+                                "amount": {
+                                  "title": "Associated costs of supply if any (£)",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "amount"
+                              ]
+                            }
+                          ]
                         }
                       }
                     },
@@ -15970,9 +18713,6 @@
                         "stopcock": {
                           "title": "Location of stopcock",
                           "type": "object",
-                          "required": [
-                            "location"
-                          ],
                           "properties": {
                             "location": {
                               "title": "Describe the location of the stopcock",
@@ -16360,7 +19100,7 @@
                               ]
                             },
                             "plantOnOtherLand": {
-                              "title": "Is any part of the septic tank, cesspit or sewerage treatment plant located on someone else’s land?",
+                              "title": "Is any part of the septic tank, cesspit or sewerage treatment plant located on someone else's land?",
                               "type": "object",
                               "properties": {
                                 "yesNo": {
@@ -16463,6 +19203,20 @@
                                       "enum": [
                                         "No, the effluent is discharged through a soakaway system."
                                       ]
+                                    },
+                                    "hasInfiltrationSystem": {
+                                      "title": "Does the sewerage system have an infiltration system?",
+                                      "type": "object",
+                                      "properties": {
+                                        "yesNo": {
+                                          "type": "string",
+                                          "title": "",
+                                          "enum": [
+                                            "Yes",
+                                            "No"
+                                          ]
+                                        }
+                                      }
                                     }
                                   }
                                 },
@@ -16503,8 +19257,26 @@
                                     "Septic tank"
                                   ]
                                 },
+                                "dateDischargeCommenced": {
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "dateInstalled": {
+                                  "title": "When was the system installed?",
+                                  "type": "string",
+                                  "format": "date"
+                                },
                                 "dateReplaced": {
-                                  "title": "Date replaced or upgraded",
+                                  "title": "When was the system last replaced or upgraded?",
                                   "type": "string",
                                   "format": "date"
                                 },
@@ -16522,6 +19294,29 @@
                                     "Cesspit"
                                   ]
                                 },
+                                "dateDischargeCommenced": {
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "dateInstalled": {
+                                  "title": "Date installed",
+                                  "type": "string",
+                                  "format": "date"
+                                },
+                                "dateReplaced": {
+                                  "title": "When was the system last replaced or upgraded?",
+                                  "type": "string",
+                                  "format": "date"
+                                },
                                 "dateLastEmptied": {
                                   "title": "Date last emptied",
                                   "type": "string",
@@ -16536,13 +19331,43 @@
                                     "Sewerage treatment plant"
                                   ]
                                 },
+                                "dateDischargeCommenced": {
+                                  "title": "When did the discharge commence?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
+                                "supplier": {
+                                  "title": "Provider name",
+                                  "type": "string"
+                                },
+                                "makeModel": {
+                                  "title": "Make/model",
+                                  "type": "string"
+                                },
+                                "serviceProviderName": {
+                                  "title": "Service provider name",
+                                  "type": "string"
+                                },
                                 "dateInstalled": {
-                                  "title": "Date installed",
+                                  "title": "When was the system installed",
+                                  "type": "string",
+                                  "format": "date"
+                                },
+                                "dateReplaced": {
+                                  "title": "When was the system last replaced or upgraded?",
                                   "type": "string",
                                   "format": "date"
                                 },
                                 "dateLastServiced": {
-                                  "title": "Date last serviced",
+                                  "title": "When was the treatment plant last serviced",
                                   "type": "string",
                                   "format": "date"
                                 },
@@ -16570,6 +19395,49 @@
                                   "type": "string"
                                 }
                               }
+                            }
+                          ]
+                        },
+                        "associatedCost": {
+                          "title": "Associated costs for sewerage",
+                          "type": "object",
+                          "properties": {
+                            "frequency": {
+                              "title": "Payment frequency if costs are associated",
+                              "type": "string",
+                              "enum": [
+                                "Per month",
+                                "Per year",
+                                "Not applicable"
+                              ]
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Not applicable"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "frequency": {
+                                  "enum": [
+                                    "Per month",
+                                    "Per year"
+                                  ]
+                                },
+                                "amount": {
+                                  "title": "Associated costs for sewerage if any (£)",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "amount"
+                              ]
                             }
                           ]
                         }
@@ -17070,8 +19938,8 @@
                                     },
                                     "mprn": {
                                       "title": "Meter Point Reference Number (MPRN)",
-                                      "description": "You can find your property’s MPRN on your gas or dual fuel bill. It’s usually marked ‘Meter Point Reference Number’ and is between six and 10 digits long.",
-                                      "type": "integer"
+                                      "description": "You can find your property's MPRN on your gas or dual fuel bill. It's usually marked 'Meter Point Reference Number' and is between six and 10 digits long.",
+                                      "type": "string"
                                     }
                                   }
                                 }
@@ -17161,12 +20029,70 @@
                                     "Yes"
                                   ]
                                 },
+                                "boilerInstallationDate": {
+                                  "title": "When was the boiler installed?",
+                                  "type": "string",
+                                  "oneOf": [
+                                    {
+                                      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                                      "format": "date"
+                                    },
+                                    {
+                                      "const": "Not known"
+                                    }
+                                  ]
+                                },
                                 "attachments": {
                                   "title": "Please supply a copy of the installation completion certificate from a competent person qualified under the relevant self-certification scheme e.g. HETAS etc",
                                   "type": "string",
                                   "enum": [
                                     "Attached",
-                                    "To follow"
+                                    "To follow",
+                                    "None"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "replacementOtherThanBoiler": {
+                          "title": "Has there been any replacement to the heating system (other than replacement of a boiler)?",
+                          "type": "object",
+                          "properties": {
+                            "yesNo": {
+                              "type": "string",
+                              "enum": [
+                                "Yes",
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          },
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "No",
+                                    "Not known"
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "yesNo": {
+                                  "enum": [
+                                    "Yes"
+                                  ]
+                                },
+                                "attachments": {
+                                  "title": "Supply compliance certificates or documentation for the alteration (such as a building regulation completion certificate).",
+                                  "type": "string",
+                                  "enum": [
+                                    "Attached",
+                                    "To follow",
+                                    "None"
                                   ]
                                 }
                               }
@@ -17205,7 +20131,8 @@
                               "title": "",
                               "enum": [
                                 "Yes",
-                                "No"
+                                "No",
+                                "Not known"
                               ]
                             }
                           },
@@ -17214,7 +20141,8 @@
                               "properties": {
                                 "yesNo": {
                                   "enum": [
-                                    "Yes"
+                                    "Yes",
+                                    "Not known"
                                   ]
                                 }
                               }
@@ -17275,9 +20203,24 @@
                   "Ground source heat pump",
                   "Air source heat pump",
                   "Solar thermal",
-                  "Passive House design"
+                  "Passive House design",
+                  "Mains gas",
+                  "Electricity",
+                  "Oil",
+                  "LPG",
+                  "Biomass"
                 ]
               }
+            },
+            "multipleHeatingSystems": {
+              "title": "Multiple heating systems",
+              "description": "If there is more than one heating system, attach answers to the above here.",
+              "type": "string",
+              "enum": [
+                "Attached",
+                "To follow",
+                "Not applicable"
+              ]
             }
           }
         },
@@ -17444,7 +20387,34 @@
                     }
                   }
                 }
-              }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "None"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "typeOfConnection": {
+                      "enum": [
+                        "ADSL copper wire",
+                        "Cable",
+                        "FTTC (Fibre to the Cabinet)",
+                        "FTTP (Fibre to the Premises)"
+                      ]
+                    },
+                    "providerName": {
+                      "title": "Provider name",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
             },
             "mobilePhone": {
               "title": "Mobile phone coverage",
@@ -17592,6 +20562,10 @@
                   }
                 }
               }
+            },
+            "otherServices": {
+              "title": "Details of any other services",
+              "type": "string"
             }
           }
         },
@@ -17791,6 +20765,11 @@
                     "No",
                     "Not applicable"
                   ]
+                },
+                "whoInsures": {
+                  "title": "Who insures the property?",
+                  "type": "string",
+                  "minLength": 1
                 }
               }
             },
@@ -17858,7 +20837,8 @@
                   "title": "",
                   "enum": [
                     "Yes",
-                    "No"
+                    "No",
+                    "Not applicable"
                   ]
                 }
               },
@@ -17867,7 +20847,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not applicable"
                       ]
                     }
                   }
@@ -17883,13 +20864,53 @@
                       "title": "Please give details including who collects payments and organises the work, the amount of the payments in the last year and whether they are regular payments or only when maintenance work is required",
                       "type": "string",
                       "minLength": 1
+                    },
+                    "disagreementOrComplaint": {
+                      "title": "Are you aware of any disagreement or complaint about any such right or arrangement?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "title": "Provide details",
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
               ]
             },
             "neighbouringLandRights": {
-              "title": "Do any rights and arrangements exist over neighbouring land from which the property benefits?  (e.g. taking wheelie bins along an accessway through a neighbour’s back garden, parking, access to maintain the boundaries from the neighbour’s side etc)",
+              "title": "Do any rights and arrangements exist over neighbouring land from which the property benefits?  (e.g. taking wheelie bins along an accessway through a neighbour's back garden, parking, access to maintain the boundaries from the neighbour's side etc)",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -17923,6 +20944,45 @@
                       "type": "string",
                       "minLength": 1
                     },
+                    "disagreementOrComplaint": {
+                      "title": "Are you aware of any disagreement or complaint about any such right or arrangement?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    },
                     "attachments": {
                       "title": "Attachments",
                       "type": "string",
@@ -17944,7 +21004,8 @@
                   "title": "",
                   "enum": [
                     "Yes",
-                    "No"
+                    "No",
+                    "Not known"
                   ]
                 }
               },
@@ -17953,7 +21014,8 @@
                   "properties": {
                     "yesNo": {
                       "enum": [
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   }
@@ -18020,6 +21082,45 @@
                             "Attached",
                             "To follow"
                           ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "privateRightOfWay": {
+                  "title": "A private right of way through and/or across your house, buildings or land",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Please provide details",
+                          "type": "string",
+                          "minLength": 1
                         }
                       }
                     }
@@ -18297,8 +21398,127 @@
                       }
                     }
                   ]
+                },
+                "disagreementOrComplaint": {
+                  "title": "Are you aware of any disagreement or complaint about any such rights?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No",
+                        "Not known"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
                 }
               }
+            },
+            "askedOthersToContribute": {
+              "title": "Have you asked the owner of any other properties to contribute towards the cost of the jointly used facilities?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "enum": [
+                    "Yes",
+                    "No",
+                    "Not applicable"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No",
+                        "Not applicable"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Specify whether you receive this payment or if it is made to a third party. Include details about how much is paid and how often payments are made:",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "disagreementOrComplaint": {
+                      "title": "Are you aware of any disagreement or complaint about any such arrangements?",
+                      "type": "object",
+                      "properties": {
+                        "yesNo": {
+                          "type": "string",
+                          "enum": [
+                            "Yes",
+                            "No",
+                            "Not known"
+                          ]
+                        }
+                      },
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "No",
+                                "Not known"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "yesNo": {
+                              "enum": [
+                                "Yes"
+                              ]
+                            },
+                            "details": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
             }
           }
         },
@@ -18310,6 +21530,48 @@
               "title": "Flooding",
               "type": "object",
               "properties": {
+                "floodRiskReport": {
+                  "title": "Flood risk report",
+                  "type": "object",
+                  "properties": {
+                    "hasReportBeenPrepared": {
+                      "title": "Has a flood risk report been prepared?",
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "hasReportBeenPrepared": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "title": "Please supply a copy",
+                          "type": "string",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
                 "floodRisk": {
                   "title": "Flood Risk",
                   "type": "object",
@@ -18512,6 +21774,45 @@
                 }
               }
             },
+            "stormFireFloodDamage": {
+              "title": "Has the property ever suffered storm, fire or flood damage?",
+              "type": "object",
+              "properties": {
+                "yesNo": {
+                  "type": "string",
+                  "title": "",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "oneOf": [
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "yesNo": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "details": {
+                      "title": "Please provide details",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              ]
+            },
             "radon": {
               "title": "Radon",
               "type": "object",
@@ -18612,7 +21913,8 @@
                       "title": "",
                       "enum": [
                         "Yes",
-                        "No"
+                        "No",
+                        "Not known"
                       ]
                     }
                   },
@@ -18621,7 +21923,8 @@
                       "properties": {
                         "yesNo": {
                           "enum": [
-                            "No"
+                            "No",
+                            "Not known"
                           ]
                         }
                       }
@@ -19662,8 +22965,7 @@
                   "properties": {
                     "riskIndicator": {
                       "enum": [
-                        "No",
-                        "Not known"
+                        "No"
                       ]
                     }
                   }
@@ -19743,7 +23045,7 @@
               "properties": {
                 "yesNo": {
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, has the property been subject to any crime, burglary or violent death?",
                   "enum": [
                     "Yes",
                     "No"
@@ -19790,7 +23092,7 @@
               "properties": {
                 "yesNo": {
                   "type": "string",
-                  "title": "",
+                  "title": "To your knowledge, has the property been occupied by someone who has been cautioned or convicted of a serious crime?",
                   "enum": [
                     "Yes",
                     "No"
@@ -19837,7 +23139,7 @@
               "properties": {
                 "yesNo": {
                   "type": "string",
-                  "title": "",
+                  "title": "Have there been any failed purchase transactions on the property within the last 12 months?",
                   "enum": [
                     "Yes",
                     "No"
@@ -19884,6 +23186,48 @@
           "title": "Additional Information",
           "type": "object",
           "properties": {
+            "consents": {
+              "title": "Please supply copies of all consents that have been given under any covenants, estate management schemes or other restrictions affecting the title to the property for all actions you have disclosed in your answers to questions 5 (Alterations), 8.5 (Green Deal), 10.3 (EV charging points) and 11 (Services).",
+              "type": "object",
+              "properties": {
+                "attachments": {
+                  "enum": [
+                    "Attached",
+                    "To follow",
+                    "Not applicable",
+                    "Not available"
+                  ]
+                },
+                "consentsAttached": {
+                  "title": "List the consents that are attached",
+                  "type": "string"
+                },
+                "consentsToFollow": {
+                  "title": "List the consents to follow",
+                  "type": "string"
+                },
+                "consentsNotAvailable": {
+                  "title": "List any consents that are not available",
+                  "type": "string"
+                }
+              }
+            },
+            "furtherInformation": {
+              "title": "If there is any further information about any of your answers supplied, provide details below and/or supply additional documents.",
+              "type": "object",
+              "properties": {
+                "details": {
+                  "type": "string"
+                },
+                "attachments": {
+                  "enum": [
+                    "Attached",
+                    "To follow",
+                    "Not applicable"
+                  ]
+                }
+              }
+            },
             "restrictionsOnUseNotCompliedWith": {
               "title": "Are you aware of any restrictions on the use or alteration of the property which have not been complied with?",
               "type": "object",
@@ -19932,7 +23276,7 @@
               ]
             },
             "otherMaterialIssue": {
-              "title": "Are you aware of any other material issue or information which relates to the property or has anything occurred which may affect the average person’s decision to proceed?",
+              "title": "Are you aware of any other material issue or information which relates to the property or has anything occurred which may affect the average person's decision to proceed?",
               "description": "This disclosure is required under the Consumer Protection from Unfair Trading Regulations 2008",
               "type": "object",
               "properties": {
@@ -20039,7 +23383,7 @@
           "type": "object",
           "properties": {
             "consumerProtectionRegulationsResponse": {
-              "title": "Seller’s declaration",
+              "title": "Seller's declaration",
               "description": "I/we confirm the answers to be truthful and accurate and to the best of my/our knowledge. The questions have been designed to assist with the disclosure of material information and any misleading or incorrect answers are likely to be exposed later in the legal process which may hinder my/our sale. I/we will provide my property lawyer with the additional documentation in support of the information supplied on this form. If there are any changes which alter the information provided, I/we will immediately notify the person marketing the property as well as my/our property lawyer.",
               "type": "boolean"
             }
@@ -20115,7 +23459,7 @@
           "type": "object",
           "properties": {
             "partOutsideLegalOwnership": {
-              "title": "Is any part of the property outside the seller’s legal ownership?",
+              "title": "Is any part of the property outside the seller's legal ownership?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -20468,7 +23812,6 @@
             "flyingFreehold": {
               "title": "Is there a flying freehold?",
               "description": "NOTE: a flying freehold is when part of the property overhangs a neighbour's property or an accessway - e.g. a terrace house where part of the upstairs is over an accessway which belongs to someone else.",
-              "ta6Description": "",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -20477,7 +23820,8 @@
                   "enum": [
                     "Yes",
                     "No",
-                    "Not applicable"
+                    "Not applicable",
+                    "Not known"
                   ]
                 }
               },
@@ -20487,7 +23831,8 @@
                     "yesNo": {
                       "enum": [
                         "No",
-                        "Not applicable"
+                        "Not applicable",
+                        "Not known"
                       ]
                     }
                   }
@@ -20565,7 +23910,7 @@
             },
             "pipesWiresCablesDrainsFromProperty": {
               "title": "Are you aware of any pipes, wires, cables or drains taking services to neighbouring property cross this property?",
-              "ta6Ttle": "Do any drains, pipes or wires leading to any neighbour’s property cross the property?",
+              "ta6Ttle": "Do any drains, pipes or wires leading to any neighbour's property cross the property?",
               "type": "object",
               "properties": {
                 "yesNo": {
@@ -20707,7 +24052,8 @@
                       "type": "string",
                       "enum": [
                         "Attached",
-                        "To follow"
+                        "To follow",
+                        "Not available"
                       ]
                     }
                   }
@@ -20772,7 +24118,8 @@
                           "type": "string",
                           "enum": [
                             "Attached",
-                            "To follow"
+                            "To follow",
+                            "Not available"
                           ]
                         }
                       }
@@ -21225,6 +24572,39 @@
                             "Attached",
                             "To follow"
                           ]
+                        },
+                        "fensaCertificates": {
+                          "type": "object",
+                          "properties": {
+                            "certificates": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "certificateId": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  },
+                                  "numberOfWindows": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "numberOfDoors": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                  },
+                                  "certificateIssued": {
+                                    "type": "string",
+                                    "format": "date"
+                                  },
+                                  "workCompleted": {
+                                    "type": "string",
+                                    "format": "date"
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
@@ -21274,6 +24654,48 @@
                 },
                 "subsidenceWork": {
                   "title": "Underpinning or other preventative work and/or remedial action relating to subsidence",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "title": "",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "attachments": {
+                          "title": "",
+                          "type": "string",
+                          "enum": [
+                            "Attached",
+                            "To follow"
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "insulation": {
+                  "title": "Insulation",
                   "type": "object",
                   "properties": {
                     "yesNo": {
@@ -21450,6 +24872,44 @@
                     }
                   ]
                 },
+                "breachOfTermsOrConditions": {
+                  "title": "Are you aware of anything that may breach the terms and conditions of any of these guarantees or warranties?",
+                  "type": "object",
+                  "properties": {
+                    "yesNo": {
+                      "type": "string",
+                      "enum": [
+                        "Yes",
+                        "No"
+                      ]
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "No"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "yesNo": {
+                          "enum": [
+                            "Yes"
+                          ]
+                        },
+                        "details": {
+                          "title": "Please give details",
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      }
+                    }
+                  ]
+                },
                 "titleDefectInsurance": {
                   "title": "Do you have any title defect insurance policies?",
                   "description": "e.g. for breach of planning permission, buildings regulations, restrictions, chancel repair etc",
@@ -21574,6 +25034,7 @@
                         "soldWithVacantPossession": {
                           "type": "string",
                           "title": "Is the property being sold with vacant possession?",
+                          "description": "(empty of all occupiers, rubbish and any contents or fittings not included in the sale)",
                           "enum": [
                             "Yes",
                             "No"
@@ -21815,6 +25276,7 @@
                       ]
                     },
                     "details": {
+                      "title": "Please provide details",
                       "type": "string"
                     }
                   }
@@ -21929,7 +25391,28 @@
                     "format": "date-time"
                   },
                   "externalIds": {
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "patternProperties": {
+                              ".*": {}
+                            }
+                          }
+                        ]
+                      }
+                    }
                   }
                 }
               }
@@ -33939,12 +37422,12 @@
                     "documentDate": {
                       "title": "Date of original document",
                       "type": "string",
-                      "fornat": "date"
+                      "format": "date"
                     },
                     "retrievedOn": {
                       "title": "Datetime retrieved from HMLR",
                       "type": "string",
-                      "fornat": "date-time"
+                      "format": "date-time"
                     },
                     "filedUnder": {
                       "title": "Related title number",
@@ -34074,6 +37557,34 @@
                 "minLength": 1
               },
               "externalIds": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {}
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "isDeleted": {
+                "type": "boolean"
+              },
+              "summary": {
+                "title": "Structured summary of the document",
                 "type": "object"
               }
             }
@@ -36849,7 +40360,28 @@
                     "format": "uri"
                   },
                   "externalIds": {
-                    "type": "object"
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "object",
+                            "patternProperties": {
+                              ".*": {}
+                            }
+                          }
+                        ]
+                      }
+                    }
                   },
                   "requiredSignatories": {
                     "type": "array",
@@ -36905,7 +40437,28 @@
                   "format": "date-time"
                 },
                 "externalIds": {
-                  "type": "object"
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "object",
+                          "patternProperties": {
+                            ".*": {}
+                          }
+                        }
+                      ]
+                    }
+                  }
                 }
               },
               "role": {
@@ -36951,7 +40504,28 @@
                 "type": "string"
               },
               "externalIds": {
-                "type": "object"
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {}
+                        }
+                      }
+                    ]
+                  }
+                }
               },
               "address": {
                 "title": "Address",
@@ -37033,7 +40607,28 @@
               "type": "string"
             },
             "externalIds": {
-              "type": "object"
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
             },
             "address": {
               "title": "Address",
@@ -37218,6 +40813,412 @@
               "format": "date-time"
             }
           }
+        }
+      }
+    },
+    "offers": {
+      "title": "Offers for purchase of the property",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+      },
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "minimum": 0
+            },
+            "currency": {
+              "type": "string",
+              "pattern": "^[A-Z]{3}$"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "Pending",
+                "Withdrawn",
+                "Rejected",
+                "Accepted",
+                "Note of Interest"
+              ]
+            },
+            "inclusions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclusions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "conditions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "externalIds": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "buyerCircumstances": {
+              "title": "Buyer circumstances",
+              "description": "Information about the buyer's circumstances for lender compatibility analysis and conveyancing quotes",
+              "type": "object",
+              "properties": {
+                "intendedUse": {
+                  "type": "string",
+                  "title": "Intended use of property",
+                  "enum": [
+                    "Owner occupied",
+                    "Buy-to-let",
+                    "Holiday let",
+                    "Second home"
+                  ]
+                },
+                "firstTimeBuyer": {
+                  "type": "boolean",
+                  "title": "First-time buyer"
+                },
+                "rightToBuy": {
+                  "type": "boolean",
+                  "title": "Right to Buy purchase"
+                },
+                "ltdCompanyPurchase": {
+                  "type": "boolean",
+                  "title": "Limited company purchase"
+                },
+                "numberOfOwners": {
+                  "type": "integer",
+                  "title": "Number of owners",
+                  "nullable": true
+                },
+                "numberOfExpats": {
+                  "type": "integer",
+                  "title": "Number of expat buyers",
+                  "nullable": true
+                },
+                "giftedEquity": {
+                  "type": "boolean",
+                  "title": "Gifted equity"
+                },
+                "numberOfGiftedDeposits": {
+                  "type": "integer",
+                  "title": "Number of gifted deposits",
+                  "nullable": true
+                },
+                "requiresMortgage": {
+                  "type": "string",
+                  "title": "Requires mortgage",
+                  "enum": [
+                    "Yes",
+                    "No"
+                  ]
+                }
+              },
+              "required": [
+                "requiresMortgage"
+              ],
+              "oneOf": [
+                {
+                  "properties": {
+                    "requiresMortgage": {
+                      "enum": [
+                        "No"
+                      ]
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "requiresMortgage": {
+                      "enum": [
+                        "Yes"
+                      ]
+                    },
+                    "helpToBuyEquityLoan": {
+                      "type": "boolean",
+                      "title": "Help to Buy equity loan"
+                    },
+                    "armedForcesHelpToBuy": {
+                      "type": "boolean",
+                      "title": "Armed Forces Help to Buy"
+                    },
+                    "numberOfHelpToBuyIsas": {
+                      "type": "integer",
+                      "title": "Number of Help to Buy ISAs",
+                      "nullable": true
+                    },
+                    "bridgingFinanceRepresentation": {
+                      "type": "string",
+                      "title": "Bridging finance representation",
+                      "enum": [
+                        "Dual",
+                        "Separate"
+                      ],
+                      "nullable": true
+                    },
+                    "depositAmount": {
+                      "type": "number",
+                      "title": "Deposit amount",
+                      "minimum": 0
+                    },
+                    "loanToValue": {
+                      "type": "number",
+                      "title": "Loan-to-Value (LTV)",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "numberOfBorrowers": {
+                      "type": "integer",
+                      "title": "Number of borrowers",
+                      "minimum": 1,
+                      "maximum": 4,
+                      "default": 1
+                    },
+                    "jointProprietorSoleMortgagor": {
+                      "type": "boolean",
+                      "title": "Joint proprietor, sole mortgagor"
+                    },
+                    "soleProprietorJointMortgagor": {
+                      "type": "boolean",
+                      "title": "Sole proprietor, joint mortgagor"
+                    },
+                    "deedOfPostponement": {
+                      "type": "boolean",
+                      "title": "Deed of postponement required"
+                    },
+                    "separateRepresentation": {
+                      "type": "boolean",
+                      "title": "Separate legal representation required",
+                      "nullable": true
+                    },
+                    "oldestBorrowerAge": {
+                      "type": "integer",
+                      "title": "Oldest borrower age",
+                      "minimum": 18,
+                      "maximum": 85
+                    },
+                    "mortgageTerm": {
+                      "type": "integer",
+                      "title": "Mortgage term",
+                      "minimum": 5,
+                      "maximum": 40
+                    },
+                    "adverseCredit": {
+                      "type": "string",
+                      "title": "Adverse credit",
+                      "enum": [
+                        "No",
+                        "Yes",
+                        "Prefer not to say"
+                      ]
+                    },
+                    "employmentType": {
+                      "type": "string",
+                      "title": "Employment type",
+                      "enum": [
+                        "Employed",
+                        "Self-employed",
+                        "Retired",
+                        "Contractor",
+                        "Other"
+                      ]
+                    },
+                    "existingMortgagedProperties": {
+                      "type": "integer",
+                      "title": "Existing mortgaged properties",
+                      "minimum": 0
+                    },
+                    "annualIncome": {
+                      "type": "number",
+                      "title": "Annual gross income",
+                      "minimum": 0
+                    },
+                    "residencyStatus": {
+                      "type": "string",
+                      "title": "Residency status",
+                      "enum": [
+                        "UK citizen",
+                        "Permanent resident",
+                        "Visa holder",
+                        "Non-resident"
+                      ]
+                    },
+                    "nominatedLender": {
+                      "type": "string",
+                      "title": "Nominated lender"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "enquiries": {
+      "title": "Property transaction enquiries between conveyancers",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+      },
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "subject": {
+              "description": "The subject or topic of the enquiry",
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "open",
+                "resolved",
+                "resolvedWithCondition",
+                "withdrawn"
+              ]
+            },
+            "messages": {
+              "description": "Messages exchanged regarding this enquiry",
+              "type": "object",
+              "propertyNames": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:+-]*$"
+              },
+              "patternProperties": {
+                ".*": {
+                  "type": "object",
+                  "properties": {
+                    "datetime": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "originatorRole": {
+                      "type": "string",
+                      "enum": [
+                        "Seller",
+                        "Seller's Conveyancer",
+                        "Buyer",
+                        "Buyer's Conveyancer",
+                        "Estate Agent",
+                        "Buyer's Agent",
+                        "Surveyor",
+                        "Mortgage Broker",
+                        "Lender"
+                      ]
+                    },
+                    "destinationRole": {
+                      "type": "string",
+                      "enum": [
+                        "Seller",
+                        "Seller's Conveyancer",
+                        "Buyer",
+                        "Buyer's Conveyancer",
+                        "Estate Agent",
+                        "Buyer's Agent",
+                        "Surveyor",
+                        "Mortgage Broker",
+                        "Lender"
+                      ]
+                    },
+                    "messageText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "datetime",
+                    "originatorRole",
+                    "destinationRole",
+                    "messageText"
+                  ]
+                }
+              }
+            },
+            "externalIds": {
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {}
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "required": [
+            "subject",
+            "status",
+            "messages"
+          ],
+          "oneOf": [
+            {
+              "properties": {
+                "status": {
+                  "const": "resolvedWithCondition"
+                },
+                "resolutionCondition": {
+                  "description": "Condition that must be met for the enquiry to be fully resolved",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "resolutionCondition"
+              ]
+            },
+            {
+              "properties": {
+                "status": {
+                  "enum": [
+                    "pending",
+                    "open",
+                    "resolved",
+                    "withdrawn"
+                  ]
+                }
+              }
+            }
+          ]
         }
       }
     }

--- a/src/schemas/v3/skeleton.json
+++ b/src/schemas/v3/skeleton.json
@@ -1,6 +1,10 @@
 {
   "transactionId": "string",
-  "externalIds": {},
+  "externalIds": {
+    "*": {
+      "*": {}
+    }
+  },
   "status": "string",
   "participants": [
     {
@@ -21,7 +25,7 @@
         "street": "string",
         "line1": "string",
         "line2": "string",
-        "line 3": "string",
+        "line3": "string",
         "town": "string",
         "postcode": "string",
         "homeNation": "string",
@@ -30,13 +34,57 @@
       "organisation": "string",
       "organisationReference": "string",
       "role": "variant",
-      "externalIds": {},
+      "externalIds": {
+        "*": {
+          "*": {}
+        }
+      },
       "participantStatus": "string",
+      "verification": {
+        "identity": {
+          "status": "string",
+          "result": "string",
+          "reports": [
+            {
+              "reportName": "string",
+              "result": "string",
+              "details": "string"
+            }
+          ]
+        },
+        "antiMoneyLaundering": {
+          "status": "string",
+          "result": "string",
+          "reports": [
+            {
+              "reportName": "string",
+              "result": "string",
+              "details": "string"
+            }
+          ]
+        },
+        "sourceOfFunds": {
+          "status": "string",
+          "result": "string",
+          "reports": [
+            {
+              "reportName": "string",
+              "result": "string",
+              "details": "string"
+            }
+          ]
+        }
+      },
+      "offerId": "string",
       "sellersCapacity": {
         "capacity": "variant",
         "sellersCapacityDetails": "string",
-        "attachments": "string"
-      }
+        "attachments": "string",
+        "companyName": "string",
+        "companyNumber": "string",
+        "countryOfIncorporation": "string"
+      },
+      "dateBecameOwnerOrAuthority": "string"
     }
   ],
   "propertyPack": {
@@ -226,6 +274,8 @@
     "ownership": {
       "numberOfSellers": "integer",
       "numberOfNonUkResidentSellers": "integer",
+      "outstandingMortgage": "string",
+      "existingLender": "string",
       "hasHelpToBuyEquityLoan": "string",
       "isFirstRegistration": "string",
       "isLimitedCompanySale": "string",
@@ -238,6 +288,10 @@
             "yesNo": "variant",
             "details": "string",
             "amount": "number"
+          },
+          "titleRestrictions": {
+            "yesNo": "variant",
+            "details": "string"
           },
           "wholeFreeholdForSale": {
             "yesNo": "variant",
@@ -348,7 +402,20 @@
                 "other": {
                   "isApplicableParty": "variant",
                   "feeIncludingVAT": "number",
-                  "noticeViaEmail": "string"
+                  "noticeViaEmail": "string",
+                  "contact": {
+                    "nameOrOrganisation": "string",
+                    "address": {
+                      "line1": "string",
+                      "line2": "string",
+                      "line3": "string",
+                      "town": "string",
+                      "postcode": "string"
+                    },
+                    "telephone": "string",
+                    "emailAddress": "string"
+                  },
+                  "capacity": "string"
                 },
                 "otherDetailsRequired": {
                   "areOtherDetailsRequired": "variant",
@@ -510,11 +577,15 @@
               "feesForAdminServices": "string"
             },
             "confirmation": {
-              "response": {},
+              "response": "boolean",
               "capacity": "string"
             }
           },
           "leaseholdInformation": {
+            "typeOfLeasehold": {
+              "leaseholdType": "variant",
+              "otherLeaseholdType": "string"
+            },
             "sharedOwnership": {
               "isSharedOwnership": "variant",
               "sharedOwnershipPercentage": "number",
@@ -588,6 +659,48 @@
                     "accountNumber": "integer",
                     "reference": "string",
                     "feeType": "string"
+                  }
+                },
+                "rightToManageCompany": {
+                  "contact": {
+                    "nameOrOrganisation": "string",
+                    "address": {
+                      "line1": "string",
+                      "line2": "string",
+                      "line3": "string",
+                      "town": "string",
+                      "postcode": "string"
+                    },
+                    "emailAddress": "string",
+                    "telephone": "string"
+                  }
+                },
+                "freeholder": {
+                  "contact": {
+                    "nameOrOrganisation": "string",
+                    "address": {
+                      "line1": "string",
+                      "line2": "string",
+                      "line3": "string",
+                      "town": "string",
+                      "postcode": "string"
+                    },
+                    "emailAddress": "string",
+                    "telephone": "string"
+                  }
+                },
+                "headLeaseHolder": {
+                  "contact": {
+                    "nameOrOrganisation": "string",
+                    "address": {
+                      "line1": "string",
+                      "line2": "string",
+                      "line3": "string",
+                      "town": "string",
+                      "postcode": "string"
+                    },
+                    "emailAddress": "string",
+                    "telephone": "string"
                   }
                 },
                 "managingAgent": {
@@ -669,7 +782,20 @@
                   "other": {
                     "isApplicableParty": "variant",
                     "feeIncludingVAT": "number",
-                    "noticeViaEmail": "string"
+                    "noticeViaEmail": "string",
+                    "contact": {
+                      "nameOrOrganisation": "string",
+                      "address": {
+                        "line1": "string",
+                        "line2": "string",
+                        "line3": "string",
+                        "town": "string",
+                        "postcode": "string"
+                      },
+                      "telephone": "string",
+                      "emailAddress": "string"
+                    },
+                    "capacity": "string"
                   }
                 },
                 "noticeOfTransferAndCharge": {
@@ -696,16 +822,35 @@
                   "other": {
                     "isApplicableParty": "variant",
                     "feeIncludingVAT": "number",
-                    "noticeViaEmail": "string"
+                    "noticeViaEmail": "string",
+                    "contact": {
+                      "nameOrOrganisation": "string",
+                      "address": {
+                        "line1": "string",
+                        "line2": "string",
+                        "line3": "string",
+                        "town": "string",
+                        "postcode": "string"
+                      },
+                      "telephone": "string",
+                      "emailAddress": "string"
+                    },
+                    "capacity": "string"
                   },
                   "otherDetailsRequired": {
                     "areOtherDetailsRequired": "variant",
                     "details": "string"
                   }
                 },
-                "collectsGroundRent": "string",
+                "collectsGroundRent": {
+                  "collector": "variant",
+                  "otherCollector": "string"
+                },
                 "collectsServiceCharges": "string",
-                "collectsbuildingInsurancePremiums": "string",
+                "collectsbuildingInsurancePremiums": {
+                  "collector": "variant",
+                  "otherCollector": "string"
+                },
                 "dealsWithDayToDayMaintenanceOfManagedArea": "string",
                 "organisesBuildingInsurance": "string",
                 "dealsWithDayToDayMaintenanceOfBuilding": {
@@ -728,6 +873,11 @@
             "consents": {
               "changesInTermOfLease": {
                 "isSellerAwareOfChanges": "variant",
+                "details": "string",
+                "attachments": "string"
+              },
+              "landlordConsents": {
+                "isSellerAwareOfLandlordConsents": "variant",
                 "details": "string",
                 "attachments": "string"
               }
@@ -756,6 +906,7 @@
               "isGroundRentPayable": "variant",
               "annualGroundRent": "number",
               "groundRentFrequency": "string",
+              "mostRecentGroundRentDemandStatus": "string",
               "rentSubjectToIncrease": {
                 "yesNo": "variant",
                 "rentReviewFrequency": "string",
@@ -780,12 +931,18 @@
                 "buildingManagerType": "variant",
                 "details": "string"
               },
-              "hasTenantCompanyDissolved": "string",
-              "isManagingAgentEmployed": "string"
+              "isManagingAgentEmployed": "string",
+              "sellerOwnership": {
+                "yesNo": "variant",
+                "attachments": "string"
+              },
+              "hasTenantCompanyDissolved": "variant",
+              "hasTenantCompanyDissolvedDetails": "string"
             },
             "serviceCharge": {
               "sellerContributesToServiceCharge": "variant",
               "annualServiceCharge": "number",
+              "mostRecentServiceChargeDemandStatus": "string",
               "largeAdditionalExpense": {
                 "yesNo": "variant",
                 "details": "string"
@@ -798,7 +955,10 @@
                 "yesNo": "variant",
                 "details": "string"
               },
-              "dangerousCladdingOrDefects": "string",
+              "dangerousCladdingOrDefects": {
+                "yesNo": "variant",
+                "details": "string"
+              },
               "difficultyInCollectingServiceCharge": {
                 "yesNo": "variant",
                 "details": "string"
@@ -880,6 +1040,7 @@
                 "yesNo": "variant",
                 "details": "string"
               },
+              "mostRecentBuildingsInsuranceDemandStatus": "string",
               "lastDemandPeriod": {
                 "from": "string",
                 "to": "string"
@@ -900,7 +1061,10 @@
                 "yesNo": "variant",
                 "riskAssessments": {
                   "assessmentsCarriedOut": "variant",
-                  "urgentWorksRecommended": "string"
+                  "urgentWorksRecommended": "variant",
+                  "urgentWorksCarriedOut": "string",
+                  "outstandingEnforcementAction": "variant",
+                  "dateRemedialActionRequired": "string"
                 }
               },
               "standardTermsAvailable": {
@@ -1040,6 +1204,10 @@
               "managementCompanyAGMMinutes": "string",
               "enforcementNotices": "string"
             },
+            "additionalInformation": {
+              "details": "string",
+              "attachments": "string"
+            },
             "confirmationOfAccuracy": {
               "confirmation": "boolean",
               "capacity": "string"
@@ -1058,14 +1226,25 @@
       },
       "controlledParking": {
         "yesNo": "variant",
-        "annualCostOfPermit": "number"
+        "annualCostOfPermit": "number",
+        "costOfPermit": "number",
+        "costOfPermitFrequency": "string"
       },
       "vehicleTypeRestriction": {
         "yesNo": "variant",
         "details": "string"
       },
-      "electricVehicleChargingPoint": {
+      "droppedKerbAccess": {
         "yesNo": "string"
+      },
+      "electricVehicleChargingPoint": {
+        "yesNo": "variant",
+        "chargerDetails": "string",
+        "chargerDetailsAttachments": "string",
+        "cableCrossesPavement": {
+          "yesNo": "variant",
+          "details": "string"
+        }
       },
       "locatedInUlez": {
         "yesNo": "string"
@@ -1086,6 +1265,7 @@
         "yesNo": "variant",
         "workCarriedOut": {
           "yesNo": "variant",
+          "details": "string",
           "consentsObtained": "string",
           "attachments": "string"
         }
@@ -1306,6 +1486,11 @@
           "details": "string"
         }
       },
+      "nonResidentialPurposes": {
+        "yesNo": "variant",
+        "details": "string",
+        "attachments": "string"
+      },
       "windowReplacementsSince2002": {
         "yesNo": "variant",
         "details": "string",
@@ -1326,6 +1511,30 @@
           "details": "string"
         },
         "deedRestrictionConsent": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string"
+      },
+      "extension": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
           "yesNo": "variant",
           "attachments": "string",
           "details": "string"
@@ -1351,6 +1560,125 @@
           "details": "string"
         },
         "deedRestrictionConsent": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string"
+      },
+      "loftConversion": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        }
+      },
+      "garageConversion": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        }
+      },
+      "removalOfInternalWalls": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        }
+      },
+      "removalOfChimneyBreast": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        }
+      },
+      "insulation": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        }
+      },
+      "otherBuildingWorksOrChangesToTheProperty": {
+        "yesNo": "variant",
+        "details": "string",
+        "workCompleted": {
+          "yesNo": "variant",
+          "details": "string"
+        },
+        "documents": "string",
+        "planningPermission": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "buildingRegApproval": {
           "yesNo": "variant",
           "attachments": "string",
           "details": "string"
@@ -1423,8 +1751,12 @@
         "attachments": "string"
       },
       "japaneseKnotweed": {
+        "knotweedSurveyCarriedOut": {
+          "yesNo": "variant",
+          "attachments": "string"
+        },
         "yesNo": "variant",
-        "managementPlanInPlace": "string",
+        "managementPlanInPlace": "variant",
         "attachments": "string"
       },
       "subsidenceOrStructuralFault": {
@@ -1436,6 +1768,22 @@
         "yesNo": "variant",
         "details": "string",
         "attachments": "string"
+      },
+      "wellsDitchesShaft": {
+        "yesNo": "variant",
+        "details": "string"
+      },
+      "damagedOrExposedElectrics": {
+        "yesNo": "variant",
+        "details": "string"
+      },
+      "damageToFlooringOrStaircases": {
+        "yesNo": "variant",
+        "details": "string"
+      },
+      "knownAreasInPoorCondition": {
+        "yesNo": "variant",
+        "details": "string"
       }
     },
     "fixturesAndFittings": {
@@ -1717,6 +2065,7 @@
           {
             "itemName": "string",
             "isIncludedOrExcluded": "variant",
+            "comments": "string",
             "price": "number"
           }
         ]
@@ -1807,6 +2156,7 @@
             {
               "itemName": "string",
               "isIncludedOrExcluded": "variant",
+              "comments": "string",
               "price": "number"
             }
           ]
@@ -2032,18 +2382,23 @@
         "electricityMeter": {
           "location": "string",
           "attachments": "string",
-          "mpan": "integer"
+          "mpan": "string"
         },
         "dateToBeConnected": "string"
       },
       "solarPanels": {
         "yesNo": "variant",
         "supplier": "string",
+        "hotWaterOnly": "string",
         "yearInstalled": "integer",
         "panelsOwnedOutright": {
           "yesNo": "variant",
           "details": "string",
-          "attachments": "string"
+          "attachments": "string",
+          "associatedCost": {
+            "frequency": "variant",
+            "amount": "number"
+          }
         },
         "panelProviderLease": {
           "yesNo": "variant",
@@ -2055,13 +2410,28 @@
           "yesNo": "variant",
           "details": "string"
         },
-        "isConnectedToNationalGrid": "string",
         "photovoltaicMeterPanelLocation": {
           "attachments": "string"
         },
-        "photovoltaicBatteriesLocation": {
+        "maintenanceAgreement": {
+          "yesNo": "variant",
           "attachments": "string"
         },
+        "photovoltaicBatteries": {
+          "yesNo": "variant",
+          "attachments": "string",
+          "details": "string"
+        },
+        "nationalGrid": {
+          "yesNo": "variant",
+          "fitOrSegInPlace": {
+            "yesNo": "variant",
+            "fitSegAgreementCopy": "string",
+            "attachments": "string",
+            "fitSegAssignmentProcedure": "string"
+          }
+        },
+        "installationCertificates": "string",
         "dateToBeConnected": "string"
       },
       "heatPump": {
@@ -2070,6 +2440,8 @@
         "supplier": "string",
         "dateInstalled": "string",
         "attachments": "string",
+        "makeModel": "string",
+        "serviceProviderName": "string",
         "dateToBeConnected": "string"
       },
       "otherSources": {
@@ -2088,6 +2460,10 @@
         "mainsWater": {
           "yesNo": "variant",
           "details": "string",
+          "associatedCost": {
+            "frequency": "variant",
+            "amount": "number"
+          },
           "supplier": "string",
           "stopcock": {
             "location": "string",
@@ -2142,14 +2518,25 @@
             },
             "plantDrainsIntoWaterway": {
               "yesNo": "variant",
+              "hasInfiltrationSystem": {
+                "yesNo": "string"
+              },
               "dischargeCompliesWithGBR": "string"
             },
+            "dateDischargeCommenced": {},
+            "dateInstalled": "string",
             "dateReplaced": "string",
             "dateLastEmptied": "string",
-            "dateInstalled": "string",
+            "supplier": "string",
+            "makeModel": "string",
+            "serviceProviderName": "string",
             "dateLastServiced": "string",
             "attachments": "string",
             "details": "string"
+          },
+          "associatedCost": {
+            "frequency": "variant",
+            "amount": "number"
           }
         },
         "surfaceDrainageCharge": {
@@ -2210,12 +2597,17 @@
             "gasMeter": {
               "location": "string",
               "attachments": "string",
-              "mprn": "integer"
+              "mprn": "string"
             },
             "otherCentralHeatingFuelType": "string"
           },
           "centralHeatingInstalled": {},
           "boilerInstallationCertificate": {
+            "yesNo": "variant",
+            "boilerInstallationDate": {},
+            "attachments": "string"
+          },
+          "replacementOtherThanBoiler": {
             "yesNo": "variant",
             "attachments": "string"
           },
@@ -2230,7 +2622,8 @@
       },
       "otherHeatingFeatures": [
         "string"
-      ]
+      ],
+      "multipleHeatingSystems": "string"
     },
     "connectivity": {
       "telephone": {
@@ -2244,7 +2637,7 @@
         "dateToBeConnected": "string"
       },
       "broadband": {
-        "typeOfConnection": "string",
+        "typeOfConnection": "variant",
         "predictedSpeed": {
           "maxBbPredictedDown": "number",
           "maxBbPredictedUp": "number",
@@ -2254,7 +2647,8 @@
           "maxUfbbPredictedUp": "number",
           "maxPredictedDown": "number",
           "maxPredictedUp": "number"
-        }
+        },
+        "providerName": "string"
       },
       "mobilePhone": {
         "knownSignalIssues": {
@@ -2295,7 +2689,8 @@
           "voDataIndoor": "integer",
           "voDataIndoorNo4g": "integer"
         }
-      }
+      },
+      "otherServices": "string"
     },
     "insurance": {
       "difficultiesObtainingInsurance": {
@@ -2319,6 +2714,7 @@
       "isInsured": "variant",
       "details": "string",
       "landlordInsuresIfFlat": "string",
+      "whoInsures": "string",
       "insuranceClaims": {
         "yesNo": "variant",
         "details": "string"
@@ -2327,11 +2723,19 @@
     "rightsAndInformalArrangements": {
       "sharedContributions": {
         "yesNo": "variant",
-        "details": "string"
+        "details": "string",
+        "disagreementOrComplaint": {
+          "yesNo": "variant",
+          "details": "string"
+        }
       },
       "neighbouringLandRights": {
         "yesNo": "variant",
         "details": "string",
+        "disagreementOrComplaint": {
+          "yesNo": "variant",
+          "details": "string"
+        },
         "attachments": "string"
       },
       "accessRestrictionAttempts": {
@@ -2343,6 +2747,10 @@
           "yesNo": "variant",
           "details": "string",
           "attachments": "string"
+        },
+        "privateRightOfWay": {
+          "yesNo": "variant",
+          "details": "string"
         },
         "rightsOfLight": {
           "yesNo": "variant",
@@ -2371,11 +2779,27 @@
         "otherRights": {
           "yesNo": "variant",
           "details": "string"
+        },
+        "disagreementOrComplaint": {
+          "yesNo": "variant",
+          "details": "string"
+        }
+      },
+      "askedOthersToContribute": {
+        "yesNo": "variant",
+        "details": "string",
+        "disagreementOrComplaint": {
+          "yesNo": "variant",
+          "details": "string"
         }
       }
     },
     "environmentalIssues": {
       "flooding": {
+        "floodRiskReport": {
+          "hasReportBeenPrepared": "variant",
+          "attachments": "string"
+        },
         "floodRisk": {
           "riskIndicator": "variant",
           "actionAlertRating": "integer",
@@ -2406,6 +2830,10 @@
           "hasFloodDefences": "variant",
           "details": "string"
         }
+      },
+      "stormFireFloodDamage": {
+        "yesNo": "variant",
+        "details": "string"
       },
       "radon": {
         "radonRisk": {
@@ -2668,6 +3096,16 @@
       }
     },
     "additionalInformation": {
+      "consents": {
+        "attachments": {},
+        "consentsAttached": "string",
+        "consentsToFollow": "string",
+        "consentsNotAvailable": "string"
+      },
+      "furtherInformation": {
+        "details": "string",
+        "attachments": {}
+      },
       "restrictionsOnUseNotCompliedWith": {
         "yesNo": "variant",
         "details": "string",
@@ -2816,13 +3254,28 @@
       },
       "doubleGlazing": {
         "yesNo": "variant",
-        "attachments": "string"
+        "attachments": "string",
+        "fensaCertificates": {
+          "certificates": [
+            {
+              "certificateId": "string",
+              "numberOfWindows": "integer",
+              "numberOfDoors": "integer",
+              "certificateIssued": "string",
+              "workCompleted": "string"
+            }
+          ]
+        }
       },
       "electricalRepairOrInstallation": {
         "yesNo": "variant",
         "attachments": "string"
       },
       "subsidenceWork": {
+        "yesNo": "variant",
+        "attachments": "string"
+      },
+      "insulation": {
         "yesNo": "variant",
         "attachments": "string"
       },
@@ -2839,6 +3292,10 @@
         "yesNo": "variant",
         "details": "string",
         "attachments": "string"
+      },
+      "breachOfTermsOrConditions": {
+        "yesNo": "variant",
+        "details": "string"
       },
       "titleDefectInsurance": {
         "yesNo": "variant",
@@ -2913,7 +3370,11 @@
         {
           "name": "string",
           "signedOn": "string",
-          "externalIds": {}
+          "externalIds": {
+            "*": {
+              "*": {}
+            }
+          }
         }
       ]
     },
@@ -4220,7 +4681,812 @@
         "fileName": "string",
         "mimeType": "string",
         "documentType": "string",
-        "externalIds": {}
+        "externalIds": {
+          "*": {
+            "*": {}
+          }
+        },
+        "isDeleted": "boolean",
+        "summary": {}
+      }
+    ],
+    "surveys": [
+      {
+        "outside": {
+          "chimneyStacks": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "visibilityRestriction": "string",
+            "flashings": "string",
+            "defectsFlag": "boolean",
+            "defectsList": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ]
+          },
+          "roofCoverings": {
+            "condition": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restriction": "string",
+            "features": "string",
+            "mainPitchedCovering": "string",
+            "mainPitchedFeatures": "string",
+            "mainFlatCovering": "string",
+            "mainFlatFeatures": "string",
+            "additionalPitchedCovering": "string",
+            "additionalPitchedFeatures": "string",
+            "additionalDetail": "string",
+            "additionalFeatures": "string",
+            "bay": "string",
+            "bayFeatures": "string",
+            "dormer": "string",
+            "dormerFeatures": "string",
+            "defectsGeneral": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "mainPitchedDefects": "boolean",
+            "mainPitchedDefectsDetail": "string",
+            "mainFlatDefects": "string",
+            "mainFlatDefectsDetail": "string",
+            "additionalPitchedDefects": "boolean",
+            "additionalPitchedDefectsDetail": "string",
+            "additionalFlatDefects": "boolean",
+            "additionalFlatDefectsDetail": "string",
+            "bayDefects": "boolean",
+            "bayDefectsDetail": "string",
+            "dormerDefects": "boolean",
+            "dormerDefectsDetail": "string"
+          },
+          "rainwaterPipesGutters": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "features": "string",
+            "gutterDescription": "string",
+            "downpipeDescription": "string",
+            "hopperHeadDescription": "string",
+            "gutterIssues": "boolean",
+            "gutterIssueLocation": "string",
+            "gutterDefect": "string",
+            "downpipeDefect": "string",
+            "hopperHeadDefect": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ]
+          },
+          "mainWalls": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "externalElevation": "string",
+            "construction": "string",
+            "features": "string",
+            "dpc": "string",
+            "structuralMovement": "boolean",
+            "movementType": "string",
+            "movementCause": "string",
+            "movementStatus": "string",
+            "otherDefects": "boolean",
+            "otherDefectsDescription": "string",
+            "cladding": "string",
+            "fireRisk": "boolean",
+            "advice": "string",
+            "extensions": "string",
+            "movementLocation": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "extension1": {
+              "detail": "string",
+              "construction": "string",
+              "dpc": "string",
+              "defects": "boolean",
+              "defectDescription": "string",
+              "movementType": "string",
+              "movementCause": "string",
+              "movementStatus": "string"
+            },
+            "extension2": {
+              "detail": "string",
+              "construction": "string",
+              "dpc": "string",
+              "defects": "boolean",
+              "defectDescription": "string",
+              "movementType": "string",
+              "movementCause": "string",
+              "movementStatus": "string"
+            },
+            "extension3": {
+              "detail": "string",
+              "construction": "string",
+              "dpc": "string",
+              "defects": "boolean",
+              "defectDescription": "string",
+              "movementType": "string",
+              "movementCause": "string",
+              "movementStatus": "string"
+            }
+          },
+          "windows": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "visibilityRestrictions": "string",
+            "glazingType": "string",
+            "glazingDescription": "string",
+            "glazingHeight": "boolean",
+            "glazingSafety": "boolean",
+            "glazingDefects": "boolean",
+            "glazingDefectList": "string",
+            "photos": [
+              {
+                "photoId": "string",
+                "report": "boolean"
+              }
+            ]
+          },
+          "outsideDoors": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "glazingDescription": "string",
+            "glazingType": "string",
+            "glazingHeight": "boolean",
+            "glazingSafety": "boolean",
+            "glazingDefects": "boolean",
+            "glazingDefectDetails": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ]
+          },
+          "conservatoryPorches": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "conservatory": "boolean",
+            "porch": "boolean",
+            "restrictions": "string",
+            "visibility": "string",
+            "conservatoryWall": "string",
+            "conservatoryFrame": "string",
+            "conservatoryGlazing": "string",
+            "conservatoryRoof": "string",
+            "conservatorySeparate": "boolean",
+            "conservatoryHeating": "string",
+            "porchWall": "string",
+            "porchFrame": "string",
+            "porchGlazing": "string",
+            "porchRoof": "string",
+            "porchPitched": "string",
+            "porchFlat": "string",
+            "defectsFlag": "boolean",
+            "defectLocation": "string",
+            "conservatoryEconomic": "boolean",
+            "conservatoryStructural": "boolean",
+            "conservatoryMovement": "string",
+            "conservatoryMovementCause": "string",
+            "conservatoryMovementStatus": "string",
+            "conservatoryDefects": "boolean",
+            "conservatoryDefectDetail": "string",
+            "porchEconomic": "boolean",
+            "porchStructural": "boolean",
+            "porchMovement": "string",
+            "porchMovementCause": "string",
+            "porchMovementStatus": "string",
+            "porchDefects": "boolean",
+            "porchDefectDetail": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ]
+          },
+          "otherJoinery": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "features": "string",
+            "fasciaDescription": "string",
+            "bargeboardsDescription": "string",
+            "soffitsDescription": "string",
+            "claddingDescription": "string",
+            "issues": "boolean",
+            "issueLocation": "string",
+            "issueDetail": "string",
+            "photos": [
+              {
+                "photoId": "string",
+                "report": "boolean"
+              }
+            ]
+          },
+          "other": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "defectsFlag": "boolean",
+            "defectDetail": "string",
+            "fireSafety": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ]
+          }
+        },
+        "inside": {
+          "roofStructure": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "lining": "string",
+            "insulation": "string",
+            "firewall": "string",
+            "features": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            },
+            "additional1Visibility": "string",
+            "additional1Restrictions": "string",
+            "additional1Description": "string",
+            "additional1Lining": "string",
+            "additional1Insulation": "string",
+            "additional1Defects": "boolean",
+            "additional1DefectDetail": "string",
+            "additional2Visibility": "string",
+            "additional2Restrictions": "string",
+            "additional2Description": "string",
+            "additional2Lining": "string",
+            "additional2Insulation": "string",
+            "additional2Defects": "boolean",
+            "additional2DefectDetail": "string",
+            "defectDetail": "string"
+          },
+          "ceilings": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "defectDetail": "string",
+            "integralGarageDefects": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            }
+          },
+          "wallsPartitions": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "construction": "string",
+            "adequateSupport": "boolean",
+            "wallFinish": "string",
+            "defectsMinor": "string",
+            "defectsMajor": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            }
+          },
+          "floors": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "generalDefects": "string",
+            "solidDefects": "string",
+            "timberDefects": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            }
+          },
+          "fireplaces": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "defectDetail": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            }
+          },
+          "builtinFittings": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "defectDetail": "string",
+            "advice": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            }
+          },
+          "woodwork": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "doorDescription": "string",
+            "stairDescription": "string",
+            "joineryDescription": "string",
+            "defectsDetail": "string",
+            "defectsDoorsWindows": "string",
+            "defectsStairs": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            }
+          },
+          "bathroomFittings": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "restrictions": "string",
+            "defectDetail": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            }
+          },
+          "other": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "visibility": "string",
+            "roofConversion": "string",
+            "cellar": "string",
+            "commonAreas": "string",
+            "alarms": "string",
+            "defectsRoof": "string",
+            "defectsBasement": "string",
+            "defectsOther": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            }
+          }
+        },
+        "services": {
+          "electricity": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "meter": "string",
+            "consumerUnit": "string",
+            "cutOffDevices": "string",
+            "wiring": "string",
+            "additionalFeatures": "string",
+            "supplementary": "string",
+            "testCertificate": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "gasOil": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "meter": "string",
+            "privateGas": "string",
+            "tankLocation": "string",
+            "tankInside": "string",
+            "tankOutside": "string",
+            "tankType": "string",
+            "testCertificate": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "water": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "string",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "stopTap": "string",
+            "supply": "string",
+            "distribution": "string",
+            "storageTank": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "heating": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "extent": "string",
+            "source": "string",
+            "emitter": "string",
+            "pipework": "string",
+            "controls": "string",
+            "otherFeatures": "string",
+            "testCertificate": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "waterHeating": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "integer",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "primarySource": "string",
+            "supplementarySource": "string",
+            "storage": "string",
+            "pipework": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "drainage": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "string",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "restrictions": "string",
+            "system": "string",
+            "privateSystem": "string",
+            "location": "string",
+            "runOff": "boolean",
+            "features": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          },
+          "commonServices": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": [
+              {
+                "photoId": "string",
+                "report": "boolean"
+              }
+            ],
+            "visibility": "string",
+            "type": "string",
+            "defectsPresent": "boolean",
+            "defectDetail": "string"
+          }
+        },
+        "grounds": {
+          "garage": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            },
+            "visibility": "string",
+            "restrictions": "string",
+            "wallConstruction": "string",
+            "roofConstruction": "string",
+            "location": "string",
+            "structuralMovement": "boolean",
+            "movementType": "string",
+            "movementStatus": "string",
+            "hasDefects": "boolean",
+            "defectDetail": "string"
+          },
+          "permanentOutbuildings": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": {
+              "photoId": "string",
+              "report": "boolean"
+            },
+            "visibility": "string",
+            "restrictions": "string",
+            "type": "string",
+            "wallConstruction": "string",
+            "roofConstruction": "string",
+            "location": "string",
+            "hasDefects": "boolean",
+            "defectDetail": "string"
+          },
+          "other": {
+            "condition": "string",
+            "inspectionLimitations": "string",
+            "defects": "string",
+            "advisories": "string",
+            "notes": "string",
+            "photos": {
+              "photoId": "integer",
+              "report": "boolean"
+            },
+            "visibility": "string",
+            "restrictions": "string",
+            "gardens": "string",
+            "exceed1Acre": "boolean",
+            "boundaries": {
+              "fenceDescription": "string",
+              "fenceIssues": "string",
+              "fenceDefects": "string",
+              "wallDescription": "string",
+              "wallIssues": "string",
+              "wallDefects": "string",
+              "hedgeDescription": "string",
+              "hedgeIssues": "string",
+              "hedgeDefects": "string",
+              "otherBoundaryDescription": "string"
+            },
+            "hardscaping": {
+              "drivewayLandscaping": "string",
+              "driveMaterial": "string",
+              "driveDefects": "boolean",
+              "driveDefectDetail": "string",
+              "patioMaterial": "string",
+              "patioDefects": "boolean",
+              "patioDefectDetail": "string",
+              "pathMaterial": "string",
+              "pathDefects": "boolean",
+              "pathDefectDetail": "string",
+              "deckingMaterial": "string",
+              "deckingDefects": "boolean",
+              "deckingDefectDetail": "string"
+            },
+            "buildingRegs": "boolean",
+            "otherFeatures": "string",
+            "japaneseKnotweed": "string",
+            "otherDefects": "boolean",
+            "otherDefectDetail": "string"
+          }
+        },
+        "legalIssues": {
+          "notes": "string",
+          "regulation": "string",
+          "guarantees": "string",
+          "otherMatters": "string",
+          "rightsOfWay": "string"
+        },
+        "risks": {
+          "buildingRisks": "string",
+          "groundsRisks": "string",
+          "peopleRisks": "string",
+          "otherRisks": "string"
+        },
+        "propertyValuation": {
+          "valuation": {
+            "valuationDiscriminator": "boolean",
+            "value": "integer",
+            "valueWords": "string",
+            "reinstatement": "integer",
+            "reinstatementWords": "string",
+            "tenure": "string",
+            "lease": "integer",
+            "areaOfProperty": "integer"
+          },
+          "valuationInformation": {
+            "additionalAssumptions": "string",
+            "considerations": "string"
+          }
+        },
+        "declaration": {
+          "surveyorQuals": "string",
+          "companyAddress": "string",
+          "phoneNumber": "string",
+          "faxNumber": "string",
+          "email": "string",
+          "website": "string",
+          "clientName": "string"
+        },
+        "misc": {
+          "photoFront": {
+            "value": "string",
+            "photoId": "integer",
+            "report": "boolean"
+          },
+          "areaOfProperty": {
+            "value": "string",
+            "photoId": "integer",
+            "report": "boolean"
+          },
+          "reportDate": "string",
+          "epc": "string",
+          "agentName": "string",
+          "access": "string",
+          "propertyQuestions": "boolean",
+          "propertyChanges": "string",
+          "alterations": "string",
+          "furnishings": "string",
+          "floorCoverings": "string",
+          "propertyType": "string",
+          "accommodationLocation": "string",
+          "propertyStyle": "string",
+          "topography": "string",
+          "floodingRisk": "string",
+          "coastalLocation": "boolean",
+          "siteRisk": "string",
+          "highVoltage": "string",
+          "buildFormat": "string",
+          "areaDetails": "string",
+          "groundRentType": "string",
+          "conservationArea": "boolean",
+          "valuationFactor": "string",
+          "conflict": "boolean",
+          "conflictType": "string",
+          "suspiciousActivity": "boolean",
+          "btl": "boolean",
+          "photoConsent": "boolean",
+          "adjacentCommercial": "boolean",
+          "commercialLocation": "string",
+          "commercialTypeAbove": "string",
+          "commercialTypeAdjacent": "string",
+          "separateAccess": "boolean",
+          "communal": "boolean",
+          "communalFacilities": "string",
+          "listedBuilding": "boolean",
+          "listedClassification": "string",
+          "exla": "boolean",
+          "exNature": "string",
+          "tenureSource": "string",
+          "roadType": "string",
+          "roadMadeUp": "boolean",
+          "pedestrian": "boolean",
+          "constructionType": "string",
+          "nonTradType": "string",
+          "nonTradSystem": "string",
+          "designatedDefective": "boolean",
+          "epcAvailable": "boolean",
+          "epcReason": "string",
+          "epcDiscrepancies": "boolean",
+          "epcDiscrepancyDetail": "string"
+        }
+      }
+    ],
+    "valuations": [
+      {
+        "valuationId": "integer",
+        "valuationTimestamp": "string",
+        "capitalValue": "integer",
+        "confidenceLevel": "number",
+        "confidenceBand": "string",
+        "rentalValue": "integer",
+        "rentalConfidenceLevel": "number",
+        "reinstatementCost": "integer",
+        "checkValuationResult": "string",
+        "instructionType": "string",
+        "valuationContext": "string",
+        "valuationType": "string"
       }
     ]
   },
@@ -4279,7 +5545,11 @@
         "template": {
           "name": "string",
           "url": "string",
-          "externalIds": {},
+          "externalIds": {
+            "*": {
+              "*": {}
+            }
+          },
           "requiredSignatories": [
             {
               "role": "string",
@@ -4293,7 +5563,11 @@
         {
           "name": "string",
           "signedOn": "string",
-          "externalIds": {}
+          "externalIds": {
+            "*": {
+              "*": {}
+            }
+          }
         }
       ]
     }
@@ -4302,7 +5576,11 @@
     "onwardPurchase": [
       {
         "transactionId": "string",
-        "externalIds": {},
+        "externalIds": {
+          "*": {
+            "*": {}
+          }
+        },
         "address": {
           "buildingNumber": "string",
           "buildingName": "string",
@@ -4319,5 +5597,107 @@
         "sellingAgent": "string"
       }
     ]
+  },
+  "milestones": {
+    "listed": {
+      "expected": "string",
+      "completed": "string"
+    },
+    "legalForms": {
+      "started": "string",
+      "completed": "string"
+    },
+    "soldSubjectToContract": {
+      "completed": "string"
+    },
+    "searches": {
+      "started": "string",
+      "expected": "string",
+      "completed": "string"
+    },
+    "enquiries": {
+      "started": "string",
+      "completed": "string"
+    },
+    "exchangeOfContracts": {
+      "expected": "string",
+      "completed": "string"
+    },
+    "completion": {
+      "started": "string",
+      "expected": "string",
+      "completed": "string"
+    }
+  },
+  "offers": {
+    "*": {
+      "amount": "number",
+      "currency": "string",
+      "status": "string",
+      "inclusions": [
+        "string"
+      ],
+      "exclusions": [
+        "string"
+      ],
+      "conditions": [
+        "string"
+      ],
+      "externalIds": {
+        "*": {
+          "*": {}
+        }
+      },
+      "buyerCircumstances": {
+        "intendedUse": "string",
+        "firstTimeBuyer": "boolean",
+        "rightToBuy": "boolean",
+        "ltdCompanyPurchase": "boolean",
+        "numberOfOwners": "integer",
+        "numberOfExpats": "integer",
+        "giftedEquity": "boolean",
+        "numberOfGiftedDeposits": "integer",
+        "requiresMortgage": "variant",
+        "helpToBuyEquityLoan": "boolean",
+        "armedForcesHelpToBuy": "boolean",
+        "numberOfHelpToBuyIsas": "integer",
+        "bridgingFinanceRepresentation": "string",
+        "depositAmount": "number",
+        "loanToValue": "number",
+        "numberOfBorrowers": "integer",
+        "jointProprietorSoleMortgagor": "boolean",
+        "soleProprietorJointMortgagor": "boolean",
+        "deedOfPostponement": "boolean",
+        "separateRepresentation": "boolean",
+        "oldestBorrowerAge": "integer",
+        "mortgageTerm": "integer",
+        "adverseCredit": "string",
+        "employmentType": "string",
+        "existingMortgagedProperties": "integer",
+        "annualIncome": "number",
+        "residencyStatus": "string",
+        "nominatedLender": "string"
+      }
+    }
+  },
+  "enquiries": {
+    "*": {
+      "subject": "string",
+      "status": "variant",
+      "messages": {
+        "*": {
+          "datetime": "string",
+          "originatorRole": "string",
+          "destinationRole": "string",
+          "messageText": "string"
+        }
+      },
+      "externalIds": {
+        "*": {
+          "*": {}
+        }
+      },
+      "resolutionCondition": "string"
+    }
   }
 }

--- a/src/schemas/verifiedClaims/README.md
+++ b/src/schemas/verifiedClaims/README.md
@@ -1,12 +1,21 @@
 ## README
 
 ### About verified claims
-`pdtf-verified-claims.json` describes the schema container in which we store property `claims` and their corresponding `verification`.  
+`pdtf-verified-claims.json` describes the schema container in which we store property `claims` and their corresponding `verification`.
 
-This schema structure is strongly influenced by OpenID Connect for Identity Assurance 1.0's way of storing "verified claims". 
+This schema structure is strongly influenced by OpenID Connect for Identity Assurance 1.0's way of storing "verified claims".
 
 More Details from the OIDC page which describes the details the nature of `verification` and `claims` objects: https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-representing-verified-claim
 
-Notes: 
+### Terms of Use
+The schema supports an optional `terms_of_use` object to control access to verified claims based on confidentiality levels:
+
+* **Public**: No access restrictions (`allowed_roles: []`)
+* **Restricted**: Requires some participant role but not specifically defined (`allowed_roles: []`)
+* **Confidential**: Specific roles defined for access control (e.g., `allowed_roles: ["Seller's Conveyancer", "Buyer's Conveyancer"]`)
+
+The `allowed_roles` array accepts any of the participant roles defined in [pdtf-transaction.json](../v3/pdtf-transaction.json).
+
+Notes:
 * For PDTF Schema, all data included in the `claims` object must adhere to [pdtf-transaction.json (v3)](../v3/pdtf-transaction.json)
 * For verification, there is more freedom in terms of the type of data that can currently be provided, see the documentation in the OIDC link above for details and examples.

--- a/src/schemas/verifiedClaims/pdtf-verified-claims.json
+++ b/src/schemas/verifiedClaims/pdtf-verified-claims.json
@@ -411,6 +411,22 @@
           },
           "minProperties": 1,
           "additionalProperties": false
+        },
+        "terms_of_use": {
+          "type": "object",
+          "properties": {
+            "confidentiality_level": {
+              "type": "string",
+              "enum": ["public", "restricted", "confidential"]
+            },
+            "allowed_roles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["verification", "claims"],

--- a/src/tests/v3/buyerCircumstances.test.js
+++ b/src/tests/v3/buyerCircumstances.test.js
@@ -1,0 +1,543 @@
+const { isPathValid, getSubschema, getValidator } = require("../../../index.js");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+describe("buyerCircumstances path validation", () => {
+  describe("isPathValid for buyerCircumstances fields", () => {
+    test("validates path /offers/*/buyerCircumstances", () => {
+      const path = "/offers/offer-123/buyerCircumstances";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/intendedUse", () => {
+      const path = "/offers/offer-123/buyerCircumstances/intendedUse";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/firstTimeBuyer", () => {
+      const path = "/offers/offer-123/buyerCircumstances/firstTimeBuyer";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/rightToBuy", () => {
+      const path = "/offers/offer-123/buyerCircumstances/rightToBuy";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/ltdCompanyPurchase", () => {
+      const path = "/offers/offer-123/buyerCircumstances/ltdCompanyPurchase";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/numberOfOwners", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfOwners";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/numberOfExpats", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfExpats";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/giftedEquity", () => {
+      const path = "/offers/offer-123/buyerCircumstances/giftedEquity";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/numberOfGiftedDeposits", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfGiftedDeposits";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/requiresMortgage", () => {
+      const path = "/offers/offer-123/buyerCircumstances/requiresMortgage";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/helpToBuyEquityLoan", () => {
+      const path = "/offers/offer-123/buyerCircumstances/helpToBuyEquityLoan";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/armedForcesHelpToBuy", () => {
+      const path = "/offers/offer-123/buyerCircumstances/armedForcesHelpToBuy";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/numberOfHelpToBuyIsas", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfHelpToBuyIsas";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/bridgingFinanceRepresentation", () => {
+      const path = "/offers/offer-123/buyerCircumstances/bridgingFinanceRepresentation";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/depositAmount", () => {
+      const path = "/offers/offer-123/buyerCircumstances/depositAmount";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/loanToValue", () => {
+      const path = "/offers/offer-123/buyerCircumstances/loanToValue";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/numberOfBorrowers", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfBorrowers";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/jointProprietorSoleMortgagor", () => {
+      const path = "/offers/offer-123/buyerCircumstances/jointProprietorSoleMortgagor";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/soleProprietorJointMortgagor", () => {
+      const path = "/offers/offer-123/buyerCircumstances/soleProprietorJointMortgagor";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/deedOfPostponement", () => {
+      const path = "/offers/offer-123/buyerCircumstances/deedOfPostponement";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/separateRepresentation", () => {
+      const path = "/offers/offer-123/buyerCircumstances/separateRepresentation";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/oldestBorrowerAge", () => {
+      const path = "/offers/offer-123/buyerCircumstances/oldestBorrowerAge";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/mortgageTerm", () => {
+      const path = "/offers/offer-123/buyerCircumstances/mortgageTerm";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/adverseCredit", () => {
+      const path = "/offers/offer-123/buyerCircumstances/adverseCredit";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/employmentType", () => {
+      const path = "/offers/offer-123/buyerCircumstances/employmentType";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/existingMortgagedProperties", () => {
+      const path = "/offers/offer-123/buyerCircumstances/existingMortgagedProperties";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/annualIncome", () => {
+      const path = "/offers/offer-123/buyerCircumstances/annualIncome";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/residencyStatus", () => {
+      const path = "/offers/offer-123/buyerCircumstances/residencyStatus";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /offers/*/buyerCircumstances/nominatedLender", () => {
+      const path = "/offers/offer-123/buyerCircumstances/nominatedLender";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("rejects invalid path /offers/*/buyerCircumstances/nonExistentField", () => {
+      const path = "/offers/offer-123/buyerCircumstances/nonExistentField";
+      expect(isPathValid(path, schemaId)).toBe(false);
+    });
+  });
+
+  describe("getSubschema for buyerCircumstances", () => {
+    test("returns correct subschema for buyerCircumstances", () => {
+      const path = "/offers/offer-123/buyerCircumstances";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("object");
+      expect(subschema.properties).toBeDefined();
+      expect(subschema.properties.intendedUse).toBeDefined();
+      expect(subschema.properties.firstTimeBuyer).toBeDefined();
+      expect(subschema.properties.requiresMortgage).toBeDefined();
+    });
+
+    test("returns correct subschema for intendedUse", () => {
+      const path = "/offers/offer-123/buyerCircumstances/intendedUse";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("string");
+    });
+
+    test("returns correct subschema for firstTimeBuyer (boolean)", () => {
+      const path = "/offers/offer-123/buyerCircumstances/firstTimeBuyer";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("boolean");
+    });
+
+    test("returns correct subschema for numberOfOwners (integer)", () => {
+      const path = "/offers/offer-123/buyerCircumstances/numberOfOwners";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("integer");
+    });
+
+    test("returns correct subschema for depositAmount (number)", () => {
+      const path = "/offers/offer-123/buyerCircumstances/depositAmount";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("number");
+    });
+  });
+
+  describe("validation of buyerCircumstances data", () => {
+    test("accepts valid offer with buyerCircumstances (requiresMortgage: Yes)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              intendedUse: "Owner occupied",
+              firstTimeBuyer: true,
+              rightToBuy: false,
+              ltdCompanyPurchase: false,
+              numberOfOwners: 2,
+              numberOfExpats: 0,
+              giftedEquity: false,
+              numberOfGiftedDeposits: 1,
+              requiresMortgage: "Yes",
+              helpToBuyEquityLoan: false,
+              armedForcesHelpToBuy: false,
+              numberOfHelpToBuyIsas: 2,
+              depositAmount: 50000,
+              loanToValue: 80,
+              numberOfBorrowers: 2,
+              jointProprietorSoleMortgagor: false,
+              soleProprietorJointMortgagor: false,
+              deedOfPostponement: false,
+              separateRepresentation: false,
+              oldestBorrowerAge: 35,
+              mortgageTerm: 25,
+              existingMortgagedProperties: 0,
+              annualIncome: 75000,
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts valid offer with buyerCircumstances (requiresMortgage: No)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              intendedUse: "Buy-to-let",
+              firstTimeBuyer: false,
+              requiresMortgage: "No",
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts offer with partial buyerCircumstances (requiresMortgage required)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              firstTimeBuyer: true,
+              requiresMortgage: "Yes",
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("rejects buyerCircumstances without required requiresMortgage field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              firstTimeBuyer: true,
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects buyerCircumstances with wrong type for firstTimeBuyer", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              firstTimeBuyer: "yes", // should be boolean
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects buyerCircumstances with wrong type for numberOfOwners", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              numberOfOwners: "two", // should be integer
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects buyerCircumstances with wrong type for depositAmount", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            buyerCircumstances: {
+              depositAmount: "50000", // should be number
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+});
+
+describe("ownership new fields path validation", () => {
+  describe("isPathValid for outstandingMortgage and existingLender", () => {
+    test("validates path /propertyPack/ownership/outstandingMortgage", () => {
+      const path = "/propertyPack/ownership/outstandingMortgage";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+
+    test("validates path /propertyPack/ownership/existingLender", () => {
+      const path = "/propertyPack/ownership/existingLender";
+      expect(isPathValid(path, schemaId)).toBe(true);
+    });
+  });
+
+  describe("getSubschema for ownership new fields", () => {
+    test("returns correct subschema for outstandingMortgage", () => {
+      const path = "/propertyPack/ownership/outstandingMortgage";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("string");
+    });
+
+    test("returns correct subschema for existingLender", () => {
+      const path = "/propertyPack/ownership/existingLender";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("string");
+    });
+  });
+
+  describe("validation of ownership new fields", () => {
+    test("accepts valid ownership with outstandingMortgage and existingLender", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Seller",
+            participantStatus: "Active",
+          },
+        ],
+        propertyPack: {
+          ownership: {
+            outstandingMortgage: "Yes",
+            existingLender: "Nationwide Building Society",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts ownership without outstandingMortgage and existingLender", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Seller",
+            participantStatus: "Active",
+          },
+        ],
+        propertyPack: {
+          ownership: {
+            numberOfSellers: 2,
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("rejects ownership with wrong type for outstandingMortgage", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Seller",
+            participantStatus: "Active",
+          },
+        ],
+        propertyPack: {
+          ownership: {
+            outstandingMortgage: true, // should be string
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects ownership with wrong type for existingLender", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Seller",
+            participantStatus: "Active",
+          },
+        ],
+        propertyPack: {
+          ownership: {
+            existingLender: 12345, // should be string
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+});

--- a/src/tests/v3/enquiries.test.js
+++ b/src/tests/v3/enquiries.test.js
@@ -1,0 +1,1096 @@
+const { getValidator } = require("../../../index.js");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+describe("Enquiries object validation", () => {
+  describe("Valid enquiry keys", () => {
+    test("accepts valid UUID as enquiry key", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "550e8400-e29b-41d4-a716-446655440000": {
+            subject: "Boundary wall responsibility",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts valid DID as enquiry key", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "did:example:enquiry123": {
+            subject: "Japanese knotweed treatment",
+            status: "open",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts multiple enquiries with different key types", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "550e8400-e29b-41d4-a716-446655440000": {
+            subject: "Drainage issues",
+            status: "pending",
+            messages: {},
+          },
+          "did:example:enquiry456": {
+            subject: "Electrical certificates",
+            status: "resolved",
+            messages: {},
+          },
+          "enq-abc123": {
+            subject: "Planning permissions",
+            status: "withdrawn",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Invalid enquiry keys", () => {
+    test("rejects enquiry key starting with invalid character", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "-invalid-key": {
+            subject: "Test enquiry",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects enquiry key with spaces", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "invalid key with spaces": {
+            subject: "Test enquiry",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects enquiry key with special characters", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "invalid@key#here": {
+            subject: "Test enquiry",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("Valid enquiry contents", () => {
+    test("accepts enquiry with all required fields", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Roof condition",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts all valid status values", () => {
+      const validator = getValidator(schemaId);
+      const validStatuses = [
+        "pending",
+        "open",
+        "resolved",
+        "resolvedWithCondition",
+        "withdrawn",
+      ];
+
+      validStatuses.forEach((status) => {
+        const transaction = {
+          transactionId: "123e4567-e89b-12d3-a456-426614174000",
+          status: "active",
+          participants: [
+            {
+              role: "Buyer",
+              participantStatus: "Active",
+            },
+          ],
+          enquiries: {
+            "enq-1": {
+              subject: "Test enquiry",
+              status: status,
+              messages: {},
+              ...(status === "resolvedWithCondition" && {
+                resolutionCondition: "Subject to completion of remedial works",
+              }),
+            },
+          },
+        };
+
+        const isValid = validator(transaction);
+        expect(isValid).toBe(true);
+      });
+    });
+
+    test("accepts enquiry with resolutionCondition when status is resolvedWithCondition", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Damp in basement",
+            status: "resolvedWithCondition",
+            resolutionCondition:
+              "Seller to provide evidence of damp-proofing works within 30 days",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts enquiry with optional resolutionCondition when status is not resolvedWithCondition", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Roof condition",
+            status: "resolved",
+            resolutionCondition: "No action required",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts enquiry with messages containing all required fields", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Boundary dispute",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Can you provide details of the boundary agreement with the neighboring property?",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts enquiry with multiple messages", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Tree preservation order",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Is there a tree preservation order on the oak tree in the garden?",
+              },
+              "msg-2": {
+                datetime: "2025-01-16T14:20:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText: "Yes, we will provide documentation from the council.",
+              },
+              "msg-3": {
+                datetime: "2025-01-17T09:15:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText: "Please find attached the TPO certificate from the local authority.",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts all valid participant roles for originatorRole and destinationRole", () => {
+      const validator = getValidator(schemaId);
+      const validRoles = [
+        "Seller",
+        "Seller's Conveyancer",
+        "Buyer",
+        "Buyer's Conveyancer",
+        "Estate Agent",
+        "Buyer's Agent",
+        "Surveyor",
+        "Mortgage Broker",
+        "Lender",
+      ];
+
+      validRoles.forEach((role) => {
+        const transaction = {
+          transactionId: "123e4567-e89b-12d3-a456-426614174000",
+          status: "active",
+          participants: [
+            {
+              role: "Buyer",
+              participantStatus: "Active",
+            },
+          ],
+          enquiries: {
+            "enq-1": {
+              subject: "Test enquiry",
+              status: "open",
+              messages: {
+                "msg-1": {
+                  datetime: "2025-01-15T10:30:00Z",
+                  originatorRole: role,
+                  destinationRole: "Buyer's Conveyancer",
+                  messageText: "Test message",
+                },
+              },
+            },
+          },
+        };
+
+        const isValid = validator(transaction);
+        expect(isValid).toBe(true);
+      });
+    });
+
+    test("accepts message key as UUID", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "550e8400-e29b-41d4-a716-446655440000": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts message key as DID", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "did:example:message123": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Invalid enquiry contents", () => {
+    test("rejects enquiry missing required subject field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("required property"))
+      ).toBe(true);
+    });
+
+    test("rejects enquiry missing required status field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects enquiry missing required messages field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects enquiry with invalid status value", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "invalid-status",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects enquiry with status resolvedWithCondition but missing resolutionCondition", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Damp issue",
+            status: "resolvedWithCondition",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("required property"))
+      ).toBe(true);
+    });
+
+    test("rejects message missing required datetime field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message missing required originatorRole field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message missing required destinationRole field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message missing required messageText field", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message with invalid datetime format", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "15/01/2025 10:30",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message with invalid originatorRole", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Invalid Role",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message with invalid destinationRole", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Invalid Role",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message key starting with invalid character", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "-invalid-message-key": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects message key with spaces", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: {
+              "invalid message key": {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects messages as array instead of object", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Test enquiry",
+            status: "open",
+            messages: [
+              {
+                datetime: "2025-01-15T10:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Test message",
+              },
+            ],
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("Empty enquiries object", () => {
+    test("accepts empty enquiries object", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {},
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts transaction without enquiries property", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts enquiry with empty messages object", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Newly created enquiry",
+            status: "pending",
+            messages: {},
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Complex enquiry scenarios", () => {
+    test("accepts complete enquiry lifecycle with multiple messages", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+          {
+            role: "Seller",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-drainage": {
+            subject: "Drainage and water runoff concerns",
+            status: "resolvedWithCondition",
+            resolutionCondition:
+              "Seller to provide drainage survey report before exchange of contracts",
+            messages: {
+              "msg-001": {
+                datetime: "2025-01-10T09:00:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Our client has raised concerns about drainage in the rear garden. Can you provide details of any drainage works carried out?",
+              },
+              "msg-002": {
+                datetime: "2025-01-12T14:30:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText:
+                  "The seller confirms drainage works were carried out in 2020. We will obtain the relevant documentation.",
+              },
+              "msg-003": {
+                datetime: "2025-01-15T11:00:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText:
+                  "Please find attached the drainage survey report from 2020 and building control certificates.",
+              },
+              "msg-004": {
+                datetime: "2025-01-17T10:00:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Thank you. Our client's surveyor has reviewed the documentation and is satisfied, subject to a final drainage inspection before exchange.",
+              },
+            },
+          },
+          "enq-boundaries": {
+            subject: "Boundary responsibilities",
+            status: "resolved",
+            messages: {
+              "msg-101": {
+                datetime: "2025-01-08T10:00:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Please confirm which boundaries the seller is responsible for maintaining.",
+              },
+              "msg-102": {
+                datetime: "2025-01-09T15:00:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText:
+                  "The seller is responsible for the left-hand boundary fence and the rear hedge, as shown on the title plan. The right-hand fence is the neighbor's responsibility.",
+              },
+            },
+          },
+          "enq-planning": {
+            subject: "Planning permission for extension",
+            status: "withdrawn",
+            messages: {
+              "msg-201": {
+                datetime: "2025-01-11T09:30:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Can you confirm whether planning permission was obtained for the rear extension?",
+              },
+              "msg-202": {
+                datetime: "2025-01-12T16:00:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText:
+                  "Please disregard previous enquiry. Our client has confirmed they have obtained the planning documentation from the council search.",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts enquiry with mixed participant roles in messages", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        enquiries: {
+          "enq-1": {
+            subject: "Survey findings requiring seller input",
+            status: "open",
+            messages: {
+              "msg-1": {
+                datetime: "2025-01-15T09:00:00Z",
+                originatorRole: "Surveyor",
+                destinationRole: "Buyer's Conveyancer",
+                messageText: "Survey has identified potential subsidence. Recommend further investigation.",
+              },
+              "msg-2": {
+                datetime: "2025-01-15T11:00:00Z",
+                originatorRole: "Buyer's Conveyancer",
+                destinationRole: "Seller's Conveyancer",
+                messageText: "Please see surveyor's comments regarding subsidence. Can the seller provide any relevant information?",
+              },
+              "msg-3": {
+                datetime: "2025-01-16T14:00:00Z",
+                originatorRole: "Seller's Conveyancer",
+                destinationRole: "Buyer's Conveyancer",
+                messageText: "The seller has confirmed no subsidence issues known. Will investigate further with structural engineer.",
+              },
+            },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/src/tests/v3/extensionOverlays.test.js
+++ b/src/tests/v3/extensionOverlays.test.js
@@ -2,6 +2,7 @@ const {
   getTransactionSchema,
   extensionOverlays,
   getValidator,
+  getSubschemaValidator,
 } = require("../../../index.js");
 
 const schemaId =
@@ -142,6 +143,73 @@ describe("Extension Overlays", () => {
     });
   });
 
+  describe("SEF25 extension leaf annotations", () => {
+    test("wg: every W1.x subsection exposes a yesNo ntsRef", () => {
+      const schema = getTransactionSchema(schemaId, ["nts2023", "wg"]);
+      const subsections =
+        schema.properties?.propertyPack?.properties
+          ?.guaranteesWarrantiesAndIndemnityInsurances?.oneOf?.[1]?.properties;
+
+      expect(subsections).toBeDefined();
+
+      const discriminated = Object.entries(subsections).filter(
+        ([, sub]) => sub?.discriminator?.propertyName === "yesNo"
+      );
+      expect(discriminated.length).toBeGreaterThan(0);
+
+      for (const [key, sub] of discriminated) {
+        expect(sub.ntsRef).toMatch(/^W1\.\d+$/);
+        expect(sub.properties?.yesNo?.ntsRef).toMatch(/^W1\.\d+\.1$/);
+        expect(sub.required).toContain("yesNo");
+      }
+    });
+
+    test("ic: insuranceClaims exposes a yesNo ntsRef", () => {
+      const schema = getTransactionSchema(schemaId, ["nts2023", "ic"]);
+      const icProp =
+        schema.properties?.propertyPack?.properties?.insurance?.oneOf?.[1]
+          ?.properties?.insuranceClaims;
+
+      expect(icProp).toBeDefined();
+      expect(icProp.ntsRef).toBe("I1.1");
+      expect(icProp.properties?.yesNo?.ntsRef).toBe("I1.1.1");
+      expect(icProp.required).toContain("yesNo");
+    });
+
+    test("nd: neighbourDevelopment N1.1 marker merges with nts yesNo ref", () => {
+      // nd extension only carries the parent N1.1 marker; the yesNo leaf
+      // annotation comes from the nts overlay (C4.1.1), which is required
+      // alongside nd for the field to render.
+      const schema = getTransactionSchema(schemaId, ["nts2023", "nd"]);
+      const ndProp =
+        schema.properties?.propertyPack?.properties?.notices?.properties
+          ?.neighbourDevelopment;
+
+      expect(ndProp).toBeDefined();
+      expect(ndProp.ntsRef).toBe("N1.1");
+      expect(ndProp.properties?.yesNo?.ntsRef).toBe("C4.1.1");
+      expect(ndProp.required).toContain("yesNo");
+    });
+
+    test("mi: otherMaterialIssue exposes yesNo and details ntsRef", () => {
+      const schema = getTransactionSchema(schemaId, ["nts2023", "mi"]);
+      const miProp =
+        schema.properties?.propertyPack?.properties?.additionalInformation
+          ?.properties?.otherMaterialIssue;
+
+      expect(miProp).toBeDefined();
+      expect(miProp.ntsRef).toBe("M1.1");
+      expect(miProp.properties?.yesNo?.ntsRef).toBe("M1.1.1");
+      expect(miProp.required).toContain("yesNo");
+
+      const yesBranch = miProp.oneOf?.find((branch) =>
+        branch.required?.includes("details")
+      );
+      expect(yesBranch).toBeDefined();
+      expect(yesBranch.properties?.details?.ntsRef).toBe("M1.1.2");
+    });
+  });
+
   describe("Extension overlay availability", () => {
     test("should export all extension overlays", () => {
       const expectedKeys = [
@@ -161,6 +229,20 @@ describe("Extension Overlays", () => {
         "hi",
         "fd", // Utilities & Services
         "oc", // Transaction
+        "sc",
+        "pc",
+        "ph", // SEF25
+        "dk",
+        "rw",
+        "sd",
+        "lc",
+        "wg",
+        "ic",
+        "nd",
+        "mi",
+        "tr", // SEF25 (new)
+        "ac", // SEF25 (new)
+        "ta", // Compatibility
       ];
 
       expect(Object.keys(extensionOverlays).sort()).toEqual(
@@ -175,6 +257,127 @@ describe("Extension Overlays", () => {
         expect(overlay.$id).toContain(`extensions/${key}.json`);
         expect(overlay.properties).toBeDefined();
       });
+    });
+  });
+
+  describe("TA6 edition 6 compatibility extension", () => {
+    test("keeps parking enum strict to TA6 edition 6 when compatibility is applied", () => {
+      const ta6Validator = getSubschemaValidator(
+        "/propertyPack/parking/controlledParking",
+        schemaId,
+        ["ta6ed6"]
+      );
+      expect(ta6Validator({ yesNo: "Not known" })).toBe(false);
+
+      const compatValidator = getSubschemaValidator(
+        "/propertyPack/parking/controlledParking",
+        schemaId,
+        ["nts2025", "ta"]
+      );
+      expect(compatValidator({ yesNo: "Not known" })).toBe(false);
+      expect(compatValidator({ yesNo: "No" })).toBe(true);
+    });
+
+    test("applies TA6 edition 6 selector values on shared rights and boundaries paths", () => {
+      const schema = getTransactionSchema(schemaId, [
+        "nts2025",
+        "ta",
+      ]);
+      const propertyPack = schema.properties.propertyPack.properties;
+
+      expect(
+        propertyPack.rightsAndInformalArrangements.properties
+          .sharedContributions.oneOf[0].properties.yesNo.enum
+      ).toEqual(["No", "Not applicable"]);
+
+      expect(
+        propertyPack.rightsAndInformalArrangements.properties
+          .accessRestrictionAttempts.oneOf[0].properties.yesNo.enum
+      ).toEqual(["No", "Not known"]);
+
+      expect(
+        propertyPack.legalBoundaries.properties.flyingFreehold.oneOf[0]
+          .properties.yesNo.enum
+      ).toEqual(["No", "Not known"]);
+    });
+
+    test("applies TA6 edition 6 heating values when compatibility is applied", () => {
+      const heatingFeatures = getSubschemaValidator(
+        "/propertyPack/heating/otherHeatingFeatures",
+        schemaId,
+        ["nts2025", "ta"]
+      );
+      expect(heatingFeatures(["Mains gas", "LPG", "Biomass"])).toBe(true);
+    });
+
+    // The TA6 edition 6 compatibility overlay narrows discriminator branches
+    // at these paths. Ajv 8 requires each discriminator property to also
+    // appear in `required`; otherwise validators for those branches fail at
+    // compile time rather than rejecting invalid data at validation time.
+    describe.each([
+      "/propertyPack/parking/controlledParking",
+      "/propertyPack/rightsAndInformalArrangements/sharedContributions",
+      "/propertyPack/rightsAndInformalArrangements/accessRestrictionAttempts",
+      "/propertyPack/legalBoundaries/flyingFreehold",
+    ])(
+      "discriminator-required contract at %s",
+      (path) => {
+        test("compiles cleanly under [nts2023, ta]", () => {
+          expect(() =>
+            getSubschemaValidator(path, schemaId, ["nts2023", "ta"])
+          ).not.toThrow();
+        });
+
+        test("validator rejects payloads missing the yesNo discriminator", () => {
+          const validator = getSubschemaValidator(path, schemaId, [
+            "nts2023",
+            "ta",
+          ]);
+          // Empty object should fail because yesNo is required.
+          expect(validator({})).toBe(false);
+          // Valid payloads with yesNo set should pass.
+          expect(validator({ yesNo: "No" })).toBe(true);
+        });
+      }
+    );
+
+    test("compiles cleanly with the full SEF25 compatibility overlay set", () => {
+      const compatibilityOverlays = [
+        "nts2023",
+        "as",
+        "dr",
+        "jk",
+        "sb",
+        "hs",
+        "oa",
+        "mc",
+        "er",
+        "ma",
+        "tf",
+        "sl",
+        "fd",
+        "sc",
+        "lc",
+        "wg",
+        "ic",
+        "mi",
+        "tr",
+        "sd",
+        "dk",
+        "pc",
+        "rw",
+        "ph",
+        "ac",
+        "ta",
+      ];
+
+      expect(() =>
+        getSubschemaValidator(
+          "/propertyPack/rightsAndInformalArrangements",
+          schemaId,
+          compatibilityOverlays
+        )
+      ).not.toThrow();
     });
   });
 
@@ -469,6 +672,109 @@ describe("Extension Overlays", () => {
       ).toBeTruthy();
     });
 
+    test("should merge supply costs extension into mainsWater No branch", () => {
+      const schema = getTransactionSchema(schemaId, ["sc"]);
+      const mainsWater =
+        schema.properties?.propertyPack?.properties?.waterAndDrainage
+          ?.properties?.water?.properties?.mainsWater;
+
+      expect(mainsWater?.oneOf).toBeDefined();
+
+      // Branch 0 is yesNo="No" — should now contain associatedCost
+      const noBranch = mainsWater.oneOf[0];
+      const cost = noBranch?.properties?.associatedCost;
+      expect(cost).toBeDefined();
+      expect(cost.ntsRef).toBe("U1.1");
+      expect(cost.required).toEqual(["frequency"]);
+      expect(cost.properties.frequency.type).toBe("string");
+      // amount now lives inside the frequency-discriminator's "Per month"/"Per year" branch
+      const costBranch = cost.oneOf?.find((b) =>
+        b.properties?.frequency?.enum?.includes("Per month")
+      );
+      expect(costBranch?.properties?.amount?.type).toBe("number");
+      expect(costBranch?.required).toEqual(["amount"]);
+    });
+
+    test("should merge supply costs extension into mainsFoulDrainage No/Not known branch", () => {
+      const schema = getTransactionSchema(schemaId, ["sc"]);
+      const mainsFoul =
+        schema.properties?.propertyPack?.properties?.waterAndDrainage
+          ?.properties?.drainage?.properties?.mainsFoulDrainage;
+
+      expect(mainsFoul?.oneOf).toBeDefined();
+
+      // Branch 2 is yesNo="No"/"Not known" — should now contain associatedCost
+      const noBranch = mainsFoul.oneOf[2];
+      const cost = noBranch?.properties?.associatedCost;
+      expect(cost).toBeDefined();
+      expect(cost.ntsRef).toBe("U1.2");
+      expect(cost.required).toEqual(["frequency"]);
+      // amount now lives inside the frequency-discriminator's "Per month"/"Per year" branch
+      const costBranch = cost.oneOf?.find((b) =>
+        b.properties?.frequency?.enum?.includes("Per month")
+      );
+      expect(costBranch?.properties?.amount?.type).toBe("number");
+      expect(costBranch?.required).toEqual(["amount"]);
+    });
+
+    test("should merge parking permit cost and frequency into controlledParking Yes branch", () => {
+      const schema = getTransactionSchema(schemaId, ["pc"]);
+      const controlled =
+        schema.properties?.propertyPack?.properties?.parking?.properties
+          ?.controlledParking;
+
+      expect(controlled?.oneOf).toBeDefined();
+
+      // Branch 1 is yesNo="Yes"
+      const yesBranch = controlled.oneOf[1];
+      const cost = yesBranch?.properties?.costOfPermit;
+      expect(cost).toBeDefined();
+      expect(cost.ntsRef).toBe("P1.1");
+      expect(cost.type).toBe("number");
+
+      const freq = yesBranch?.properties?.costOfPermitFrequency;
+      expect(freq).toBeDefined();
+      expect(freq.ntsRef).toBe("P1.2");
+      expect(freq.type).toBe("string");
+    });
+
+    test("should merge all 4 property hazard fields into specialistIssues", () => {
+      const schema = getTransactionSchema(schemaId, ["ph"]);
+      const si =
+        schema.properties?.propertyPack?.properties?.specialistIssues
+          ?.properties;
+
+      const expectedFields = [
+        { key: "wellsDitchesShaft", ref: "H1.1" },
+        { key: "damagedOrExposedElectrics", ref: "H1.2" },
+        { key: "damageToFlooringOrStaircases", ref: "H1.3" },
+        { key: "knownAreasInPoorCondition", ref: "H1.4" },
+      ];
+
+      expectedFields.forEach(({ key, ref }) => {
+        expect(si[key]).toBeDefined();
+        expect(si[key].ntsRef).toBe(ref);
+        expect(si[key].required).toContain("yesNo");
+        expect(si[key].discriminator?.propertyName).toBe("yesNo");
+        expect(si[key].oneOf).toHaveLength(2);
+
+        // "No" branch should not require details
+        const noBranch = si[key].oneOf.find((b) =>
+          b.properties?.yesNo?.enum?.includes("No")
+        );
+        expect(noBranch).toBeDefined();
+        expect(noBranch.required).toBeUndefined();
+
+        // "Yes" branch should require details
+        const yesBranch = si[key].oneOf.find((b) =>
+          b.properties?.yesNo?.enum?.includes("Yes")
+        );
+        expect(yesBranch).toBeDefined();
+        expect(yesBranch.required).toContain("details");
+        expect(yesBranch.properties.details.minLength).toBe(1);
+      });
+    });
+
     test("should not require additional fields when 'No' is selected in extension overlays", () => {
       // Test the 'as' (additional searches) extension overlay
       const schema = getTransactionSchema(schemaId, ["as"]);
@@ -520,6 +826,1013 @@ describe("Extension Overlays", () => {
         expect(result.valid).toBe(true);
         expect(result.errors).toHaveLength(0);
       }
+    });
+  });
+
+  describe("SEF25 extension validation", () => {
+    describe("Supply costs (sc)", () => {
+      const overlays = ["baspiV5", "sc"];
+
+      test("should validate valid private water cost", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+          details: "Private borehole",
+          associatedCost: {
+            amount: 50,
+            frequency: "Per month",
+          },
+        });
+
+        expect(result).toBe(true);
+      });
+
+      test("should validate private water with no associated costs", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+          details: "Private borehole",
+          associatedCost: {
+            amount: 0,
+            frequency: "Not applicable",
+          },
+        });
+
+        expect(result).toBe(true);
+      });
+
+      test("should require associated cost for private water supply", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+          details: "Private well",
+        });
+
+        // associatedCost is required by the sc extension
+        expect(result).toBe(false);
+      });
+
+      test("should reject invalid frequency value for water cost", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+          details: "Borehole",
+          associatedCost: {
+            amount: 100,
+            frequency: "Weekly",
+          },
+        });
+
+        expect(result).toBe(false);
+      });
+
+      test("should reject non-numeric amount for water cost", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+          details: "Borehole",
+          associatedCost: {
+            amount: "fifty pounds",
+            frequency: "Per month",
+          },
+        });
+
+        expect(result).toBe(false);
+      });
+
+      test("should validate valid private sewerage cost", () => {
+        // Use sc without baspiV5 to avoid strict offMainsDrainageSystem requirements
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/drainage/mainsFoulDrainage",
+          schemaId,
+          ["sc"]
+        );
+
+        const result = validator({
+          yesNo: "No",
+          associatedCost: {
+            amount: 200,
+            frequency: "Per year",
+          },
+        });
+
+        expect(result).toBe(true);
+      });
+
+      test("should reject invalid frequency for sewerage cost", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/drainage/mainsFoulDrainage",
+          schemaId,
+          ["sc"]
+        );
+
+        const result = validator({
+          yesNo: "No",
+          associatedCost: {
+            amount: 200,
+            frequency: "Quarterly",
+          },
+        });
+
+        expect(result).toBe(false);
+      });
+
+      test("should not allow associated cost when mains water is Yes", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/waterAndDrainage/water/mainsWater",
+          schemaId,
+          overlays
+        );
+
+        // When yesNo="Yes", associatedCost should cause validation failure
+        // because it's only defined in the "No" oneOf branch
+        const result = validator({
+          yesNo: "Yes",
+          supplier: "Thames Water",
+          associatedCost: {
+            amount: 50,
+            frequency: "Per month",
+          },
+        });
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("Parking permit cost (pc)", () => {
+      const overlays = ["baspiV5", "pc"];
+
+      test("should validate valid parking permit with frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/controlledParking",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "Yes",
+          costOfPermit: 150,
+          costOfPermitFrequency: "Per year",
+        });
+
+        expect(result).toBe(true);
+      });
+
+      test("should validate parking permit with monthly frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/controlledParking",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "Yes",
+          costOfPermit: 12.50,
+          costOfPermitFrequency: "Per month",
+        });
+
+        expect(result).toBe(true);
+      });
+
+      test("should reject invalid frequency for parking permit", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/controlledParking",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "Yes",
+          costOfPermit: 150,
+          costOfPermitFrequency: "Per quarter",
+        });
+
+        expect(result).toBe(false);
+      });
+
+      test("should validate No answer without cost fields", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/controlledParking",
+          schemaId,
+          overlays
+        );
+
+        const result = validator({
+          yesNo: "No",
+        });
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("Property hazards (ph)", () => {
+      const overlays = ["ph"];
+      const hazardFields = [
+        "wellsDitchesShaft",
+        "damagedOrExposedElectrics",
+        "damageToFlooringOrStaircases",
+        "knownAreasInPoorCondition",
+      ];
+
+      hazardFields.forEach((field) => {
+        test(`${field}: should validate "No" answer`, () => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/specialistIssues/${field}`,
+            schemaId,
+            overlays
+          );
+
+          const result = validator({ yesNo: "No" });
+          expect(result).toBe(true);
+        });
+
+        test(`${field}: should validate "Yes" with details`, () => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/specialistIssues/${field}`,
+            schemaId,
+            overlays
+          );
+
+          const result = validator({
+            yesNo: "Yes",
+            details: "Some description of the issue",
+          });
+          expect(result).toBe(true);
+        });
+
+        test(`${field}: should reject "Yes" without details`, () => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/specialistIssues/${field}`,
+            schemaId,
+            overlays
+          );
+
+          const result = validator({ yesNo: "Yes" });
+          expect(result).toBe(false);
+        });
+
+        test(`${field}: should reject "Yes" with empty details`, () => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/specialistIssues/${field}`,
+            schemaId,
+            overlays
+          );
+
+          const result = validator({ yesNo: "Yes", details: "" });
+          expect(result).toBe(false);
+        });
+
+        test(`${field}: should reject invalid yesNo value`, () => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/specialistIssues/${field}`,
+            schemaId,
+            overlays
+          );
+
+          const result = validator({ yesNo: "Maybe" });
+          expect(result).toBe(false);
+        });
+      });
+    });
+
+    describe("Combined SEF25 extensions", () => {
+      test("should load all three SEF25 extensions together", () => {
+        const schema = getTransactionSchema(schemaId, [
+          "baspiV5",
+          "sc",
+          "pc",
+          "ph",
+        ]);
+
+        // Supply costs
+        const waterCost =
+          schema.properties?.propertyPack?.properties?.waterAndDrainage
+            ?.properties?.water?.properties?.mainsWater?.oneOf?.[0]?.properties
+            ?.associatedCost;
+        expect(waterCost).toBeDefined();
+
+        const sewerageCost =
+          schema.properties?.propertyPack?.properties?.waterAndDrainage
+            ?.properties?.drainage?.properties?.mainsFoulDrainage?.oneOf?.[2]
+            ?.properties?.associatedCost;
+        expect(sewerageCost).toBeDefined();
+
+        // Parking
+        const parkingFreq =
+          schema.properties?.propertyPack?.properties?.parking?.properties
+            ?.controlledParking?.oneOf?.[1]?.properties?.costOfPermitFrequency;
+        expect(parkingFreq).toBeDefined();
+
+        // Hazards
+        const si =
+          schema.properties?.propertyPack?.properties?.specialistIssues
+            ?.properties;
+        expect(si?.wellsDitchesShaft).toBeDefined();
+        expect(si?.damagedOrExposedElectrics).toBeDefined();
+        expect(si?.damageToFlooringOrStaircases).toBeDefined();
+        expect(si?.knownAreasInPoorCondition).toBeDefined();
+      });
+
+      test("should not interfere with existing NTS2 extensions", () => {
+        const schema = getTransactionSchema(schemaId, [
+          "nts2023",
+          "jk",
+          "hs",
+          "sc",
+          "pc",
+          "ph",
+        ]);
+
+        const si =
+          schema.properties?.propertyPack?.properties?.specialistIssues;
+
+        // Existing NTS2 extensions still work
+        expect(si?.properties?.japaneseKnotweed?.ntsRef).toBe("A5.3");
+        expect(si?.properties?.ongoingHealthOrSafetyIssue?.ntsRef).toBe(
+          "A5.5"
+        );
+        expect(si?.required).toContain("japaneseKnotweed");
+        expect(si?.required).toContain("ongoingHealthOrSafetyIssue");
+
+        // SEF25 hazards also present (remapped to ntsRef in extension overlays)
+        expect(si?.properties?.wellsDitchesShaft?.ntsRef).toBe("H1.1");
+        expect(si?.properties?.knownAreasInPoorCondition?.ntsRef).toBe(
+          "H1.4"
+        );
+      });
+    });
+
+    describe("Dropped kerb (dk)", () => {
+      test("should validate Yes answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/droppedKerbAccess",
+          schemaId,
+          ["dk"]
+        );
+        expect(validator({ yesNo: "Yes" })).toBe(true);
+      });
+
+      test("should validate No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/droppedKerbAccess",
+          schemaId,
+          ["dk"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+
+      test("should reject invalid value", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/parking/droppedKerbAccess",
+          schemaId,
+          ["dk"]
+        );
+        expect(validator({ yesNo: "Maybe" })).toBe(false);
+      });
+
+      test("should not be required without dk overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5"]);
+        const parking = schema.properties?.propertyPack?.properties?.parking;
+        expect(parking?.required || []).not.toContain("droppedKerbAccess");
+      });
+
+      test("should be required with dk overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["dk"]);
+        const parking = schema.properties?.propertyPack?.properties?.parking;
+        expect(parking?.required).toContain("droppedKerbAccess");
+      });
+    });
+
+    describe("Private right of way (rw)", () => {
+      test("should validate No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/rightsAndInformalArrangements/rightsOrArrangements/privateRightOfWay",
+          schemaId,
+          ["rw"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+
+      test("should validate Yes with details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/rightsAndInformalArrangements/rightsOrArrangements/privateRightOfWay",
+          schemaId,
+          ["rw"]
+        );
+        expect(validator({ yesNo: "Yes", details: "Neighbour has access through garden" })).toBe(true);
+      });
+
+      test("should reject Yes without details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/rightsAndInformalArrangements/rightsOrArrangements/privateRightOfWay",
+          schemaId,
+          ["rw"]
+        );
+        expect(validator({ yesNo: "Yes" })).toBe(false);
+      });
+
+      test("should reject Yes with empty details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/rightsAndInformalArrangements/rightsOrArrangements/privateRightOfWay",
+          schemaId,
+          ["rw"]
+        );
+        expect(validator({ yesNo: "Yes", details: "" })).toBe(false);
+      });
+
+      test("should not be required without rw overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5"]);
+        const rights = schema.properties?.propertyPack?.properties?.rightsAndInformalArrangements
+          ?.properties?.rightsOrArrangements;
+        expect(rights?.required || []).not.toContain("privateRightOfWay");
+      });
+
+      test("should be required with rw overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["rw"]);
+        const rights = schema.properties?.propertyPack?.properties?.rightsAndInformalArrangements
+          ?.properties?.rightsOrArrangements;
+        expect(rights?.required).toContain("privateRightOfWay");
+      });
+    });
+
+    describe("Storm/fire/flood damage (sd)", () => {
+      test("should validate No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/environmentalIssues/stormFireFloodDamage",
+          schemaId,
+          ["sd"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+
+      test("should validate Yes with details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/environmentalIssues/stormFireFloodDamage",
+          schemaId,
+          ["sd"]
+        );
+        expect(validator({ yesNo: "Yes", details: "Flood damage in 2020" })).toBe(true);
+      });
+
+      test("should reject Yes without details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/environmentalIssues/stormFireFloodDamage",
+          schemaId,
+          ["sd"]
+        );
+        expect(validator({ yesNo: "Yes" })).toBe(false);
+      });
+
+      test("should not be required without sd overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5"]);
+        const env = schema.properties?.propertyPack?.properties?.environmentalIssues;
+        expect(env?.required || []).not.toContain("stormFireFloodDamage");
+      });
+
+      test("should be required with sd overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["sd"]);
+        const env = schema.properties?.propertyPack?.properties?.environmentalIssues;
+        expect(env?.required).toContain("stormFireFloodDamage");
+      });
+    });
+
+    describe("Solar lease costs (lc)", () => {
+      test("should validate Not applicable frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/electricity/solarPanels/panelsOwnedOutright/associatedCost",
+          schemaId,
+          ["lc"]
+        );
+        expect(validator({ amount: 0, frequency: "Not applicable" })).toBe(true);
+      });
+
+      test("should validate amount and frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/electricity/solarPanels/panelsOwnedOutright/associatedCost",
+          schemaId,
+          ["lc"]
+        );
+        expect(validator({ amount: 75, frequency: "Per month" })).toBe(true);
+      });
+
+      test("should reject missing amount", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/electricity/solarPanels/panelsOwnedOutright/associatedCost",
+          schemaId,
+          ["lc"]
+        );
+        expect(validator({ frequency: "Per month" })).toBe(false);
+      });
+
+      test("should reject missing frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/electricity/solarPanels/panelsOwnedOutright/associatedCost",
+          schemaId,
+          ["lc"]
+        );
+        expect(validator({ amount: 75 })).toBe(false);
+      });
+
+      test("should reject invalid frequency", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/electricity/solarPanels/panelsOwnedOutright/associatedCost",
+          schemaId,
+          ["lc"]
+        );
+        expect(validator({ amount: 75, frequency: "Weekly" })).toBe(false);
+      });
+    });
+
+    describe("Warranties and guarantees (wg)", () => {
+      const warrantyCategoryPaths = [
+        { path: "newHomeWarranty", ref: "W1.1" },
+        { path: "roofingWork", ref: "W1.2" },
+        { path: "dampProofingTreatment", ref: "W1.3" },
+        { path: "centralHeatingAndorPlumbing", ref: "W1.4" },
+        { path: "electricalRepairOrInstallation", ref: "W1.5" },
+        { path: "subsidenceWork", ref: "W1.6" },
+        { path: "otherGuarantees", ref: "W1.7" },
+      ];
+
+      test("should have ntsRef on all warranty categories when wg overlay loaded", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5", "wg"]);
+        const warranties =
+          schema.properties?.propertyPack?.properties?.guaranteesWarrantiesAndIndemnityInsurances;
+
+        // Warranty fields are in oneOf[1] (hasValidGuaranteesOrWarranties = Yes)
+        const yesBranch = warranties.oneOf[1];
+
+        warrantyCategoryPaths.forEach(({ path, ref }) => {
+          expect(yesBranch.properties[path]?.ntsRef).toBe(ref);
+        });
+      });
+
+      test("should mark warranty categories as required when wg overlay loaded", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5", "wg"]);
+        const warranties =
+          schema.properties?.propertyPack?.properties?.guaranteesWarrantiesAndIndemnityInsurances;
+
+        const yesBranch = warranties.oneOf[1];
+        warrantyCategoryPaths.forEach(({ path }) => {
+          expect(yesBranch.required).toContain(path);
+        });
+      });
+
+      test("should not require warranty categories without any overlay", () => {
+        const schema = getTransactionSchema(schemaId, []);
+        const warranties =
+          schema.properties?.propertyPack?.properties?.guaranteesWarrantiesAndIndemnityInsurances;
+
+        const yesBranch = warranties.oneOf[1];
+        // Without any overlay, warranty categories should not be in required
+        expect(yesBranch.required || []).not.toContain("newHomeWarranty");
+        expect(yesBranch.required || []).not.toContain("electricalRepairOrInstallation");
+      });
+    });
+
+    describe("Insurance claims (ic)", () => {
+      test("should mark insuranceClaims as required in isInsured=Yes branch", () => {
+        const schema = getTransactionSchema(schemaId, ["ic"]);
+        const insurance = schema.properties?.propertyPack?.properties?.insurance;
+        // oneOf[1] is isInsured=Yes
+        const yesBranch = insurance.oneOf[1];
+        expect(yesBranch?.required).toContain("insuranceClaims");
+      });
+
+      test("should require isInsured at the insurance level", () => {
+        const schema = getTransactionSchema(schemaId, ["ic"]);
+        const insurance = schema.properties?.propertyPack?.properties?.insurance;
+        expect(insurance?.required).toContain("isInsured");
+        expect(insurance?.discriminator?.propertyName).toBe("isInsured");
+        expect(insurance?.properties?.isInsured?.ntsRef).toBe("I1.2");
+      });
+
+      test("should expose I1.1.2 ntsRef on details and require it in claims Yes branch", () => {
+        const schema = getTransactionSchema(schemaId, ["ic"]);
+        const claims =
+          schema.properties?.propertyPack?.properties?.insurance?.oneOf?.[1]
+            ?.properties?.insuranceClaims;
+        const claimsYesBranch = claims?.oneOf?.find((b) =>
+          b.properties?.yesNo?.enum?.includes("Yes")
+        );
+        expect(claimsYesBranch?.required).toContain("details");
+        expect(claimsYesBranch?.properties?.details?.ntsRef).toBe("I1.1.2");
+      });
+
+      test("should compile cleanly under AJV strict-mode discriminator with [ic]", () => {
+        expect(() => getValidator(schemaId, ["ic"])).not.toThrow();
+        // /propertyPack/insurance is where the isInsured discriminator lives;
+        // compiling that subschema exercises the strict-mode constraint.
+        expect(() =>
+          getSubschemaValidator("/propertyPack/insurance", schemaId, ["ic"])
+        ).not.toThrow();
+      });
+
+      test("should compile cleanly under AJV strict-mode discriminator with [sef25]", () => {
+        // sef25 carries the same discriminator structure as the ic extension;
+        // both must satisfy the strict-mode discriminator requirement.
+        expect(() => getValidator(schemaId, ["sef25"])).not.toThrow();
+      });
+
+      test("should validate insuranceClaims No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/insurance/insuranceClaims",
+          schemaId,
+          ["baspiV5", "ic"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+
+      test("should validate insuranceClaims Yes with details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/insurance/insuranceClaims",
+          schemaId,
+          ["baspiV5", "ic"]
+        );
+        expect(validator({ yesNo: "Yes", details: "Storm damage claim in 2019" })).toBe(true);
+      });
+
+      describe("insurance-level validation with [ic]", () => {
+        const insurancePath = "/propertyPack/insurance";
+
+        test("rejects empty object (missing isInsured)", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(validator({})).toBe(false);
+        });
+
+        test("rejects invalid isInsured enum value", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(validator({ isInsured: "Maybe" })).toBe(false);
+        });
+
+        test("accepts the isInsured=No branch", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(validator({ isInsured: "No" })).toBe(true);
+        });
+
+        test("rejects isInsured=Yes without insuranceClaims", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(validator({ isInsured: "Yes" })).toBe(false);
+        });
+
+        test("accepts isInsured=Yes with insuranceClaims yesNo=No", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(
+            validator({
+              isInsured: "Yes",
+              insuranceClaims: { yesNo: "No" },
+            })
+          ).toBe(true);
+        });
+
+        test("rejects isInsured=Yes with insuranceClaims yesNo=Yes but no details", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(
+            validator({
+              isInsured: "Yes",
+              insuranceClaims: { yesNo: "Yes" },
+            })
+          ).toBe(false);
+        });
+
+        test("accepts isInsured=Yes with a full claim including details", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(
+            validator({
+              isInsured: "Yes",
+              insuranceClaims: {
+                yesNo: "Yes",
+                details: "Storm damage claim in 2019",
+              },
+            })
+          ).toBe(true);
+        });
+
+        test("rejects empty details string on the claim Yes branch", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(
+            validator({
+              isInsured: "Yes",
+              insuranceClaims: { yesNo: "Yes", details: "" },
+            })
+          ).toBe(false);
+        });
+
+        test("rejects invalid insuranceClaims yesNo enum value", () => {
+          const validator = getSubschemaValidator(insurancePath, schemaId, [
+            "ic",
+          ]);
+          expect(
+            validator({
+              isInsured: "Yes",
+              insuranceClaims: { yesNo: "Maybe" },
+            })
+          ).toBe(false);
+        });
+      });
+    });
+
+    describe("Neighbour development (nd)", () => {
+      test("should add ntsRef to neighbourDevelopment", () => {
+        const schema = getTransactionSchema(schemaId, ["nd"]);
+        const nd = schema.properties?.propertyPack?.properties?.notices
+          ?.properties?.neighbourDevelopment;
+        expect(nd?.ntsRef).toBe("N1.1");
+      });
+
+      test("preserves native ntsRef on the notices parent (does not clobber with sef25Ref)", () => {
+        const schema = getTransactionSchema(schemaId, ["nd"]);
+        const notices = schema.properties?.propertyPack?.properties?.notices;
+        // notices has both ntsRef: "C4" and sef25Ref: "N1" in combined.json.
+        // The nd extension must not overwrite the native ntsRef with the
+        // substituted sef25Ref value.
+        expect(notices?.ntsRef).toBe("C4");
+      });
+
+      test("should validate No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/notices/neighbourDevelopment",
+          schemaId,
+          ["baspiV5", "nd"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+    });
+
+    describe("Other material issue (mi)", () => {
+      test("should mark otherMaterialIssue as required", () => {
+        const schema = getTransactionSchema(schemaId, ["mi"]);
+        const additional = schema.properties?.propertyPack?.properties?.additionalInformation;
+        expect(additional?.required).toContain("otherMaterialIssue");
+      });
+
+      test("should not require otherMaterialIssue without mi overlay", () => {
+        const schema = getTransactionSchema(schemaId, []);
+        const additional = schema.properties?.propertyPack?.properties?.additionalInformation;
+        expect(additional?.required || []).not.toContain("otherMaterialIssue");
+      });
+
+      test("should validate No answer", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/additionalInformation/otherMaterialIssue",
+          schemaId,
+          ["baspiV5", "mi"]
+        );
+        expect(validator({ yesNo: "No" })).toBe(true);
+      });
+
+      test("should validate Yes with details", () => {
+        const validator = getSubschemaValidator(
+          "/propertyPack/additionalInformation/otherMaterialIssue",
+          schemaId,
+          ["baspiV5", "mi"]
+        );
+        expect(validator({ yesNo: "Yes", details: "Previous subsidence issues" })).toBe(true);
+      });
+    });
+
+    describe("Title restrictions (tr)", () => {
+      test("should require titleRestrictions in freehold branch with tr overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["tr"]);
+        const items = schema.properties?.propertyPack?.properties?.ownership
+          ?.properties?.ownershipsToBeTransferred?.items;
+        // oneOf[0] is Freehold
+        const freeholdBranch = items.oneOf[0];
+        expect(freeholdBranch?.properties?.titleRestrictions).toBeDefined();
+        expect(freeholdBranch?.required).toContain("titleRestrictions");
+      });
+
+      test("should not require titleRestrictions without tr overlay", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5"]);
+        const items = schema.properties?.propertyPack?.properties?.ownership
+          ?.properties?.ownershipsToBeTransferred?.items;
+        const freeholdBranch = items.oneOf[0];
+        expect(freeholdBranch?.required || []).not.toContain("titleRestrictions");
+      });
+
+      test("should have correct ntsRef", () => {
+        const schema = getTransactionSchema(schemaId, ["tr"]);
+        const items = schema.properties?.propertyPack?.properties?.ownership
+          ?.properties?.ownershipsToBeTransferred?.items;
+        const freeholdBranch = items.oneOf[0];
+        expect(freeholdBranch?.properties?.titleRestrictions?.ntsRef).toBe("T1.1");
+      });
+    });
+
+    describe("Alterations and changes (ac)", () => {
+      const alterationFields = [
+        "extension",
+        "loftConversion",
+        "garageConversion",
+        "removalOfInternalWalls",
+        "changeOfUse",
+      ];
+
+      test("should expose only selected alterations and changes fields", () => {
+        const schema = getTransactionSchema(schemaId, ["ac"]);
+        const alterations =
+          schema.properties?.propertyPack?.properties?.alterationsAndChanges;
+        const acOverlayAlterations =
+          extensionOverlays.ac.properties?.propertyPack?.properties
+            ?.alterationsAndChanges;
+
+        expect(alterations?.ntsRef).toBe("A1");
+        expect(alterations?.required).toEqual(
+          expect.arrayContaining(alterationFields)
+        );
+        expect(Object.keys(acOverlayAlterations?.properties || {}).sort()).toEqual(
+          alterationFields.slice().sort()
+        );
+
+        alterationFields.forEach((field) => {
+          const fieldSchema = alterations.properties?.[field];
+          const yesBranch = fieldSchema?.oneOf?.[1];
+          const planningPermission =
+            yesBranch?.properties?.planningPermission;
+          const buildingRegApproval =
+            yesBranch?.properties?.buildingRegApproval;
+          const overlayFieldSchema = acOverlayAlterations.properties?.[field];
+          const overlayYesBranch =
+            overlayFieldSchema?.oneOf?.[1];
+          const overlayPlanningPermission =
+            overlayYesBranch?.properties?.planningPermission;
+          const overlayBuildingRegApproval =
+            overlayYesBranch?.properties?.buildingRegApproval;
+
+          expect(fieldSchema?.required).toContain("yesNo");
+          expect(fieldSchema?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(overlayFieldSchema?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(fieldSchema?.properties?.yesNo?.ntsRef).toMatch(/^A1\./);
+          expect(yesBranch?.required).toEqual(
+            expect.arrayContaining([
+              "details",
+              "planningPermission",
+              "buildingRegApproval",
+            ])
+          );
+          expect(Object.keys(overlayYesBranch?.properties || {}).sort()).toEqual([
+            "buildingRegApproval",
+            "details",
+            "planningPermission",
+          ]);
+          expect(planningPermission?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(buildingRegApproval?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(overlayPlanningPermission?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(overlayBuildingRegApproval?.discriminator).toEqual({
+            propertyName: "yesNo",
+          });
+          expect(yesBranch?.properties?.workCompleted?.ntsRef).toBeUndefined();
+          expect(yesBranch?.properties?.documents?.ntsRef).toBeUndefined();
+          expect(yesBranch?.properties?.yearCompleted?.ntsRef).toBeUndefined();
+          expect(yesBranch?.properties?.listedBuildingConsent?.ntsRef).toBeUndefined();
+          expect(yesBranch?.properties?.deedRestrictionConsent?.ntsRef).toBeUndefined();
+        });
+      });
+
+      test("should require details and consent yesNo fields for Yes answers", () => {
+        alterationFields.forEach((field) => {
+          const validator = getSubschemaValidator(
+            `/propertyPack/alterationsAndChanges/${field}`,
+            schemaId,
+            ["ac"]
+          );
+
+          expect(validator({ yesNo: "No" })).toBe(true);
+          expect(validator({ yesNo: "Yes" })).toBe(false);
+          expect(
+            validator({
+              yesNo: "Yes",
+              details: `${field} details`,
+              planningPermission: { yesNo: "Not required" },
+              buildingRegApproval: { yesNo: "Yes" },
+            })
+          ).toBe(true);
+        });
+      });
+    });
+
+    describe("All SEF25 extensions combined", () => {
+      const allSef25 = ["sc", "pc", "ph", "dk", "rw", "sd", "lc", "wg", "ic", "nd", "mi", "tr", "ac"];
+
+      test("should load all SEF25 extensions together without error", () => {
+        const schema = getTransactionSchema(schemaId, ["baspiV5", ...allSef25]);
+        expect(schema).toBeDefined();
+        expect(schema.properties?.propertyPack).toBeDefined();
+      });
+
+      test("should not interfere with existing NTS2 extensions when combined", () => {
+        const schema = getTransactionSchema(schemaId, ["nts2025", ...allSef25]);
+
+        // NTS2 fields still work
+        const si = schema.properties?.propertyPack?.properties?.specialistIssues;
+        expect(si?.properties?.wellsDitchesShaft?.ntsRef).toBe("H1.1");
+
+        // New SEF25 fields present
+        const parking = schema.properties?.propertyPack?.properties?.parking?.properties;
+        expect(parking?.droppedKerbAccess).toBeDefined();
+
+        const env = schema.properties?.propertyPack?.properties?.environmentalIssues?.properties;
+        expect(env?.stormFireFloodDamage).toBeDefined();
+
+        const rights = schema.properties?.propertyPack?.properties?.rightsAndInformalArrangements
+          ?.properties?.rightsOrArrangements?.properties;
+        expect(rights?.privateRightOfWay).toBeDefined();
+      });
+    });
+  });
+
+  // Regression: when a SEF25 extension is merged on top of an NTS overlay,
+  // the intermediate parent nodes must retain their native NTS refs rather
+  // than being clobbered by sef25Ref values substituted into `ntsRef`. The
+  // extractor previously emitted `ntsRef: "R1"` on `rightsAndInformalArrangements`
+  // and `rightsOrArrangements`, which broke the form UI's traversal by NTS
+  // section number.
+  describe("sef25 extensions preserve NTS parent refs", () => {
+    test("rw (privateRightOfWay) does not clobber rightsAndInformalArrangements / rightsOrArrangements ntsRefs", () => {
+      const schema = getTransactionSchema(schemaId, ["nts2023", "rw"]);
+
+      const ria =
+        schema.properties?.propertyPack?.properties?.rightsAndInformalArrangements;
+      const ra = ria?.properties?.rightsOrArrangements;
+      const prow = ra?.properties?.privateRightOfWay;
+
+      // Parents keep their NTS section numbers.
+      expect(ria.ntsRef).toBe("C2.2");
+      expect(ra.ntsRef).toBe("C2.2.1");
+
+      // Sibling publicRightOfWay still tagged with NTS ref.
+      expect(ra.properties.publicRightOfWay.ntsRef).toBe("C2.2.1");
+
+      // The new SEF25 leaf is surfaced with its substituted (SEF25-style) ref.
+      expect(prow).toBeDefined();
+      expect(prow.ntsRef).toBe("R1.1");
+
+      // And rw still makes privateRightOfWay required.
+      expect(ra.required).toContain("publicRightOfWay");
+      expect(ra.required).toContain("privateRightOfWay");
+    });
+
+    test("merge order does not matter — rw before nts2023 yields the same parent refs", () => {
+      const schema = getTransactionSchema(schemaId, ["rw", "nts2023"]);
+
+      const ria =
+        schema.properties?.propertyPack?.properties?.rightsAndInformalArrangements;
+      const ra = ria?.properties?.rightsOrArrangements;
+
+      expect(ria.ntsRef).toBe("C2.2");
+      expect(ra.ntsRef).toBe("C2.2.1");
+      expect(ra.properties.privateRightOfWay.ntsRef).toBe("R1.1");
     });
   });
 });

--- a/src/tests/v3/offers.test.js
+++ b/src/tests/v3/offers.test.js
@@ -1,0 +1,823 @@
+const { getValidator } = require("../../../index.js");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+describe("Offers object validation", () => {
+  describe("Valid offer keys", () => {
+    test("accepts valid UUID as offer key", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "550e8400-e29b-41d4-a716-446655440000": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts valid DID as offer key", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "did:example:123456789abcdefghi": {
+            amount: 300000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts DID with various allowed characters", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "did:web:example.com:users:alice": {
+            amount: 275000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts multiple offers with different key types", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "550e8400-e29b-41d4-a716-446655440000": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+          "did:example:buyer123": {
+            amount: 260000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+          "offer-abc123": {
+            amount: 240000,
+            currency: "GBP",
+            status: "Rejected",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Invalid offer keys", () => {
+    test("rejects offer key starting with invalid character", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "-invalid-key": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+      expect(validator.errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects offer key with spaces", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "invalid key with spaces": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer key with special characters", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "invalid@key#here": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("Valid offer contents", () => {
+    test("accepts offer with all required fields", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts offer with all fields including optional ones", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Accepted",
+            inclusions: ["curtains", "carpets", "light fixtures"],
+            exclusions: ["garden furniture", "shed"],
+            conditions: [
+              "Subject to survey",
+              "Subject to mortgage approval",
+            ],
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts all valid status values", () => {
+      const validator = getValidator(schemaId);
+      const validStatuses = [
+        "Pending",
+        "Withdrawn",
+        "Rejected",
+        "Accepted",
+        "Note of Interest",
+      ];
+
+      validStatuses.forEach((status) => {
+        const transaction = {
+          transactionId: "123e4567-e89b-12d3-a456-426614174000",
+          status: "active",
+          participants: [
+            {
+              role: "Buyer",
+              participantStatus: "Active",
+            },
+          ],
+          offers: {
+            "offer-1": {
+              amount: 250000,
+              currency: "GBP",
+              status: status,
+            },
+          },
+        };
+
+        const isValid = validator(transaction);
+        expect(isValid).toBe(true);
+      });
+    });
+
+    test("accepts valid currency codes", () => {
+      const validator = getValidator(schemaId);
+      const validCurrencies = ["GBP", "USD", "EUR"];
+
+      validCurrencies.forEach((currency) => {
+        const transaction = {
+          transactionId: "123e4567-e89b-12d3-a456-426614174000",
+          status: "active",
+          participants: [
+            {
+              role: "Buyer",
+              participantStatus: "Active",
+            },
+          ],
+          offers: {
+            "offer-1": {
+              amount: 250000,
+              currency: currency,
+              status: "Pending",
+            },
+          },
+        };
+
+        const isValid = validator(transaction);
+        expect(isValid).toBe(true);
+      });
+    });
+
+    test("accepts zero amount", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 0,
+            currency: "GBP",
+            status: "Note of Interest",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Invalid offer contents", () => {
+    test("accepts offer without amount field (no required fields in schema)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts offer without currency field (no required fields in schema)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts offer without status field (no required fields in schema)", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("rejects offer with invalid status value", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "invalid-status",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with negative amount", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: -100000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with invalid currency code format", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "gb",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with lowercase currency code", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "gbp",
+            status: "Pending",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with non-array inclusions", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            inclusions: "curtains",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with non-string items in inclusions array", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            inclusions: ["curtains", 123, "carpets"],
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with non-array exclusions", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            exclusions: { item: "garden furniture" },
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("rejects offer with non-array conditions", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+            conditions: "Subject to survey",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+  });
+
+  describe("Empty offers object", () => {
+    test("accepts empty offers object", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+        offers: {},
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts transaction without offers property", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("Buyer participant with offerId", () => {
+    test("accepts Buyer with valid offerId", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "550e8400-e29b-41d4-a716-446655440000",
+          },
+        ],
+        offers: {
+          "550e8400-e29b-41d4-a716-446655440000": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts Buyer with offerId as DID", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "did:example:buyer123",
+          },
+        ],
+        offers: {
+          "did:example:buyer123": {
+            amount: 260000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts Buyer without offerId", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("rejects Buyer with invalid offerId format starting with dash", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "-invalid-offer-id",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+      // Should fail because offerId pattern requires starting with alphanumeric
+      const offerIdError = validator.errors.find(
+        (e) => e.instancePath.includes("offerId")
+      );
+      expect(offerIdError).toBeDefined();
+    });
+
+    test("rejects Buyer with offerId containing spaces", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "invalid offer id",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(false);
+    });
+
+    test("accepts multiple Buyers with different offerIds", () => {
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "offer-1",
+          },
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "offer-2",
+          },
+        ],
+        offers: {
+          "offer-1": {
+            amount: 250000,
+            currency: "GBP",
+            status: "Pending",
+          },
+          "offer-2": {
+            amount: 260000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+        },
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("accepts Buyer with offerId referencing non-existent offer (schema allows this)", () => {
+      // Note: The schema doesn't enforce referential integrity between offerId and offers keys
+      // This would need to be enforced at the application level
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Buyer",
+            participantStatus: "Active",
+            offerId: "non-existent-offer",
+          },
+        ],
+        offers: {},
+      };
+
+      const isValid = validator(transaction);
+      expect(isValid).toBe(true);
+    });
+
+    test("allows offerId on non-Buyer participants (schema doesn't restrict additionalProperties)", () => {
+      // Note: The schema uses oneOf with discriminator on role, but doesn't use
+      // additionalProperties: false, so extra properties are allowed on all participants
+      // This is intentional to maintain flexibility
+      const validator = getValidator(schemaId);
+      const transaction = {
+        transactionId: "123e4567-e89b-12d3-a456-426614174000",
+        status: "active",
+        participants: [
+          {
+            role: "Seller",
+            participantStatus: "Active",
+            offerId: "offer-1",
+          },
+        ],
+      };
+
+      const isValid = validator(transaction);
+      // This will actually pass because additionalProperties is not restricted
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/src/tests/v3/oneOfCoverage.test.js
+++ b/src/tests/v3/oneOfCoverage.test.js
@@ -1,0 +1,203 @@
+const { getSubschemaValidator } = require("../../../index.js");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+// These tests guard the audit fixes that aligned discriminator `oneOf` branches
+// with their root `enum` declarations in combined.json. For each field we
+// verify every enum value validates, and (for the fields where we removed a
+// stale oneOf branch) that the removed value is rejected.
+
+describe("Discriminator oneOf branches cover root enum", () => {
+  describe("typeOfConstruction.buildingSafety yesNo", () => {
+    const path = "/propertyPack/typeOfConstruction/buildingSafety";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([
+      ["No"],
+      ["Not applicable"],
+      ["Not known"],
+    ])("accepts yesNo = %j without details", (yesNo) => {
+      expect(validator({ yesNo })).toBe(true);
+    });
+
+    test("accepts yesNo = 'Yes' with required details", () => {
+      expect(
+        validator({
+          yesNo: "Yes",
+          details: "Cladding remediation under review",
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("heating heatingInGoodWorkingOrder yesNo", () => {
+    const path =
+      "/propertyPack/heating/heatingSystem/centralHeatingDetails/heatingInGoodWorkingOrder";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([["Yes"], ["Not known"]])(
+      "accepts yesNo = %j without details",
+      (yesNo) => {
+        expect(validator({ yesNo })).toBe(true);
+      }
+    );
+
+    test("accepts yesNo = 'No' with details", () => {
+      expect(validator({ yesNo: "No", details: "Boiler intermittent" })).toBe(
+        true
+      );
+    });
+  });
+
+  describe("rightsAndInformalArrangements.sharedContributions yesNo", () => {
+    const path = "/propertyPack/rightsAndInformalArrangements/sharedContributions";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([["No"], ["Not applicable"]])(
+      "accepts yesNo = %j without details",
+      (yesNo) => {
+        expect(validator({ yesNo })).toBe(true);
+      }
+    );
+
+    test("accepts yesNo = 'Yes' with details", () => {
+      expect(
+        validator({ yesNo: "Yes", details: "Shared driveway maintenance" })
+      ).toBe(true);
+    });
+  });
+
+  describe("rightsAndInformalArrangements.accessRestrictionAttempts yesNo", () => {
+    const path =
+      "/propertyPack/rightsAndInformalArrangements/accessRestrictionAttempts";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([["No"], ["Not known"]])(
+      "accepts yesNo = %j without details",
+      (yesNo) => {
+        expect(validator({ yesNo })).toBe(true);
+      }
+    );
+
+    test("accepts yesNo = 'Yes' with details", () => {
+      expect(
+        validator({ yesNo: "Yes", details: "Neighbour disputed access" })
+      ).toBe(true);
+    });
+  });
+
+  describe("legalBoundaries.flyingFreehold yesNo", () => {
+    const path = "/propertyPack/legalBoundaries/flyingFreehold";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([["No"], ["Not applicable"], ["Not known"]])(
+      "accepts yesNo = %j without details",
+      (yesNo) => {
+        expect(validator({ yesNo })).toBe(true);
+      }
+    );
+
+    test("accepts yesNo = 'Yes' with details", () => {
+      expect(
+        validator({ yesNo: "Yes", details: "Bedroom overhangs access road" })
+      ).toBe(true);
+    });
+  });
+
+  describe("heating replacementOtherThanBoiler yesNo", () => {
+    const path =
+      "/propertyPack/heating/heatingSystem/centralHeatingDetails/replacementOtherThanBoiler";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test.each([["No"], ["Not known"]])(
+      "accepts yesNo = %j without attachments",
+      (yesNo) => {
+        expect(validator({ yesNo })).toBe(true);
+      }
+    );
+
+    test("accepts yesNo = 'Yes' with attachments", () => {
+      expect(validator({ yesNo: "Yes", attachments: "Attached" })).toBe(true);
+    });
+  });
+});
+
+describe("Discriminator oneOf branches reconciled with root enum", () => {
+  describe("fixturesAndFittings.kitchen.otherItems isIncludedOrExcluded", () => {
+    const path = "/propertyPack/fixturesAndFittings/kitchen/otherItems";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test("accepts Included with fittedOrFreestanding", () => {
+      expect(
+        validator([
+          {
+            itemName: "Wine fridge",
+            isIncludedOrExcluded: "Included",
+            fittedOrFreestanding: { fittedOrFreestanding: "Freestanding" },
+          },
+        ])
+      ).toBe(true);
+    });
+
+    test("accepts Excluded with price + fittedOrFreestanding", () => {
+      expect(
+        validator([
+          {
+            itemName: "Range cooker",
+            isIncludedOrExcluded: "Excluded",
+            price: 500,
+            fittedOrFreestanding: { fittedOrFreestanding: "Fitted" },
+          },
+        ])
+      ).toBe(true);
+    });
+
+    test("rejects removed 'None' branch", () => {
+      expect(
+        validator([{ itemName: "Toaster", isIncludedOrExcluded: "None" }])
+      ).toBe(false);
+    });
+  });
+
+  describe("environmentalIssues.otherEnvironmental riskIndicator", () => {
+    const path = "/propertyPack/environmentalIssues/otherEnvironmental";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test("accepts riskIndicator = 'No'", () => {
+      expect(validator({ riskIndicator: "No" })).toBe(true);
+    });
+
+    test("accepts riskIndicator = 'Yes' with summary", () => {
+      expect(
+        validator({ riskIndicator: "Yes", summary: "Air pollution nearby" })
+      ).toBe(true);
+    });
+
+    test("rejects removed 'Not known' value", () => {
+      expect(validator({ riskIndicator: "Not known" })).toBe(false);
+    });
+  });
+
+  describe("riskAssessments assessmentsCarriedOut case-aligned with enum", () => {
+    const path =
+      "/propertyPack/ownership/ownershipsToBeTransferred/2/leaseholdInformation/buildingsInsurance/managedAreasCoveredByPolicy/riskAssessments";
+    const validator = getSubschemaValidator(path, schemaId);
+
+    test("accepts lower-case 'External wall fire risk assessment'", () => {
+      expect(
+        validator({
+          assessmentsCarriedOut: "External wall fire risk assessment",
+        })
+      ).toBe(true);
+    });
+
+    test("rejects mis-cased 'External Wall fire risk assessment'", () => {
+      expect(
+        validator({
+          assessmentsCarriedOut: "External Wall fire risk assessment",
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/tests/v3/patternProperties.test.js
+++ b/src/tests/v3/patternProperties.test.js
@@ -1,0 +1,688 @@
+const {
+  isPathValid,
+  getSubschema,
+  getSubschemaValidator,
+  validateVerifiedClaims,
+} = require("../../../index.js");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+describe("patternProperties support in path validation", () => {
+  describe("isPathValid with patternProperties", () => {
+    test("validates path with patternProperties - simple offer ID", () => {
+      const path = "/offers/offer-123";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("validates path with patternProperties - UUID", () => {
+      const path = "/offers/550e8400-e29b-41d4-a716-446655440000";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("validates path with patternProperties - DID format", () => {
+      const path = "/offers/did:example:buyer123";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("validates path with patternProperties - alphanumeric with special chars", () => {
+      const path = "/offers/1sorzJCFHbWVlHA2tYXA";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("validates nested path within patternProperties", () => {
+      const path = "/offers/offer-456/amount";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("validates deeply nested path within patternProperties", () => {
+      const path = "/offers/offer-456/inclusions";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("rejects invalid nested path within patternProperties", () => {
+      const path = "/offers/offer-456/nonExistentField";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(false);
+    });
+
+    test("validates path with patternProperties exists at root /offers", () => {
+      const path = "/offers";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("getSubschema with patternProperties", () => {
+    test("returns correct subschema for patternProperties path", () => {
+      const path = "/offers/offer-123";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("object");
+      expect(subschema.properties).toBeDefined();
+      expect(subschema.properties.amount).toBeDefined();
+      expect(subschema.properties.currency).toBeDefined();
+      expect(subschema.properties.status).toBeDefined();
+    });
+
+    test("returns correct subschema for nested property in patternProperties", () => {
+      const path = "/offers/offer-123/amount";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("number");
+      expect(subschema.minimum).toBe(0);
+    });
+
+    test("returns correct subschema for status enum", () => {
+      const path = "/offers/offer-123/status";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("string");
+      expect(subschema.enum).toContain("Pending");
+      expect(subschema.enum).toContain("Accepted");
+      expect(subschema.enum).toContain("Rejected");
+      expect(subschema.enum).toContain("Withdrawn");
+      expect(subschema.enum).toContain("Note of Interest");
+    });
+
+    test("returns correct subschema for currency pattern", () => {
+      const path = "/offers/offer-123/currency";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("string");
+      expect(subschema.pattern).toBe("^[A-Z]{3}$");
+    });
+
+    test("returns offers object schema", () => {
+      const path = "/offers";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeDefined();
+      expect(subschema.type).toBe("object");
+      expect(subschema.patternProperties).toBeDefined();
+      expect(subschema.propertyNames).toBeDefined();
+    });
+
+    test("returns undefined for invalid path", () => {
+      const path = "/offers/offer-123/invalidField";
+      const subschema = getSubschema(path, schemaId);
+
+      expect(subschema).toBeUndefined();
+    });
+  });
+
+  describe("getSubschemaValidator with patternProperties", () => {
+    test("returns working validator for patternProperties path", () => {
+      const path = "/offers/offer-123";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      expect(validator).toBeDefined();
+      expect(typeof validator).toBe("function");
+
+      const validOffer = {
+        amount: 500000,
+        currency: "GBP",
+        status: "Pending",
+      };
+
+      const isValid = validator(validOffer);
+      expect(isValid).toBe(true);
+    });
+
+    test("validator correctly validates valid offer data", () => {
+      const path = "/offers/offer-456";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      const validOffer = {
+        amount: 300000,
+        currency: "EUR",
+        status: "Accepted",
+        inclusions: ["carpets", "curtains"],
+        exclusions: ["garden furniture"],
+        conditions: ["Subject to survey"],
+      };
+
+      const isValid = validator(validOffer);
+      expect(isValid).toBe(true);
+    });
+
+    test("validator accepts offer data without status (no required fields in schema)", () => {
+      const path = "/offers/offer-789";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      const offer = {
+        amount: 400000,
+        currency: "GBP",
+      };
+
+      const isValid = validator(offer);
+      expect(isValid).toBe(true);
+    });
+
+    test("validator correctly rejects invalid offer data - negative amount", () => {
+      const path = "/offers/offer-999";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      const invalidOffer = {
+        amount: -100000,
+        currency: "GBP",
+        status: "Pending",
+      };
+
+      const isValid = validator(invalidOffer);
+      expect(isValid).toBe(false);
+      expect(validator.errors.some((e) => e.keyword === "minimum")).toBe(true);
+    });
+
+    test("validator correctly rejects invalid offer data - invalid status", () => {
+      const path = "/offers/offer-abc";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      const invalidOffer = {
+        amount: 250000,
+        currency: "GBP",
+        status: "invalid-status",
+      };
+
+      const isValid = validator(invalidOffer);
+      expect(isValid).toBe(false);
+      expect(validator.errors.some((e) => e.keyword === "enum")).toBe(true);
+    });
+
+    test("validator for nested path works correctly", () => {
+      const path = "/offers/offer-nested/amount";
+      const validator = getSubschemaValidator(path, schemaId);
+
+      expect(validator(500000)).toBe(true);
+      expect(validator(0)).toBe(true);
+      expect(validator(-1)).toBe(false);
+      expect(validator("not a number")).toBe(false);
+    });
+  });
+
+  describe("validateVerifiedClaims with patternProperties paths", () => {
+    test("accepts valid claim with patternProperties path", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-001": {
+            amount: 500000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts valid claim with UUID offer ID", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/1sorzJCFHbWVlHA2tYXA": {
+            amount: 750000,
+            currency: "GBP",
+            status: "Accepted",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts valid claim with DID format offer ID", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/did:example:buyer123": {
+            amount: 600000,
+            currency: "EUR",
+            status: "Note of Interest",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts valid claim with nested patternProperties path", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-002/amount": 450000,
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim with all optional offer fields", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-complete": {
+            amount: 550000,
+            currency: "GBP",
+            status: "Accepted",
+            inclusions: ["carpets", "curtains", "light fixtures"],
+            exclusions: ["garden shed"],
+            conditions: ["Subject to survey", "Subject to mortgage approval"],
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim with offer data without status (no required fields in schema)", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-no-status": {
+            amount: 500000,
+            currency: "GBP",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("rejects claim with invalid offer data - negative amount", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-negative": {
+            amount: -100000,
+            currency: "GBP",
+            status: "Pending",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects claim with invalid offer data - invalid status enum", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-bad-status": {
+            amount: 500000,
+            currency: "GBP",
+            status: "completed", // not a valid enum value
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test("rejects claim with invalid offer data - invalid currency format", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-bad-currency": {
+            amount: 500000,
+            currency: "gbp", // should be uppercase
+            status: "Pending",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test("accepts multiple claims with different patternProperties paths", () => {
+      const claims = [
+        {
+          timestamp: 1643115903108,
+          verification: {
+            trust_framework: "uk_pdtf",
+            time: "2025-01-15T12:00:00Z",
+          },
+          claims: {
+            "/offers/offer-1": {
+              amount: 500000,
+              currency: "GBP",
+              status: "Pending",
+            },
+          },
+        },
+        {
+          timestamp: 1643115903109,
+          verification: {
+            trust_framework: "uk_pdtf",
+            time: "2025-01-15T12:01:00Z",
+          },
+          claims: {
+            "/offers/offer-2": {
+              amount: 520000,
+              currency: "GBP",
+              status: "Accepted",
+            },
+          },
+        },
+      ];
+
+      const errors = validateVerifiedClaims(claims, schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim with multiple patternProperties paths", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-1": {
+            amount: 500000,
+            currency: "GBP",
+            status: "Pending",
+          },
+          "/offers/offer-2": {
+            amount: 510000,
+            currency: "GBP",
+            status: "Withdrawn",
+          },
+          "/offers/offer-3/status": "Rejected",
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("rejects claim for non-existent nested property in patternProperties", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/offers/offer-1/nonExistentField": "some value",
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.includes("not a valid PDTF schema path"))).toBe(
+        true
+      );
+    });
+  });
+
+  describe("precedence: explicit properties over patternProperties", () => {
+    // This test documents the expected behavior that explicit properties
+    // should take precedence over patternProperties matches
+    test("explicit property should match before patternProperties", () => {
+      // If offers had an explicit property called "special" and also had
+      // patternProperties that would match "special", the explicit property
+      // should win. This is standard JSON Schema behavior.
+
+      // Since our current schema doesn't have this scenario, this test
+      // documents the expected behavior for future schema changes
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("caching with patternProperties paths", () => {
+    test("caches subschema for patternProperties paths", () => {
+      const path = "/offers/cached-offer-123";
+
+      // First call - cache miss
+      const subschema1 = getSubschema(path, schemaId);
+      expect(subschema1).toBeDefined();
+
+      // Second call - should hit cache
+      const subschema2 = getSubschema(path, schemaId);
+      expect(subschema2).toBeDefined();
+      expect(subschema2).toEqual(subschema1);
+    });
+
+    test("caches validator for patternProperties paths", () => {
+      const path = "/offers/cached-offer-456";
+
+      // First call - cache miss
+      const validator1 = getSubschemaValidator(path, schemaId);
+      expect(validator1).toBeDefined();
+
+      // Second call - should hit cache
+      const validator2 = getSubschemaValidator(path, schemaId);
+      expect(validator2).toBeDefined();
+
+      // Should be the same validator function
+      expect(validator2).toBe(validator1);
+    });
+
+    test("different patternProperties paths get separate cache entries", () => {
+      const path1 = "/offers/offer-aaa";
+      const path2 = "/offers/offer-bbb";
+
+      const validator1 = getSubschemaValidator(path1, schemaId);
+      const validator2 = getSubschemaValidator(path2, schemaId);
+
+      // Both should work but point to same schema (since they match same pattern)
+      expect(validator1).toBeDefined();
+      expect(validator2).toBeDefined();
+
+      // They should be the same since they resolve to the same schema
+      expect(validator1).toBe(validator2);
+    });
+  });
+
+  describe("externalIds patternProperties paths", () => {
+    test("accepts claim for /externalIds with a nested key path", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/nptn/selectedQuoteId": "12345577",
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim for /externalIds with a simple string value", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/lms": "abc-123",
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim for /externalIds with a numeric value", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/systemRef": 98765,
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim for /externalIds with a boolean value", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/isActive": true,
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim for /externalIds with an object value", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/nptn": {
+            selectedQuoteId: "12345577",
+            caseRef: "CASE-001",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim with multiple externalIds paths in same claim", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds/nptn/selectedQuoteId": "12345577",
+          "/externalIds/lms": "LMS-REF-001",
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+
+    test("accepts claim for /externalIds root object", () => {
+      const claim = {
+        timestamp: 1643115903108,
+        verification: {
+          trust_framework: "uk_pdtf",
+          time: "2025-01-15T12:00:00Z",
+        },
+        claims: {
+          "/externalIds": {
+            nptn: {
+              selectedQuoteId: "12345577",
+            },
+            lms: "LMS-REF-001",
+          },
+        },
+      };
+
+      const errors = validateVerifiedClaims([claim], schemaId);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles offer ID with dots", () => {
+      const path = "/offers/offer.123.abc";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("handles offer ID with underscores", () => {
+      const path = "/offers/offer_123_abc";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("handles offer ID with colons (DID format)", () => {
+      const path = "/offers/did:web:example.com:users:alice";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("handles offer ID with plus signs", () => {
+      const path = "/offers/offer+123";
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+
+    test("handles very long offer ID", () => {
+      const longId = "a".repeat(100);
+      const path = `/offers/${longId}`;
+      const isValid = isPathValid(path, schemaId);
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/src/tests/v3/ta6ed6.test.js
+++ b/src/tests/v3/ta6ed6.test.js
@@ -1,0 +1,2374 @@
+const {
+  getTransactionSchema,
+  getSubschemaValidator,
+} = require("../../../index.js");
+const ta6ed6Overlay = require("../../schemas/v3/overlays/ta6ed6.json");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+const collectRequiredWithoutPropertyIssues = (schema) => {
+  const issues = [];
+
+  const walk = (node, path = "#") => {
+    if (!node || typeof node !== "object") return;
+
+    if (Array.isArray(node.required)) {
+      node.required.forEach((propertyName) => {
+        if (!node.properties?.[propertyName]) {
+          issues.push(`${path} requires ${propertyName}`);
+        }
+      });
+    }
+
+    Object.entries(node.properties || {}).forEach(([key, value]) =>
+      walk(value, `${path}/properties/${key}`)
+    );
+    (node.oneOf || []).forEach((value, index) =>
+      walk(value, `${path}/oneOf/${index}`)
+    );
+    if (node.items) walk(node.items, `${path}/items`);
+  };
+
+  walk(schema);
+  return issues;
+};
+
+describe("TA6 Edition 6 overlay", () => {
+  describe("Schema merging", () => {
+    test("merged schema contains ta6ed6Ref annotations", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      expect(schema.properties.propertyPack.properties.address.ta6ed6Ref).toBe(
+        "1.1"
+      );
+      expect(
+        schema.properties.propertyPack.properties.parking.ta6ed6Ref
+      ).toBe("10");
+      expect(
+        schema.properties.propertyPack.properties.electricalWorks.ta6ed6Ref
+      ).toBe("11");
+    });
+
+    test("generated overlay exposes every TA6 edition 6 required property", () => {
+      expect(collectRequiredWithoutPropertyIssues(ta6ed6Overlay)).toEqual([]);
+    });
+
+    test("merged schema has all 22 ta6ed6 required propertyPack sections", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required = schema.properties.propertyPack.required;
+      const expectedRequired = [
+        "address",
+        "parking",
+        "disputesAndComplaints",
+        "alterationsAndChanges",
+        "listingAndConservation",
+        "notices",
+        "specialistIssues",
+        "waterAndDrainage",
+        "electricity",
+        "heating",
+        "connectivity",
+        "insurance",
+        "rightsAndInformalArrangements",
+        "environmentalIssues",
+        "legalBoundaries",
+        "servicesCrossing",
+        "electricalWorks",
+        "guaranteesWarrantiesAndIndemnityInsurances",
+        "occupiers",
+        "completionAndMoving",
+        "confirmationOfAccuracyByOwners",
+        "additionalInformation",
+      ];
+      expectedRequired.forEach((field) => {
+        expect(required).toContain(field);
+      });
+    });
+
+    test("merged schema requires participants and propertyPack at root", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      expect(schema.required).toContain("participants");
+      expect(schema.required).toContain("propertyPack");
+    });
+
+    test("can combine ta6ed6 with baspiV5 overlay", () => {
+      const schema = getTransactionSchema(schemaId, ["baspiV5", "ta6ed6"]);
+      const parkingProp =
+        schema.properties.propertyPack.properties.parking.properties
+          .parkingArrangements;
+      expect(parkingProp.baspi5Ref).toBe("A1.6.0");
+      expect(parkingProp.ta6ed6Ref).toBe("10.1");
+    });
+
+    test("alterationsAndChanges requires ta6ed6-specific fields", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required =
+        schema.properties.propertyPack.properties.alterationsAndChanges
+          .required;
+      expect(required).toContain("windowReplacementsSince2002");
+      expect(required).toContain("hasAddedConservatory");
+      expect(required).toContain("extension");
+      expect(required).toContain("loftConversion");
+      expect(required).toContain("garageConversion");
+      expect(required).toContain("removalOfInternalWalls");
+      expect(required).toContain("removalOfChimneyBreast");
+      expect(required).toContain("insulation");
+      expect(required).toContain("otherBuildingWorksOrChangesToTheProperty");
+      expect(required).not.toContain("changeOfUse"); // removed in ed6
+      expect(required).toContain("planningPermissionBreaches");
+      expect(required).toContain("unresolvedPlanningIssues");
+    });
+
+    test("parking requires parkingArrangements, controlledParking, and electricVehicleChargingPoint", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required =
+        schema.properties.propertyPack.properties.parking.required;
+      expect(required).toEqual(
+        expect.arrayContaining([
+          "parkingArrangements",
+          "controlledParking",
+          "electricVehicleChargingPoint",
+        ])
+      );
+    });
+
+    test("occupiers requires sellerLivesAtProperty and othersAged17OrOver", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required =
+        schema.properties.propertyPack.properties.occupiers.required;
+      expect(required).toContain("sellerLivesAtProperty");
+      expect(required).toContain("othersAged17OrOver");
+    });
+
+    test("completionAndMoving requires sellerWillEnsure and sufficientToRepayAllMortgages", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required =
+        schema.properties.propertyPack.properties.completionAndMoving.required;
+      expect(required).toContain("sellerWillEnsure");
+      expect(required).toContain("sufficientToRepayAllMortgages");
+    });
+
+    test("heating requires ta6ed6-specific fields", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const required =
+        schema.properties.propertyPack.properties.heating.required;
+      expect(required).toContain("heatingSystem");
+      expect(required).toContain("otherHeatingFeatures");
+      expect(required).toContain("multipleHeatingSystems");
+    });
+  });
+
+  describe("Parking section validation", () => {
+    let parkingValidator;
+
+    beforeAll(() => {
+      parkingValidator = getSubschemaValidator(
+        "/propertyPack/parking",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid parking data passes", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(true);
+    });
+
+    test("missing parkingArrangements is invalid", () => {
+      const data = {
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(false);
+      expect(
+        parkingValidator.errors.some((e) =>
+          e.message.includes("'parkingArrangements'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing controlledParking is invalid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        electricVehicleChargingPoint: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(false);
+      expect(
+        parkingValidator.errors.some((e) =>
+          e.message.includes("'controlledParking'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing electricVehicleChargingPoint is invalid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(false);
+      expect(
+        parkingValidator.errors.some((e) =>
+          e.message.includes("'electricVehicleChargingPoint'")
+        )
+      ).toBe(true);
+    });
+
+    test("controlledParking Yes is valid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "Yes" },
+        electricVehicleChargingPoint: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(true);
+    });
+
+    test("controlledParking No is valid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: { yesNo: "No" },
+      };
+      expect(parkingValidator(data)).toBe(true);
+    });
+
+    test("electricVehicleChargingPoint Yes without additional details is invalid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: { yesNo: "Yes" },
+      };
+      expect(parkingValidator(data)).toBe(false);
+      expect(
+        parkingValidator.errors.some((e) =>
+          e.message.includes("'chargerDetails'")
+        )
+      ).toBe(true);
+    });
+
+    test("electricVehicleChargingPoint Yes with all required details is valid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: {
+          yesNo: "Yes",
+          chargerDetails: "7kW home charger",
+          chargerDetailsAttachments: "Attached",
+          cableCrossesPavement: { yesNo: "No" },
+        },
+      };
+      expect(parkingValidator(data)).toBe(true);
+    });
+
+    test("electricVehicleChargingPoint cable crosses pavement Yes without details is invalid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: {
+          yesNo: "Yes",
+          chargerDetails: "7kW home charger",
+          chargerDetailsAttachments: "Attached",
+          cableCrossesPavement: { yesNo: "Yes" },
+        },
+      };
+      expect(parkingValidator(data)).toBe(false);
+      expect(
+        parkingValidator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("electricVehicleChargingPoint cable crosses pavement Yes with details is valid", () => {
+      const data = {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: {
+          yesNo: "Yes",
+          chargerDetails: "7kW home charger",
+          chargerDetailsAttachments: "Attached",
+          cableCrossesPavement: {
+            yesNo: "Yes",
+            details: "Cable runs under pavement with council approval",
+          },
+        },
+      };
+      expect(parkingValidator(data)).toBe(true);
+    });
+  });
+
+  describe("Disputes and complaints validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/disputesAndComplaints",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid disputes data with No answers passes", () => {
+      const data = {
+        hasDisputesAndComplaints: { yesNo: "No" },
+        leadingToDisputesAndComplaints: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("hasDisputesAndComplaints Yes without details is invalid", () => {
+      const data = {
+        hasDisputesAndComplaints: { yesNo: "Yes" },
+        leadingToDisputesAndComplaints: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("hasDisputesAndComplaints Yes with details is valid", () => {
+      const data = {
+        hasDisputesAndComplaints: {
+          yesNo: "Yes",
+          details: "Boundary fence dispute with neighbour",
+        },
+        leadingToDisputesAndComplaints: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("leadingToDisputesAndComplaints Yes without details is invalid", () => {
+      const data = {
+        hasDisputesAndComplaints: { yesNo: "No" },
+        leadingToDisputesAndComplaints: { yesNo: "Yes" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("leadingToDisputesAndComplaints Yes with details is valid", () => {
+      const data = {
+        hasDisputesAndComplaints: { yesNo: "No" },
+        leadingToDisputesAndComplaints: {
+          yesNo: "Yes",
+          details: "Ongoing noise dispute",
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Listing and conservation validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/listingAndConservation",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid data with all No answers passes", () => {
+      const data = {
+        isListed: { yesNo: "No" },
+        isConservationArea: { yesNo: "No" },
+        hasTreePreservationOrder: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("isListed missing yesNo is invalid", () => {
+      const data = {
+        isListed: {},
+        isConservationArea: { yesNo: "No" },
+        hasTreePreservationOrder: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'yesNo'"))
+      ).toBe(true);
+    });
+
+    test("missing isConservationArea is invalid", () => {
+      const data = {
+        isListed: { yesNo: "No" },
+        hasTreePreservationOrder: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'isConservationArea'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing hasTreePreservationOrder is invalid", () => {
+      const data = {
+        isListed: { yesNo: "No" },
+        isConservationArea: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'hasTreePreservationOrder'")
+        )
+      ).toBe(true);
+    });
+
+    test("Not known is valid for isListed and isConservationArea", () => {
+      const data = {
+        isListed: { yesNo: "Not known" },
+        isConservationArea: { yesNo: "Not known" },
+        hasTreePreservationOrder: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Heating section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/heating",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid heating data passes", () => {
+      const data = {
+        heatingSystem: { heatingType: "None" },
+        otherHeatingFeatures: ["None"],
+        multipleHeatingSystems: "Not applicable",
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing heatingSystem is invalid", () => {
+      const data = {
+        otherHeatingFeatures: {},
+        multipleHeatingSystems: {},
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'heatingSystem'"))
+      ).toBe(true);
+    });
+
+    test("missing otherHeatingFeatures is invalid", () => {
+      const data = {
+        heatingSystem: { heatingType: "None" },
+        multipleHeatingSystems: {},
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'otherHeatingFeatures'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Services crossing validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/servicesCrossing",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid data with all No answers passes", () => {
+      const data = {
+        pipesWiresCablesDrainsToProperty: { yesNo: "No" },
+        pipesWiresCablesDrainsFromProperty: { yesNo: "No" },
+        formalOrInformalAgreements: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing pipesWiresCablesDrainsToProperty is invalid", () => {
+      const data = {
+        pipesWiresCablesDrainsFromProperty: { yesNo: "No" },
+        formalOrInformalAgreements: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'pipesWiresCablesDrainsToProperty'")
+        )
+      ).toBe(true);
+    });
+
+    test("pipesWiresCablesDrainsToProperty Yes without details is invalid", () => {
+      const data = {
+        pipesWiresCablesDrainsToProperty: { yesNo: "Yes" },
+        pipesWiresCablesDrainsFromProperty: { yesNo: "No" },
+        formalOrInformalAgreements: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("pipesWiresCablesDrainsToProperty Yes with details is valid", () => {
+      const data = {
+        pipesWiresCablesDrainsToProperty: {
+          yesNo: "Yes",
+          details: "Shared drainage pipe runs from next door",
+        },
+        pipesWiresCablesDrainsFromProperty: { yesNo: "No" },
+        formalOrInformalAgreements: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Electrical works validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/electricalWorks",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid data with all No answers passes", () => {
+      const data = {
+        testedByQualifiedElectrician: { yesNo: "No" },
+        electricalWorkSince2005: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing testedByQualifiedElectrician is invalid", () => {
+      const data = {
+        electricalWorkSince2005: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'testedByQualifiedElectrician'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing electricalWorkSince2005 is invalid", () => {
+      const data = {
+        testedByQualifiedElectrician: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'electricalWorkSince2005'")
+        )
+      ).toBe(true);
+    });
+
+    test("testedByQualifiedElectrician Yes with year and attachments is valid", () => {
+      const data = {
+        testedByQualifiedElectrician: {
+          yesNo: "Yes",
+          yearTested: 2023,
+          attachments: "Attached",
+        },
+        electricalWorkSince2005: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("electricalWorkSince2005 Yes with details and certificate is valid", () => {
+      const data = {
+        testedByQualifiedElectrician: { yesNo: "No" },
+        electricalWorkSince2005: {
+          yesNo: "Yes",
+          details: "Rewired ground floor",
+          yearWorkCarriedOut: 2020,
+          suppliedCertificate: {
+            certificateType: "Electrical Safety Certificate (BS7671)",
+            attachments: "Attached",
+          },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Occupiers section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/occupiers",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid occupiers data passes", () => {
+      const data = {
+        sellerLivesAtProperty: { yesNo: "Yes" },
+        othersAged17OrOver: { hasOthersAged17OrOver: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing sellerLivesAtProperty is invalid", () => {
+      const data = {
+        othersAged17OrOver: { hasOthersAged17OrOver: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'sellerLivesAtProperty'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing othersAged17OrOver is invalid", () => {
+      const data = {
+        sellerLivesAtProperty: { yesNo: "Yes" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'othersAged17OrOver'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Completion and moving validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/completionAndMoving",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid completion data passes", () => {
+      const data = {
+        sellerWillEnsure: {
+          removeRubbish: true,
+          replaceLightFittings: true,
+          takeReasonableCare: true,
+          leaveKeys: true,
+        },
+        sufficientToRepayAllMortgages: { yesNo: "Yes" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing sellerWillEnsure is invalid", () => {
+      const data = {
+        sufficientToRepayAllMortgages: { yesNo: "Yes" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'sellerWillEnsure'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing sufficientToRepayAllMortgages is invalid", () => {
+      const data = {
+        sellerWillEnsure: {
+          removeRubbish: true,
+          replaceLightFittings: true,
+          takeReasonableCare: true,
+          leaveKeys: true,
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'sufficientToRepayAllMortgages'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Connectivity validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/connectivity",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid connectivity with telephone Yes passes", () => {
+      const data = {
+        telephone: { yesNo: "Yes", supplier: "BT" },
+        broadband: { typeOfConnection: "None" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing telephone is invalid", () => {
+      const data = { broadband: { typeOfConnection: "None" } };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'telephone'"))
+      ).toBe(true);
+    });
+
+    test("telephone No is valid", () => {
+      const data = {
+        telephone: { yesNo: "No" },
+        broadband: { typeOfConnection: "None" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Insurance section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/insurance",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("isInsured is a string enum in merged schema", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const isInsured =
+        schema.properties.propertyPack.properties.insurance.properties
+          .isInsured;
+      expect(isInsured.type).toBe("string");
+      expect(isInsured.enum).toEqual(["Yes", "No"]);
+    });
+
+    test("isInsured Yes with insuranceClaims is valid", () => {
+      const data = {
+        isInsured: "Yes",
+        difficultiesObtainingInsurance: {
+          abnormalRiseInPremiums: { yesNo: "No" },
+          subjectToHighExcesses: { yesNo: "No" },
+          subjectToUnusualConditions: { yesNo: "No" },
+          refused: { yesNo: "No" },
+        },
+        insuranceClaims: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("isInsured No with whoInsures is valid", () => {
+      const data = {
+        isInsured: "No",
+        difficultiesObtainingInsurance: {
+          abnormalRiseInPremiums: { yesNo: "No" },
+          subjectToHighExcesses: { yesNo: "No" },
+          subjectToUnusualConditions: { yesNo: "No" },
+          refused: { yesNo: "No" },
+        },
+        whoInsures: "Landlord insures the building",
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("isInsured Yes without insuranceClaims is invalid", () => {
+      const data = {
+        isInsured: "Yes",
+        difficultiesObtainingInsurance: {
+          abnormalRiseInPremiums: { yesNo: "No" },
+          subjectToHighExcesses: { yesNo: "No" },
+          subjectToUnusualConditions: { yesNo: "No" },
+          refused: { yesNo: "No" },
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'insuranceClaims'"))
+      ).toBe(true);
+    });
+
+    test("isInsured No without whoInsures is invalid", () => {
+      const data = {
+        isInsured: "No",
+        difficultiesObtainingInsurance: { yesNo: "No" },
+        insuranceClaims: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'whoInsures'"))
+      ).toBe(true);
+    });
+
+    test("missing isInsured is invalid", () => {
+      const data = {
+        difficultiesObtainingInsurance: { yesNo: "No" },
+        insuranceClaims: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'isInsured'"))
+      ).toBe(true);
+    });
+
+    test("missing difficultiesObtainingInsurance is invalid", () => {
+      const data = {
+        isInsured: "Yes",
+        insuranceClaims: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'difficultiesObtainingInsurance'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Confirmation of accuracy validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/confirmationOfAccuracyByOwners",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid confirmation data passes", () => {
+      const data = {
+        confirmInformationIsAccurate: true,
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing confirmInformationIsAccurate is invalid", () => {
+      const data = {};
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'confirmInformationIsAccurate'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Rights and informal arrangements validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/rightsAndInformalArrangements",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid data with all No answers passes", () => {
+      const data = {
+        neighbouringLandRights: { yesNo: "No" },
+        sharedContributions: { yesNo: "No" },
+        rightsOrArrangements: {
+          publicRightOfWay: { yesNo: "No" },
+          rightsOfLight: { yesNo: "No" },
+          rightsOfSupport: { yesNo: "No" },
+          rightsCreatedThroughCustom: { yesNo: "No" },
+          minesAndMinerals: { yesNo: "No" },
+          churchChancel: { yesNo: "No" },
+          rightsToTakeFromLand: { yesNo: "No" },
+          otherRights: { yesNo: "No" },
+          disagreementOrComplaint: { yesNo: "No" },
+        },
+        rightsOverProperty: { yesNo: "No" },
+        askedOthersToContribute: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing neighbouringLandRights is invalid", () => {
+      const data = {
+        sharedContributions: { yesNo: "No" },
+        disagreementAboutRightsYouExercise: { yesNo: "No" },
+        rightsOverProperty: { yesNo: "No" },
+        askedOthersToContribute: { yesNo: "No" },
+        accessRestrictionAttempts: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'neighbouringLandRights'")
+        )
+      ).toBe(true);
+    });
+
+    test("missing all required fields is invalid", () => {
+      const data = {};
+      expect(validator(data)).toBe(false);
+      const errorMessages = validator.errors.map((e) => e.message);
+      expect(errorMessages).toContain(
+        "must have required property 'neighbouringLandRights'"
+      );
+      expect(errorMessages).toContain(
+        "must have required property 'sharedContributions'"
+      );
+    });
+  });
+
+  describe("Specialist issues validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/specialistIssues",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid specialist issues data passes", () => {
+      const data = {
+        dryRotEtcTreatment: { yesNo: "No" },
+        containsAsbestos: { yesNo: "No" },
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: { yesNo: "No" },
+        },
+        subsidenceOrStructuralFault: { yesNo: "No" },
+        ongoingHealthOrSafetyIssue: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing japaneseKnotweed is invalid (required by overlay)", () => {
+      const data = {};
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'japaneseKnotweed'")
+        )
+      ).toBe(true);
+    });
+
+    test("japaneseKnotweed missing knotweedSurveyCarriedOut is invalid", () => {
+      const data = {
+        japaneseKnotweed: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'knotweedSurveyCarriedOut'")
+        )
+      ).toBe(true);
+    });
+
+    test("knotweedSurveyCarriedOut No is valid without attachments", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: { yesNo: "No" },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("knotweedSurveyCarriedOut Not known is valid without attachments", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: { yesNo: "Not known" },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("knotweedSurveyCarriedOut Yes without attachments is invalid", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: { yesNo: "Yes" },
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'attachments'")
+        )
+      ).toBe(true);
+    });
+
+    test("knotweedSurveyCarriedOut Yes with attachments is valid", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: {
+            yesNo: "Yes",
+            attachments: "Attached",
+          },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("knotweedSurveyCarriedOut Yes with To follow attachments is valid", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "No",
+          knotweedSurveyCarriedOut: {
+            yesNo: "Yes",
+            attachments: "To follow",
+          },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("japaneseKnotweed Yes with management plan and survey is valid", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "Yes",
+          managementPlanInPlace: "Yes",
+          attachments: "Attached",
+          knotweedSurveyCarriedOut: {
+            yesNo: "Yes",
+            attachments: "Attached",
+          },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("japaneseKnotweed Yes with management plan No does not require attachments", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "Yes",
+          managementPlanInPlace: "No",
+          knotweedSurveyCarriedOut: { yesNo: "No" },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("japaneseKnotweed Yes with management plan Yes without attachments is invalid", () => {
+      const data = {
+        japaneseKnotweed: {
+          yesNo: "Yes",
+          managementPlanInPlace: "Yes",
+          knotweedSurveyCarriedOut: { yesNo: "No" },
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'attachments'")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("Alterations section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/alterationsAndChanges",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("all No answers passes", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: { yesNo: "No" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing extension is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'extension'"))
+      ).toBe(true);
+    });
+
+    test("extension Yes without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: { yesNo: "Yes" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("extension Yes with details is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Single storey rear extension built 2018",
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("extension Yes with full details including nested discriminators is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Single storey rear extension built 2018",
+          workCompleted: { yesNo: "Yes" },
+          documents: "Attached",
+          planningPermission: { yesNo: "Yes", attachments: "Attached" },
+          buildingRegApproval: { yesNo: "Yes", attachments: "Attached" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("workCompleted No without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Extension built 2020",
+          workCompleted: { yesNo: "No" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("workCompleted No with details is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Extension built 2020",
+          workCompleted: {
+            yesNo: "No",
+            details: "Roof tiles still to be completed",
+          },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("windowReplacementsSince2002 Yes with details is valid", () => {
+      const data = {
+        windowReplacementsSince2002: {
+          yesNo: "Yes",
+          details: "All windows replaced with double glazing in 2015",
+        },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: { yesNo: "No" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("hasAddedConservatory Yes without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "Yes" },
+        extension: { yesNo: "No" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("multiple alteration types with Yes answers all valid", () => {
+      const data = {
+        windowReplacementsSince2002: {
+          yesNo: "Yes",
+          details: "Double glazing throughout",
+        },
+        hasAddedConservatory: {
+          yesNo: "Yes",
+          details: "Rear conservatory 2019",
+        },
+        extension: { yesNo: "No" },
+        loftConversion: {
+          yesNo: "Yes",
+          details: "Loft converted to bedroom 2017",
+          workCompleted: { yesNo: "Yes" },
+          planningPermission: {
+            yesNo: "Not required",
+            details: "Permitted development rights applied",
+          },
+          buildingRegApproval: {
+            yesNo: "Yes",
+            attachments: "Attached",
+          },
+        },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("extension planningPermission Yes without attachments is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: { yesNo: "Yes" },
+          buildingRegApproval: { yesNo: "Yes", attachments: "Attached" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'attachments'"))
+      ).toBe(true);
+    });
+
+    test("extension planningPermission Yes with attachments is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: { yesNo: "Yes", attachments: "Attached" },
+          buildingRegApproval: { yesNo: "Yes", attachments: "Attached" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("extension planningPermission No without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: { yesNo: "No" },
+          buildingRegApproval: { yesNo: "No", details: "Exempt from regs" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("extension planningPermission No with details is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: {
+            yesNo: "No",
+            details: "Permitted development rights applied",
+          },
+          buildingRegApproval: {
+            yesNo: "No",
+            details: "Exempt from building regulations",
+          },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("extension planningPermission Not required without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: { yesNo: "Not required" },
+          buildingRegApproval: {
+            yesNo: "Not required",
+            details: "Work exempt",
+          },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("extension buildingRegApproval Yes without attachments is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: { yesNo: "Yes", attachments: "Attached" },
+          buildingRegApproval: { yesNo: "Yes" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'attachments'"))
+      ).toBe(true);
+    });
+
+    test("extension buildingRegApproval No without details is invalid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: {
+            yesNo: "No",
+            details: "Permitted development",
+          },
+          buildingRegApproval: { yesNo: "No" },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'details'"))
+      ).toBe(true);
+    });
+
+    test("extension buildingRegApproval Not required with details is valid", () => {
+      const data = {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: {
+          yesNo: "Yes",
+          details: "Rear extension 2020",
+          planningPermission: {
+            yesNo: "Not required",
+            details: "Permitted development rights applied",
+          },
+          buildingRegApproval: {
+            yesNo: "Not required",
+            details: "Work exempt from building regulations",
+          },
+        },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Water and drainage section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/waterAndDrainage",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("valid water and drainage with mains passes", () => {
+      const data = {
+        water: {
+          mainsWater: {
+            yesNo: "Yes",
+            supplier: "Thames Water",
+            stopcock: { location: "Under the stairs" },
+            waterMeter: { isSupplyMetered: "No" },
+          },
+        },
+        drainage: {
+          mainsFoulDrainage: { yesNo: "Yes", supplier: "Thames Water" },
+          mainsSurfaceWaterDrainage: { yesNo: "Yes" },
+          offMainsDrainageSystem: {},
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing drainage is invalid", () => {
+      const data = {
+        water: {
+          mainsWater: {
+            yesNo: "Yes",
+            supplier: "Thames Water",
+            stopcock: { location: "Under the stairs" },
+            waterMeter: { isSupplyMetered: "No" },
+          },
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'drainage'"))
+      ).toBe(true);
+    });
+
+    test("missing water is invalid", () => {
+      const data = {
+        drainage: {
+          mainsFoulDrainage: { yesNo: "Yes", supplier: "Thames Water" },
+          mainsSurfaceWaterDrainage: { yesNo: "Yes" },
+          offMainsDrainageSystem: {},
+        },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'water'"))
+      ).toBe(true);
+    });
+
+    test("mainsFoulDrainage is an object with discriminator in merged schema", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const mfd =
+        schema.properties.propertyPack.properties.waterAndDrainage.properties
+          .drainage.properties.mainsFoulDrainage;
+      expect(mfd.type).toBe("object");
+      expect(mfd.oneOf).toBeDefined();
+      expect(mfd.discriminator).toBeDefined();
+    });
+
+    test("plant registered yesNo carries TA6 edition 6 ref", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const plantRegistered =
+        schema.properties.propertyPack.properties.waterAndDrainage.properties
+          .drainage.properties.mainsFoulDrainage.oneOf[2].properties
+          .offMainsDrainageSystem.properties.plantRegistered;
+      expect(plantRegistered.ta6ed6Ref).toBe("11.7j");
+      expect(plantRegistered.properties.yesNo.ta6ed6Ref).toBe("11.7j");
+    });
+
+    test("mainsFoulDrainage No with object is accepted", () => {
+      const data = {
+        water: {
+          mainsWater: {
+            yesNo: "Yes",
+            supplier: "Thames Water",
+            stopcock: { location: "Kitchen" },
+            waterMeter: { isSupplyMetered: "No" },
+          },
+        },
+        drainage: {
+          mainsFoulDrainage: {
+            yesNo: "No",
+            offMainsDrainageSystem: {
+              offMainsDrainageSystemType: "Other",
+              otherConnectedProperties: { yesNo: "No" },
+              plantOnOtherLand: { yesNo: "No" },
+              plantRegistered: { yesNo: "No" },
+              plantDrainsIntoWaterway: { yesNo: "Yes" },
+            },
+          },
+          mainsSurfaceWaterDrainage: { yesNo: "Yes" },
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("mainsSurfaceWaterDrainage is an object with yesNo discriminator", () => {
+      const schema = getTransactionSchema(schemaId, ["ta6ed6"]);
+      const mswd =
+        schema.properties.propertyPack.properties.waterAndDrainage.properties
+          .drainage.properties.mainsSurfaceWaterDrainage;
+      expect(mswd.type).toBe("object");
+      expect(mswd.properties.yesNo.enum).toEqual(["Yes", "No", "Not known"]);
+    });
+  });
+
+  describe("Solar panels validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/electricity",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("solarPanels No is valid", () => {
+      const data = {
+        mainsElectricity: {
+          yesNo: "Yes",
+          supplier: "British Gas",
+          electricityMeter: { location: "Hall cupboard", mpan: "1234567890123" },
+        },
+        solarPanels: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("solarPanels Yes without required sub-properties is invalid", () => {
+      const data = {
+        mainsElectricity: {
+          yesNo: "Yes",
+          supplier: "British Gas",
+          electricityMeter: { location: "Hall cupboard", mpan: "1234567890123" },
+        },
+        solarPanels: { yesNo: "Yes" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'hotWaterOnly'")
+        )
+      ).toBe(true);
+    });
+
+    test("solarPanels Yes with all required sub-properties is valid", () => {
+      const data = {
+        mainsElectricity: {
+          yesNo: "Yes",
+          supplier: "British Gas",
+          electricityMeter: { location: "Hall cupboard", mpan: "1234567890123" },
+        },
+        solarPanels: {
+          yesNo: "Yes",
+          hotWaterOnly: "No",
+          yearInstalled: 2020,
+          panelsOwnedOutright: { yesNo: "Yes" },
+          panelProviderLease: { yesNo: "No" },
+          maintenanceAgreement: { yesNo: "No" },
+          photovoltaicBatteries: { yesNo: "No" },
+          nationalGrid: { yesNo: "No" },
+          installationCertificates: "Attached",
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("solarPanels Yes with battery details and nationalGrid is valid", () => {
+      const data = {
+        mainsElectricity: {
+          yesNo: "Yes",
+          supplier: "British Gas",
+          electricityMeter: { location: "Hall cupboard", mpan: "1234567890123" },
+        },
+        solarPanels: {
+          yesNo: "Yes",
+          hotWaterOnly: "No",
+          yearInstalled: 2021,
+          panelsOwnedOutright: { yesNo: "Yes" },
+          panelProviderLease: { yesNo: "No" },
+          maintenanceAgreement: { yesNo: "Yes", attachments: "Attached" },
+          photovoltaicBatteries: {
+            yesNo: "Yes",
+            description: "Garage wall",
+            details: "Tesla Powerwall 13.5kWh",
+          },
+          nationalGrid: { yesNo: "Yes", fitOrSegInPlace: { yesNo: "No" } },
+          installationCertificates: "Attached",
+        },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Notices section validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/notices",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("all No answers passes", () => {
+      const data = {
+        neighbourDevelopment: { yesNo: "No" },
+        planningApplication: { yesNo: "No" },
+        requiredMaintenance: { yesNo: "No" },
+        listedBuildingApplication: { yesNo: "No" },
+        infrastructureProject: { yesNo: "No" },
+        partyWallAct: { yesNo: "No" },
+        otherNotices: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing neighbourDevelopment is invalid", () => {
+      const data = {
+        planningApplication: { yesNo: "No" },
+        partyWallAct: { yesNo: "No" },
+        otherNotices: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'neighbourDevelopment'")
+        )
+      ).toBe(true);
+    });
+
+    test("neighbourDevelopment Yes with details is valid", () => {
+      const data = {
+        neighbourDevelopment: {
+          yesNo: "Yes",
+          details: "Neighbour planning a two-storey extension",
+        },
+        planningApplication: { yesNo: "No" },
+        partyWallAct: { yesNo: "No" },
+        otherNotices: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("partyWallAct Yes with details is valid", () => {
+      const data = {
+        neighbourDevelopment: { yesNo: "No" },
+        planningApplication: { yesNo: "No" },
+        partyWallAct: {
+          yesNo: "Yes",
+          details: "Party wall notice served by neighbour for loft conversion",
+        },
+        otherNotices: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Environmental issues validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/environmentalIssues",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("all No answers passes", () => {
+      const data = {
+        flooding: {
+          historicalFlooding: { hasBeenFlooded: "No" },
+          floodDefences: { hasFloodDefences: "No" },
+        },
+        radon: {
+          radonTest: { yesNo: "No" },
+          remedialMeasuresOnConstruction: { yesNo: "No" },
+        },
+        greenDealScheme: { hasGreenDealLoan: { yesNo: "No" } },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing flooding is invalid", () => {
+      const data = {
+        radon: {
+          radonTest: { yesNo: "No" },
+          remedialMeasuresOnConstruction: { yesNo: "No" },
+        },
+        greenDealScheme: { hasGreenDealLoan: { yesNo: "No" } },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'flooding'"))
+      ).toBe(true);
+    });
+
+    test("historicalFlooding Yes with type and details is valid", () => {
+      const data = {
+        flooding: {
+          historicalFlooding: {
+            hasBeenFlooded: "Yes",
+            typeOfFlooding: ["Surface water"],
+            details: "Minor surface water flooding in 2020 winter storms",
+          },
+          floodDefences: { hasFloodDefences: "No" },
+        },
+        radon: {
+          radonTest: { yesNo: "No" },
+          remedialMeasuresOnConstruction: { yesNo: "No" },
+        },
+        greenDealScheme: { hasGreenDealLoan: { yesNo: "No" } },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("floodDefences Yes with details is valid", () => {
+      const data = {
+        flooding: {
+          historicalFlooding: { hasBeenFlooded: "No" },
+          floodDefences: {
+            hasFloodDefences: "Yes",
+            details: "Flood barrier installed by EA in 2018",
+          },
+        },
+        radon: {
+          radonTest: { yesNo: "No" },
+          remedialMeasuresOnConstruction: { yesNo: "No" },
+        },
+        greenDealScheme: { hasGreenDealLoan: { yesNo: "No" } },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Legal boundaries validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/legalBoundaries",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("uniform boundaries with all sides specified passes", () => {
+      // The merged schema requires both uniformBoundaries and irregularBoundaries
+      // (union of required arrays from base and overlay oneOf branches).
+      // When areBoundariesUniform is "Yes", provide irregularBoundaries with yesNo: "No".
+      const data = {
+        ownership: {
+          areBoundariesUniform: "Yes",
+          uniformBoundaries: {
+            left: "Seller",
+            right: "Neighbour",
+            rear: "Seller",
+            front: "Not known",
+          },
+          irregularBoundaries: { yesNo: "No" },
+        },
+        haveBoundaryFeaturesMoved: { yesNo: "No" },
+        flyingFreehold: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing ownership is invalid", () => {
+      const data = {
+        haveBoundaryFeaturesMoved: { yesNo: "No" },
+        flyingFreehold: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'ownership'"))
+      ).toBe(true);
+    });
+
+    test("missing haveBoundaryFeaturesMoved is invalid", () => {
+      const data = {
+        ownership: {
+          areBoundariesUniform: "Yes",
+          uniformBoundaries: {
+            left: "Seller",
+            right: "Seller",
+            rear: "Seller",
+            front: "Seller",
+          },
+          irregularBoundaries: { yesNo: "No" },
+        },
+        flyingFreehold: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'haveBoundaryFeaturesMoved'")
+        )
+      ).toBe(true);
+    });
+
+    test("boundaries Not applicable is valid", () => {
+      // Even for "Not applicable", the merged schema requires uniformBoundaries
+      // and irregularBoundaries due to required array union from overlays.
+      const data = {
+        ownership: {
+          areBoundariesUniform: "Not applicable",
+          uniformBoundaries: {
+            left: "Not known",
+            right: "Not known",
+            rear: "Not known",
+            front: "Not known",
+          },
+          irregularBoundaries: { yesNo: "No" },
+        },
+        haveBoundaryFeaturesMoved: { yesNo: "No" },
+        flyingFreehold: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("haveBoundaryFeaturesMoved Yes with details is valid", () => {
+      const data = {
+        ownership: {
+          areBoundariesUniform: "Yes",
+          uniformBoundaries: {
+            left: "Seller",
+            right: "Neighbour",
+            rear: "Shared",
+            front: "Seller",
+          },
+          irregularBoundaries: { yesNo: "No" },
+        },
+        haveBoundaryFeaturesMoved: {
+          yesNo: "Yes",
+          details: "Rear fence moved by 30cm after storm damage",
+        },
+        flyingFreehold: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Guarantees warranties and indemnity insurances validation", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator(
+        "/propertyPack/guaranteesWarrantiesAndIndemnityInsurances",
+        schemaId,
+        ["ta6ed6"]
+      );
+    });
+
+    test("all No answers passes", () => {
+      const data = {
+        hasValidGuaranteesOrWarranties: "No",
+        newHomeWarranty: { yesNo: "No" },
+        dampProofingTreatment: { yesNo: "No" },
+        timberRotOrInfestationTreatment: { yesNo: "No" },
+        doubleGlazing: { yesNo: "No" },
+        roofingWork: { yesNo: "No" },
+        centralHeatingAndorPlumbing: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherGuarantees: { yesNo: "No" },
+        outstandingClaimsOrApplications: { yesNo: "No" },
+        breachOfTermsOrConditions: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("missing hasValidGuaranteesOrWarranties is invalid", () => {
+      const data = {
+        newHomeWarranty: { yesNo: "No" },
+        dampProofingTreatment: { yesNo: "No" },
+        timberRotOrInfestationTreatment: { yesNo: "No" },
+        doubleGlazing: { yesNo: "No" },
+        roofingWork: { yesNo: "No" },
+        centralHeatingAndorPlumbing: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherGuarantees: { yesNo: "No" },
+        outstandingClaimsOrApplications: { yesNo: "No" },
+        breachOfTermsOrConditions: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) =>
+          e.message.includes("'hasValidGuaranteesOrWarranties'")
+        )
+      ).toBe(true);
+    });
+
+    test("newHomeWarranty Yes with attachments is valid", () => {
+      const data = {
+        hasValidGuaranteesOrWarranties: "Yes",
+        newHomeWarranty: { yesNo: "Yes", attachments: "Attached" },
+        dampProofingTreatment: { yesNo: "No" },
+        timberRotOrInfestationTreatment: { yesNo: "No" },
+        doubleGlazing: { yesNo: "No" },
+        roofingWork: { yesNo: "No" },
+        centralHeatingAndorPlumbing: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherGuarantees: { yesNo: "No" },
+        outstandingClaimsOrApplications: { yesNo: "No" },
+        breachOfTermsOrConditions: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+
+    test("newHomeWarranty Yes without attachments is invalid", () => {
+      const data = {
+        hasValidGuaranteesOrWarranties: "Yes",
+        newHomeWarranty: { yesNo: "Yes" },
+        dampProofingTreatment: { yesNo: "No" },
+        timberRotOrInfestationTreatment: { yesNo: "No" },
+        doubleGlazing: { yesNo: "No" },
+        roofingWork: { yesNo: "No" },
+        centralHeatingAndorPlumbing: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherGuarantees: { yesNo: "No" },
+        outstandingClaimsOrApplications: { yesNo: "No" },
+        breachOfTermsOrConditions: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'attachments'"))
+      ).toBe(true);
+    });
+
+    test("multiple guarantees with Yes answers all valid", () => {
+      const data = {
+        hasValidGuaranteesOrWarranties: "Yes",
+        newHomeWarranty: { yesNo: "Yes", attachments: "Attached" },
+        dampProofingTreatment: { yesNo: "Yes", attachments: "To follow" },
+        timberRotOrInfestationTreatment: { yesNo: "No" },
+        doubleGlazing: { yesNo: "Yes", attachments: "Attached" },
+        roofingWork: { yesNo: "No" },
+        centralHeatingAndorPlumbing: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        subsidenceWork: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherGuarantees: { yesNo: "No" },
+        outstandingClaimsOrApplications: { yesNo: "No" },
+        breachOfTermsOrConditions: { yesNo: "No" },
+      };
+      expect(validator(data)).toBe(true);
+    });
+  });
+
+  describe("Previously broken discriminator sections now compile", () => {
+    // These sections previously failed AJV compilation because their
+    // discriminated properties were not in the required array of each
+    // oneOf branch. This has been fixed in combined.json.
+
+    const sections = [
+      "alterationsAndChanges",
+      "notices",
+      "waterAndDrainage",
+      "electricity",
+      "environmentalIssues",
+      "legalBoundaries",
+      "guaranteesWarrantiesAndIndemnityInsurances",
+    ];
+
+    test.each(sections)(
+      "%s subschema validator compiles successfully",
+      (section) => {
+        const validator = getSubschemaValidator(
+          `/propertyPack/${section}`,
+          schemaId,
+          ["ta6ed6"]
+        );
+        expect(typeof validator).toBe("function");
+      }
+    );
+
+    test("full transaction validator compiles successfully", () => {
+      const validator = getSubschemaValidator("", schemaId, ["ta6ed6"]);
+      expect(typeof validator).toBe("function");
+    });
+  });
+
+  describe("Full transaction validation with ta6ed6", () => {
+    let validator;
+
+    beforeAll(() => {
+      validator = getSubschemaValidator("", schemaId, ["ta6ed6"]);
+    });
+
+    test("example transaction is invalid under ta6ed6 (missing required sections)", () => {
+      const exampleTransaction = require("../../examples/v3/exampleTransaction.json");
+      expect(validator(exampleTransaction)).toBe(false);
+      const errorMessages = validator.errors.map((e) => e.message);
+      expect(errorMessages).toContain(
+        "must have required property 'consents'"
+      );
+    });
+
+    test("transaction missing required propertyPack section is invalid", () => {
+      const transaction = buildMinimalTransaction();
+      delete transaction.propertyPack.parking;
+      expect(validator(transaction)).toBe(false);
+      expect(
+        validator.errors.some((e) => e.message.includes("'parking'"))
+      ).toBe(true);
+    });
+  });
+});
+
+/**
+ * Builds a minimal transaction object for testing missing-section validation.
+ * Note: this transaction may not fully pass validation due to known schema
+ * merge conflicts (e.g. insurance.isInsured type/enum conflict, capacity
+ * enum mismatch), but it contains all required propertyPack sections so
+ * we can test that removing one is detected.
+ */
+function buildMinimalTransaction() {
+  return {
+    transactionId: "test-ta6ed6",
+    status: "For sale",
+    participants: [
+      {
+        role: "Seller",
+        name: { firstName: "Jane", lastName: "Doe" },
+        email: "jane@example.com",
+        address: { line1: "1 Test St", postcode: "SW1A 1AA" },
+        organisation: "Self",
+        sellersCapacity: { capacity: "Legal Owner" },
+      },
+      {
+        role: "Seller's Conveyancer",
+        name: { firstName: "John", lastName: "Law" },
+        email: "john@law.co.uk",
+        address: { line1: "2 Law Lane", postcode: "EC1A 1BB" },
+        organisation: "Law Firm LLP",
+        organisationReference: "REF001",
+      },
+    ],
+    propertyPack: {
+      address: { line1: "1 Test St", postcode: "SW1A 1AA" },
+      parking: {
+        parkingArrangements: ["Driveway"],
+        controlledParking: { yesNo: "No" },
+        electricVehicleChargingPoint: { yesNo: "No" },
+      },
+      disputesAndComplaints: {
+        hasDisputesAndComplaints: { yesNo: "No" },
+        leadingToDisputesAndComplaints: { yesNo: "No" },
+      },
+      alterationsAndChanges: {
+        windowReplacementsSince2002: { yesNo: "No" },
+        hasAddedConservatory: { yesNo: "No" },
+        extension: { yesNo: "No" },
+        loftConversion: { yesNo: "No" },
+        garageConversion: { yesNo: "No" },
+        removalOfInternalWalls: { yesNo: "No" },
+        removalOfChimneyBreast: { yesNo: "No" },
+        insulation: { yesNo: "No" },
+        otherBuildingWorksOrChangesToTheProperty: { yesNo: "No" },
+        changeOfUse: { yesNo: "No" },
+        nonResidentialPurposes: { yesNo: "No" },
+        planningPermissionBreaches: { yesNo: "No" },
+        unresolvedPlanningIssues: { yesNo: "No" },
+      },
+      listingAndConservation: {
+        isListed: { yesNo: "No" },
+        isConservationArea: { yesNo: "No" },
+        hasTreePreservationOrder: { yesNo: "No" },
+      },
+      notices: {
+        neighbourDevelopment: { yesNo: "No" },
+        planningApplication: { yesNo: "No" },
+        requiredMaintenance: { yesNo: "No" },
+        listedBuildingApplication: { yesNo: "No" },
+        infrastructureProject: { yesNo: "No" },
+        partyWallAct: { yesNo: "No" },
+        otherNotices: { yesNo: "No" },
+      },
+      specialistIssues: {},
+      waterAndDrainage: {
+        water: {
+          mainsWater: {
+            yesNo: "Yes",
+            supplier: "Thames Water",
+            stopcock: { location: "Under the stairs" },
+            waterMeter: { isSupplyMetered: "No" },
+          },
+        },
+        drainage: {
+          mainsFoulDrainage: { yesNo: "Yes", supplier: "Thames Water" },
+          mainsSurfaceWaterDrainage: { yesNo: "Yes" },
+          offMainsDrainageSystem: {},
+        },
+      },
+      electricity: {
+        mainsElectricity: {
+          yesNo: "Yes",
+          supplier: "British Gas",
+          electricityMeter: { location: "Hall cupboard" },
+        },
+        solarPanels: { yesNo: "No" },
+      },
+      heating: {
+        heatingTypes: ["Central heating"],
+        heatingOtherDetails: "Gas central heating",
+        heatingSystemInstalledDate: "2015",
+        boilerInstalledDate: "2015",
+        heatingReplacementOtherThanBoiler: "No",
+        heatingComplianceDocs: "None",
+        heatingInspectionReport: "None",
+        boilerWorking: "Yes",
+        boilerLastServicedYear: "2024",
+        multipleHeatingSystemsAttachment: "Attached",
+      },
+      connectivity: {
+        telephone: { yesNo: "Yes", supplier: "BT" },
+        broadband: { typeOfConnection: "None" },
+      },
+      insurance: {
+        isInsured: "Yes",
+        difficultiesObtainingInsurance: { yesNo: "No" },
+        insuranceClaims: { yesNo: "No" },
+      },
+      rightsAndInformalArrangements: {
+        neighbouringLandRights: { yesNo: "No" },
+        sharedContributions: { yesNo: "No" },
+        disagreementAboutRightsYouExercise: { yesNo: "No" },
+        rightsOverProperty: { yesNo: "No" },
+        askedOthersToContribute: { yesNo: "No" },
+        accessRestrictionAttempts: { yesNo: "No" },
+      },
+      environmentalIssues: {
+        flooding: {
+          historicalFlooding: { hasBeenFlooded: "No" },
+          floodDefences: { hasFloodDefences: "No" },
+        },
+        radon: { yesNo: "No" },
+        radonRemedialMeasures: { yesNo: "No" },
+        greenDealScheme: { yesNo: "No" },
+        japaneseKnotweed: { yesNo: "No" },
+        japaneseKnotweedSurvey: { yesNo: "No" },
+      },
+      legalBoundaries: {
+        ownership: {
+          areBoundariesUniform: "Yes",
+          uniformBoundaries: {
+            left: "Seller",
+            right: "Neighbour",
+            rear: "Seller",
+            front: "Not known",
+          },
+          irregularBoundaries: { yesNo: "No" },
+        },
+        haveBoundaryFeaturesMoved: { yesNo: "No" },
+        flyingFreehold: { yesNo: "No" },
+      },
+      servicesCrossing: {
+        pipesWiresCablesDrainsToProperty: { yesNo: "No" },
+        pipesWiresCablesDrainsFromProperty: { yesNo: "No" },
+        formalOrInformalAgreements: { yesNo: "No" },
+      },
+      electricalWorks: {
+        testedByQualifiedElectrician: { yesNo: "No" },
+        electricalWorkSince2005: { yesNo: "No" },
+      },
+      guaranteesWarrantiesAndIndemnityInsurances: {
+        hasValidGuaranteesOrWarranties: "No",
+      },
+      occupiers: {
+        sellerLivesAtProperty: { yesNo: "Yes" },
+        othersAged17OrOver: { hasOthersAged17OrOver: "No" },
+        vacantPossession: { soldWithVacantPossession: "Yes" },
+        occupiersAged17OrOverAgreedToSignAndVacate: { yesNo: "Yes" },
+        tenancyAgreementsIfNotVacantPossession: "Attached",
+      },
+      completionAndMoving: {
+        sellerWillEnsure: {
+          removeRubbish: true,
+          replaceLightFittings: true,
+          takeReasonableCare: true,
+          leaveKeys: true,
+        },
+        sufficientToRepayAllMortgages: { yesNo: "Yes" },
+      },
+      confirmationOfAccuracyByOwners: {
+        confirmInformationIsAccurate: true,
+      },
+      additionalInformation: {},
+    },
+  };
+}

--- a/src/tests/v3/ta7ed5.test.js
+++ b/src/tests/v3/ta7ed5.test.js
@@ -1,0 +1,600 @@
+const {
+  getTransactionSchema,
+  getSubschemaValidator,
+} = require("../../../index.js");
+const ta7ed5Overlay = require("../../schemas/v3/overlays/ta7ed5.json");
+
+const schemaId =
+  "https://trust.propdata.org.uk/schemas/v3/pdtf-transaction.json";
+
+const overlays = ["ta7ed5"];
+
+const collectRequiredWithoutPropertyIssues = (schema) => {
+  const issues = [];
+
+  const walk = (node, path = "#") => {
+    if (!node || typeof node !== "object") return;
+
+    if (Array.isArray(node.required)) {
+      node.required.forEach((propertyName) => {
+        if (!node.properties?.[propertyName]) {
+          issues.push(`${path} requires ${propertyName}`);
+        }
+      });
+    }
+
+    Object.entries(node.properties || {}).forEach(([key, value]) =>
+      walk(value, `${path}/properties/${key}`)
+    );
+    (node.oneOf || []).forEach((value, index) =>
+      walk(value, `${path}/oneOf/${index}`)
+    );
+    if (node.items) walk(node.items, `${path}/items`);
+  };
+
+  walk(schema);
+  return issues;
+};
+
+// Helper: navigate to a deeply nested property in the merged schema
+const getSchemaProperty = (schema, dotPath) => {
+  return dotPath.split(".").reduce((obj, key) => obj?.[key], schema);
+};
+
+// Base path to leasehold information (through the ownership discriminator)
+// The /0/ element navigates through the array type to items, then
+// leaseholdInformation is found in the Leasehold oneOf branch.
+const leaseholdBase =
+  "/propertyPack/ownership/ownershipsToBeTransferred/0/leaseholdInformation";
+
+describe("TA7 5th edition overlay", () => {
+  let schema;
+
+  beforeAll(() => {
+    schema = getTransactionSchema(schemaId, overlays);
+  });
+
+  // ---------------------------------------------------------------
+  // Schema structure tests
+  // ---------------------------------------------------------------
+
+  describe("overlay structure", () => {
+    test("merged schema requires address and ownership at propertyPack level", () => {
+      const required = schema.properties?.propertyPack?.required;
+      expect(required).toContain("address");
+      expect(required).toContain("ownership");
+    });
+
+    test("generated overlay exposes every TA7 edition 5 required property", () => {
+      expect(collectRequiredWithoutPropertyIssues(ta7ed5Overlay)).toEqual([]);
+    });
+
+    test("leasehold branch requires the referenced ta7ed5 sections", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+
+      // Find the Leasehold branch
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      expect(leaseholdBranch).toBeDefined();
+
+      const required =
+        leaseholdBranch.properties.leaseholdInformation.required;
+      expect(required).toContain("typeOfLeasehold");
+      expect(required).toContain("contactDetails");
+      expect(required).toContain("ownershipAndManagement");
+      expect(required).toContain("serviceCharge");
+      expect(required).toContain("disputes");
+      expect(required).toContain("buildingSafetyAct");
+      expect(required).toContain("enfranchisement");
+      expect(required).toContain("requiredDocuments");
+      expect(required).toContain("additionalInformation");
+      expect(required).toContain("confirmationOfAccuracy");
+      expect(required).not.toContain("buildingSafety");
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // typeOfLeasehold discriminator (section 2.1)
+  // ---------------------------------------------------------------
+
+  describe("typeOfLeasehold discriminator", () => {
+    const path = `${leaseholdBase}/typeOfLeasehold`;
+
+    test("valid with a standard leasehold type", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ leaseholdType: "Flat" })).toBe(true);
+    });
+
+    test("valid with Other when otherLeaseholdType provided", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          leaseholdType: "Other",
+          otherLeaseholdType: "Live/work unit",
+        })
+      ).toBe(true);
+    });
+
+    test("invalid with Other when otherLeaseholdType missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ leaseholdType: "Other" })).toBe(false);
+      const err = validator.errors.find((e) =>
+        e.message.includes("otherLeaseholdType")
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("invalid when leaseholdType missing entirely", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+    });
+
+    test("invalid with unrecognised enum value", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ leaseholdType: "Bungalow" })).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Managing agent contact required fields (section 4.1)
+  // ---------------------------------------------------------------
+
+  describe("managingAgent contact required fields", () => {
+    const path = `${leaseholdBase}/contactDetails/contacts/managingAgent`;
+
+    test("valid managing agent with all required fields", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          contact: {
+            nameOrOrganisation: "ABC Property Management",
+            address: { line1: "1 High St", postcode: "SW1A 1AA" },
+            emailAddress: "info@abc.co.uk",
+          },
+        })
+      ).toBe(true);
+    });
+
+    test("invalid when contact is missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+      const err = validator.errors.find((e) =>
+        e.message.includes("contact")
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("invalid when contact.emailAddress is missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          contact: {
+            nameOrOrganisation: "ABC Property Management",
+            address: { line1: "1 High St", postcode: "SW1A 1AA" },
+          },
+        })
+      ).toBe(false);
+      const err = validator.errors.find((e) =>
+        e.message.includes("emailAddress")
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("invalid when contact.nameOrOrganisation is missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          contact: {
+            address: { line1: "1 High St", postcode: "SW1A 1AA" },
+            emailAddress: "info@abc.co.uk",
+          },
+        })
+      ).toBe(false);
+    });
+
+    test("telephone is not required for managing agent contact", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      // Valid without telephone
+      expect(
+        validator({
+          contact: {
+            nameOrOrganisation: "ABC Property Management",
+            address: { line1: "1 High St", postcode: "SW1A 1AA" },
+            emailAddress: "info@abc.co.uk",
+          },
+        })
+      ).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // ownershipAndManagement required fields (section 4)
+  // ---------------------------------------------------------------
+
+  describe("ownershipAndManagement required fields", () => {
+    const path = `${leaseholdBase}/ownershipAndManagement`;
+
+    test("requires isManagingAgentEmployed, sellerOwnership, hasTenantCompanyDissolved", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+
+      const missingFields = validator.errors
+        .filter((e) => e.keyword === "required")
+        .map((e) => e.params.missingProperty);
+
+      expect(missingFields).toContain("isManagingAgentEmployed");
+      expect(missingFields).toContain("sellerOwnership");
+      expect(missingFields).toContain("hasTenantCompanyDissolved");
+    });
+
+    test("isManagingAgentEmployed accepts Not applicable", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      validator({
+        isManagingAgentEmployed: "Not applicable",
+        sellerOwnership: { yesNo: "No" },
+        hasTenantCompanyDissolved: "No",
+      });
+      // Should not have enum errors for isManagingAgentEmployed
+      const enumErr = (validator.errors || []).find(
+        (e) =>
+          e.instancePath === "/isManagingAgentEmployed" &&
+          e.keyword === "enum"
+      );
+      expect(enumErr).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // collectsGroundRent discriminator (section 4.3)
+  // ---------------------------------------------------------------
+
+  describe("collectsGroundRent discriminator", () => {
+    const path = `${leaseholdBase}/contactDetails/serviceContactAssignments/collectsGroundRent`;
+
+    test("requires collector field", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+      const err = validator.errors.find(
+        (e) =>
+          e.keyword === "required" &&
+          e.params.missingProperty === "collector"
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("valid with Landlord (no otherCollector needed)", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Landlord" })).toBe(true);
+    });
+
+    test("valid with Management Company (no otherCollector needed)", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Management Company" })).toBe(true);
+    });
+
+    test("invalid with Other when otherCollector is missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Other" })).toBe(false);
+      const err = validator.errors.find(
+        (e) =>
+          e.keyword === "required" &&
+          e.params.missingProperty === "otherCollector"
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("valid with Other when otherCollector is provided", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({ collector: "Other", otherCollector: "The Crown Estate" })
+      ).toBe(true);
+    });
+
+    test("invalid with Other when otherCollector is empty string", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({ collector: "Other", otherCollector: "" })
+      ).toBe(false);
+    });
+
+    test("invalid with unrecognised enum value", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "The Pope" })).toBe(false);
+    });
+
+    test("invalid when collector is wrong type", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: 42 })).toBe(false);
+    });
+
+    test("ta7ed5 overlay enum has exactly 3 values", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const collector =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments?.properties
+          ?.collectsGroundRent?.properties?.collector;
+      expect(collector?.enum).toEqual([
+        "Landlord",
+        "Management Company",
+        "Other",
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // collectsbuildingInsurancePremiums discriminator (section 4.2)
+  // ---------------------------------------------------------------
+
+  describe("collectsbuildingInsurancePremiums discriminator", () => {
+    const path = `${leaseholdBase}/contactDetails/serviceContactAssignments/collectsbuildingInsurancePremiums`;
+
+    test("requires collector field", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+      const err = validator.errors.find(
+        (e) =>
+          e.keyword === "required" &&
+          e.params.missingProperty === "collector"
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("valid with Freeholder (no otherCollector needed)", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Freeholder" })).toBe(true);
+    });
+
+    test("valid with each non-Other enum value", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      for (const value of [
+        "Freeholder",
+        "Landlord",
+        "Management Company",
+        "Head Leaseholder",
+        "Seller",
+      ]) {
+        expect(validator({ collector: value })).toBe(true);
+      }
+    });
+
+    test("invalid with Other when otherCollector is missing", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Other" })).toBe(false);
+      const err = validator.errors.find(
+        (e) =>
+          e.keyword === "required" &&
+          e.params.missingProperty === "otherCollector"
+      );
+      expect(err).toBeDefined();
+    });
+
+    test("valid with Other when otherCollector is provided", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          collector: "Other",
+          otherCollector: "Residents association",
+        })
+      ).toBe(true);
+    });
+
+    test("invalid with Other when otherCollector is empty string", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({ collector: "Other", otherCollector: "" })
+      ).toBe(false);
+    });
+
+    test("invalid with unrecognised enum value", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({ collector: "Managing Agent" })).toBe(false);
+    });
+
+    test("ta7ed5 overlay enum has exactly 6 values", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const collector =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments?.properties
+          ?.collectsbuildingInsurancePremiums?.properties?.collector;
+      expect(collector?.enum).toEqual([
+        "Freeholder",
+        "Landlord",
+        "Management Company",
+        "Head Leaseholder",
+        "Seller",
+        "Other",
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // serviceContactAssignments required fields
+  // ---------------------------------------------------------------
+
+  describe("serviceContactAssignments required fields", () => {
+    const path = `${leaseholdBase}/contactDetails/serviceContactAssignments`;
+
+    test("requires collectsGroundRent and collectsbuildingInsurancePremiums", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(validator({})).toBe(false);
+
+      const missingFields = validator.errors
+        .filter((e) => e.keyword === "required")
+        .map((e) => e.params.missingProperty);
+
+      expect(missingFields).toContain("collectsGroundRent");
+      expect(missingFields).toContain("collectsbuildingInsurancePremiums");
+    });
+
+    test("valid when both collection fields provided", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          collectsGroundRent: { collector: "Landlord" },
+          collectsbuildingInsurancePremiums: { collector: "Management Company" },
+        })
+      ).toBe(true);
+    });
+
+    test("invalid when collectsGroundRent is a string instead of object", () => {
+      const validator = getSubschemaValidator(path, schemaId, overlays);
+      expect(
+        validator({
+          collectsGroundRent: "Landlord",
+          collectsbuildingInsurancePremiums: { collector: "Landlord" },
+        })
+      ).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Removed properties should not exist
+  // ---------------------------------------------------------------
+
+  describe("removed redundant properties", () => {
+    test("isGroundRentCollectedByManagingAgent does not exist in merged schema", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const serviceContactAssignments =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments;
+
+      expect(
+        serviceContactAssignments?.properties
+          ?.isGroundRentCollectedByManagingAgent
+      ).toBeUndefined();
+    });
+
+    test("managingAgentArrangesOrCollectsBuildingInsuranceCharges does not exist in merged schema", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const serviceContactAssignments =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments;
+
+      expect(
+        serviceContactAssignments?.properties
+          ?.managingAgentArrangesOrCollectsBuildingInsuranceCharges
+      ).toBeUndefined();
+    });
+
+    test("standalone groundRentOtherCollector does not exist (absorbed into collectsGroundRent oneOf)", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const serviceContactAssignments =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments;
+
+      expect(
+        serviceContactAssignments?.properties?.groundRentOtherCollector
+      ).toBeUndefined();
+    });
+
+    test("standalone buildingInsurancePremiumsOtherCollector does not exist (absorbed into collectsbuildingInsurancePremiums oneOf)", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const serviceContactAssignments =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments;
+
+      expect(
+        serviceContactAssignments?.properties
+          ?.buildingInsurancePremiumsOtherCollector
+      ).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // Discriminator structure in the overlay
+  // ---------------------------------------------------------------
+
+  describe("discriminator oneOf structure", () => {
+    test("collectsGroundRent has discriminator on collector with two branches", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const collectsGroundRent =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments?.properties
+          ?.collectsGroundRent;
+
+      expect(collectsGroundRent.discriminator).toEqual({
+        propertyName: "collector",
+      });
+      expect(collectsGroundRent.oneOf).toHaveLength(2);
+
+      // Branch 1: non-Other values
+      const branch1Enum =
+        collectsGroundRent.oneOf[0].properties.collector.enum;
+      expect(branch1Enum).not.toContain("Other");
+
+      // Branch 2: Other + required otherCollector
+      const branch2 = collectsGroundRent.oneOf[1];
+      expect(branch2.properties.collector.enum).toEqual(["Other"]);
+      expect(branch2.required).toContain("otherCollector");
+      expect(branch2.properties.otherCollector).toBeDefined();
+      expect(branch2.properties.otherCollector.type).toBe("string");
+    });
+
+    test("collectsbuildingInsurancePremiums has discriminator on collector with two branches", () => {
+      const leaseholdOneOf =
+        schema.properties?.propertyPack?.properties?.ownership?.properties
+          ?.ownershipsToBeTransferred?.items?.oneOf;
+      const leaseholdBranch = leaseholdOneOf?.find((branch) =>
+        branch.properties?.ownershipType?.enum?.includes("Leasehold")
+      );
+      const collectsInsurance =
+        leaseholdBranch?.properties?.leaseholdInformation?.properties
+          ?.contactDetails?.properties?.serviceContactAssignments?.properties
+          ?.collectsbuildingInsurancePremiums;
+
+      expect(collectsInsurance.discriminator).toEqual({
+        propertyName: "collector",
+      });
+      expect(collectsInsurance.oneOf).toHaveLength(2);
+
+      // Branch 1: non-Other values (superset of all overlay values)
+      const branch1Enum =
+        collectsInsurance.oneOf[0].properties.collector.enum;
+      expect(branch1Enum).toHaveLength(7);
+      expect(branch1Enum).not.toContain("Other");
+
+      // Branch 2: Other + required otherCollector
+      const branch2 = collectsInsurance.oneOf[1];
+      expect(branch2.properties.collector.enum).toEqual(["Other"]);
+      expect(branch2.required).toContain("otherCollector");
+    });
+  });
+});

--- a/src/tests/v3/transactionSchema.test.js
+++ b/src/tests/v3/transactionSchema.test.js
@@ -233,6 +233,37 @@ test("correctly gets yes another subschema but through a non-baspi oneOf structu
   expect(subschema).toEqual({ type: "string" });
 });
 
+test("correctly resolves properties inside nested oneOf branches", () => {
+  // attachments is at japaneseKnotweed.oneOf[1].oneOf[1].properties.attachments
+  const subschema = getSubschema(
+    "/propertyPack/specialistIssues/japaneseKnotweed/attachments"
+  );
+  expect(subschema).toBeDefined();
+  expect(subschema.type).toBe("string");
+  expect(subschema.enum).toContain("To follow");
+  expect(subschema.enum).toContain("Attached");
+});
+
+test("isPathValid returns true for nested oneOf properties", () => {
+  expect(
+    isPathValid("/propertyPack/specialistIssues/japaneseKnotweed/attachments")
+  ).toBe(true);
+  // knotweedSurveyCarriedOut.attachments is also nested in a oneOf
+  expect(
+    isPathValid(
+      "/propertyPack/specialistIssues/japaneseKnotweed/knotweedSurveyCarriedOut/attachments"
+    )
+  ).toBe(true);
+});
+
+test("isPathValid returns false for non-existent paths in nested oneOf", () => {
+  expect(
+    isPathValid(
+      "/propertyPack/specialistIssues/japaneseKnotweed/nonExistentField"
+    )
+  ).toBe(false);
+});
+
 test("correctly gets an overlaid enum in a subschema", () => {
   const subschema = getSubschema(
     "/propertyPack/electricity/mainsElectricity/yesNo",
@@ -314,9 +345,11 @@ test("correctly gets a subschema validator for a TA6 overlay which validates wit
   );
   const data = jp.get(exampleTransaction, path);
   data.uprn = undefined;
-  const validator = getSubschemaValidator(path, exampleTransaction.$schema, [
-    "ta6ed4",
-  ]);
+  const validator = getSubschemaValidator(
+    path,
+    clonedExampleTransaction.$schema,
+    ["ta6ed4"]
+  );
   let isValid = validator(data);
   expect(isValid).toBe(true);
 });
@@ -458,7 +491,7 @@ test("ntsl2025 requires parking and listingAndConservation fields", () => {
   const clonedExampleTransaction = JSON.parse(
     JSON.stringify(exampleTransaction)
   );
-  
+
   // Set up lettings-specific fields
   clonedExampleTransaction.propertyPack.lettingInformation = {
     rent: 3500,
@@ -467,32 +500,47 @@ test("ntsl2025 requires parking and listingAndConservation fields", () => {
   };
   delete clonedExampleTransaction.propertyPack.priceInformation;
   delete clonedExampleTransaction.propertyPack.ownership;
-  
+
   // Remove ALL parking fields - this should make validation fail
   delete clonedExampleTransaction.propertyPack.parking.parkingArrangements;
   delete clonedExampleTransaction.propertyPack.parking.disabledParking;
   delete clonedExampleTransaction.propertyPack.parking.controlledParking;
-  delete clonedExampleTransaction.propertyPack.parking.electricVehicleChargingPoint;
-  
+  delete clonedExampleTransaction.propertyPack.parking
+    .electricVehicleChargingPoint;
+
   // Remove ALL listingAndConservation fields - this should make validation fail
   delete clonedExampleTransaction.propertyPack.listingAndConservation.isListed;
-  delete clonedExampleTransaction.propertyPack.listingAndConservation.isConservationArea;
-  delete clonedExampleTransaction.propertyPack.listingAndConservation.hasTreePreservationOrder;
-  
+  delete clonedExampleTransaction.propertyPack.listingAndConservation
+    .isConservationArea;
+  delete clonedExampleTransaction.propertyPack.listingAndConservation
+    .hasTreePreservationOrder;
+
   const isValid = validator(clonedExampleTransaction);
-  
+
   // The data should be INVALID because required fields are missing
   expect(isValid).toBe(false);
-  
+
   // Specifically check that parking and listingAndConservation fields are reported as missing
-  const errorMessages = validator.errors.map(e => e.message);
-  expect(errorMessages).toContain("must have required property 'parkingArrangements'");
-  expect(errorMessages).toContain("must have required property 'disabledParking'");
-  expect(errorMessages).toContain("must have required property 'controlledParking'");
-  expect(errorMessages).toContain("must have required property 'electricVehicleChargingPoint'");
+  const errorMessages = validator.errors.map((e) => e.message);
+  expect(errorMessages).toContain(
+    "must have required property 'parkingArrangements'"
+  );
+  expect(errorMessages).toContain(
+    "must have required property 'disabledParking'"
+  );
+  expect(errorMessages).toContain(
+    "must have required property 'controlledParking'"
+  );
+  expect(errorMessages).toContain(
+    "must have required property 'electricVehicleChargingPoint'"
+  );
   expect(errorMessages).toContain("must have required property 'isListed'");
-  expect(errorMessages).toContain("must have required property 'isConservationArea'");
-  expect(errorMessages).toContain("must have required property 'hasTreePreservationOrder'");
+  expect(errorMessages).toContain(
+    "must have required property 'isConservationArea'"
+  );
+  expect(errorMessages).toContain(
+    "must have required property 'hasTreePreservationOrder'"
+  );
 });
 
 test("waterAndDrainage state is invalid under nts2023 overlay when mainsFoulDrainage yesNo is Not known", () => {
@@ -500,36 +548,37 @@ test("waterAndDrainage state is invalid under nts2023 overlay when mainsFoulDrai
   const clonedExampleTransaction = JSON.parse(
     JSON.stringify(exampleTransaction)
   );
-  
+
   // Set the waterAndDrainage to an actually invalid state for nts2023
-  // The nts overlay restricts mainsFoulDrainage.yesNo to only "Yes" or "No" 
+  // The nts overlay restricts mainsFoulDrainage.yesNo to only "Yes" or "No"
   // (not "Not known" like the base schema allows)
   clonedExampleTransaction.propertyPack.waterAndDrainage = {
-    "water": {
-      "mainsWater": {
-        "yesNo": "Yes",
-        "waterMeter": {
-          "isSupplyMetered": "No"
-        }
-      }
-    },
-    "drainage": {
-      "mainsSurfaceWaterDrainage": {
-        "yesNo": "Yes"
+    water: {
+      mainsWater: {
+        yesNo: "Yes",
+        waterMeter: {
+          isSupplyMetered: "No",
+        },
       },
-      "mainsFoulDrainage": {
-        "yesNo": "Not known"  // This is invalid under nts2023 overlay
-      }
-    }
+    },
+    drainage: {
+      mainsSurfaceWaterDrainage: {
+        yesNo: "Yes",
+      },
+      mainsFoulDrainage: {
+        yesNo: "Not known", // This is invalid under nts2023 overlay
+      },
+    },
   };
-  
+
   const isValid = validator(clonedExampleTransaction);
   expect(isValid).toBe(false);
-  
+
   // Check that the validation error is about the invalid enum value
-  const relevantError = validator.errors.find(error => 
-    error.instancePath.includes('mainsFoulDrainage') && 
-    error.message.includes('must be equal to one of the allowed values')
+  const relevantError = validator.errors.find(
+    (error) =>
+      error.instancePath.includes("mainsFoulDrainage") &&
+      error.message.includes("must be equal to one of the allowed values")
   );
   expect(relevantError).toBeDefined();
 });
@@ -539,36 +588,59 @@ test("waterAndDrainage state with mainsFoulDrainage No missing offMainsDrainageS
   const clonedExampleTransaction = JSON.parse(
     JSON.stringify(exampleTransaction)
   );
-  
+
   // Set the waterAndDrainage to the state from the user request
   // This SHOULD be invalid because offMainsDrainageSystem is required when mainsFoulDrainage.yesNo is "No"
   clonedExampleTransaction.propertyPack.waterAndDrainage = {
-    "water": {
-      "mainsWater": {
-        "yesNo": "Yes",
-        "waterMeter": {
-          "isSupplyMetered": "No"
-        }
-      }
-    },
-    "drainage": {
-      "mainsSurfaceWaterDrainage": {
-        "yesNo": "Yes"
+    water: {
+      mainsWater: {
+        yesNo: "Yes",
+        waterMeter: {
+          isSupplyMetered: "No",
+        },
       },
-      "mainsFoulDrainage": {
-        "yesNo": "No"
+    },
+    drainage: {
+      mainsSurfaceWaterDrainage: {
+        yesNo: "Yes",
+      },
+      mainsFoulDrainage: {
+        yesNo: "No",
         // Missing offMainsDrainageSystem - this should make validation fail
-      }
-    }
+      },
+    },
   };
-  
+
   const isValid = validator(clonedExampleTransaction);
   expect(isValid).toBe(false);
-  
+
   // Check that the validation error is about missing offMainsDrainageSystem
-  const relevantError = validator.errors.find(error => 
-    error.instancePath.includes('mainsFoulDrainage') && 
-    error.message.includes('offMainsDrainageSystem')
+  const relevantError = validator.errors.find(
+    (error) =>
+      error.instancePath.includes("mainsFoulDrainage") &&
+      error.message.includes("offMainsDrainageSystem")
   );
   expect(relevantError).toBeDefined();
+});
+
+test("TA7 overlay organisesBuildingInsurance enum has exactly three items", () => {
+  const schema = getTransactionSchema(schemaId, ["ta7ed3"]);
+
+  // Navigate to the organisesBuildingInsurance property in the merged schema
+  const organisesBuildingInsurance =
+    schema.properties?.propertyPack?.properties?.ownership?.properties
+      ?.ownershipsToBeTransferred?.items?.oneOf?.[2]?.properties
+      ?.leaseholdInformation?.properties?.contactDetails?.properties
+      ?.serviceContactAssignments?.properties?.organisesBuildingInsurance;
+
+  expect(organisesBuildingInsurance).toBeDefined();
+  expect(organisesBuildingInsurance.enum).toBeDefined();
+
+  // The TA7 overlay defines exactly 3 enum values, which should replace the base schema's 6 values
+  expect(organisesBuildingInsurance.enum).toHaveLength(3);
+  expect(organisesBuildingInsurance.enum).toEqual([
+    "the Lessees",
+    "Management Company",
+    "Landlord",
+  ]);
 });

--- a/src/tests/v3/verifiedClaimsValidator.test.js
+++ b/src/tests/v3/verifiedClaimsValidator.test.js
@@ -126,3 +126,70 @@ test("returns an empty array of errors for verified claim with multiple valid pa
   };
   expect(validateVerifiedClaims([clonedVouch], v3SchemaId, null)).toEqual([]);
 });
+
+test("returns an empty array for valid terms_of_use object with confidential level", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "confidential",
+    allowed_roles: ["Seller's Conveyancer", "Buyer's Conveyancer"]
+  };
+  expect(validateVerifiedClaims([clonedVouch])).toEqual([]);
+});
+
+test("returns an empty array for valid terms_of_use with public confidentiality", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "public",
+    allowed_roles: []
+  };
+  expect(validateVerifiedClaims([clonedVouch])).toEqual([]);
+});
+
+test("returns an empty array for valid terms_of_use with restricted level", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "restricted",
+    allowed_roles: []
+  };
+  expect(validateVerifiedClaims([clonedVouch])).toEqual([]);
+});
+
+test("returns errors for invalid confidentiality_level in terms_of_use", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "invalid_level",
+    allowed_roles: ["Seller's Conveyancer"]
+  };
+  const errors = validateVerifiedClaims([clonedVouch]);
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toHaveLength(1);
+  expect(errors[0][0].instancePath).toBe("/verified_claims/0/terms_of_use/confidentiality_level");
+  expect(errors[0][0].keyword).toBe("enum");
+});
+
+test("returns errors for invalid allowed_roles type in terms_of_use", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "confidential",
+    allowed_roles: "not_an_array"
+  };
+  const errors = validateVerifiedClaims([clonedVouch]);
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toHaveLength(1);
+  expect(errors[0][0].instancePath).toBe("/verified_claims/0/terms_of_use/allowed_roles");
+  expect(errors[0][0].keyword).toBe("type");
+});
+
+test("returns errors for additional properties in terms_of_use", () => {
+  const clonedVouch = JSON.parse(JSON.stringify(exampleVouch));
+  clonedVouch.terms_of_use = {
+    confidentiality_level: "confidential",
+    allowed_roles: ["Estate Agent"],
+    extra_property: "should_not_be_allowed"
+  };
+  const errors = validateVerifiedClaims([clonedVouch]);
+  expect(errors).toHaveLength(1);
+  expect(errors[0]).toHaveLength(1);
+  expect(errors[0][0].instancePath).toBe("/verified_claims/0/terms_of_use");
+  expect(errors[0][0].keyword).toBe("additionalProperties");
+});

--- a/src/utils/extractExtensionOverlays.js
+++ b/src/utils/extractExtensionOverlays.js
@@ -5,6 +5,41 @@ const path = require("path");
 
 const combinedSchema = require("../schemas/v3/combined.json");
 
+// Derive ref-related field names from a refType
+function getRefConfig(refType) {
+  if (refType === "nts2Ref") {
+    // Legacy mapping: nts2Ref -> ntsRef in output
+    return {
+      ref: "nts2Ref",
+      outputRef: "ntsRef",
+      required: "nts2Required",
+      title: "nts2Title",
+      description: "nts2Description",
+      enumKey: "nts2Enum",
+    };
+  }
+  if (refType === "sef25Ref") {
+    // SEF25 extensions also appear as ntsRef in output
+    return {
+      ref: "sef25Ref",
+      outputRef: "ntsRef",
+      required: "sef25Required",
+      title: "sef25Title",
+      description: "sef25Description",
+      enumKey: "sef25Enum",
+    };
+  }
+  // For other ref types, derive keys by replacing "Ref" suffix
+  return {
+    ref: refType,
+    outputRef: refType,
+    required: refType.replace("Ref", "Required"),
+    title: refType.replace("Ref", "Title"),
+    description: refType.replace("Ref", "Description"),
+    enumKey: refType.replace("Ref", "Enum"),
+  };
+}
+
 // Define the extension overlay mappings
 const extensionMappings = {
   // Outside areas
@@ -150,18 +185,192 @@ const extensionMappings = {
       "/properties/propertyPack/properties/completionAndMoving/properties/otherPropertyInChain",
     ],
   },
+
+  // Private supply costs (water & sewerage)
+  sc: {
+    name: "supplyCosts",
+    description: "Associated costs for private water and sewerage supply",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/waterAndDrainage/properties/water/properties/mainsWater/oneOf/0/properties/associatedCost",
+      "/properties/propertyPack/properties/waterAndDrainage/properties/drainage/properties/mainsFoulDrainage/oneOf/2/properties/associatedCost",
+    ],
+  },
+
+  // Parking permit costs
+  pc: {
+    name: "parkingPermitCost",
+    description: "Parking permit cost and frequency",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/parking/properties/controlledParking/oneOf/1/properties/costOfPermit",
+      "/properties/propertyPack/properties/parking/properties/controlledParking/oneOf/1/properties/costOfPermitFrequency",
+    ],
+  },
+
+  // Property hazards
+  ph: {
+    name: "propertyHazards",
+    description: "Property hazards and known issues",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/specialistIssues",
+    ],
+  },
+
+  // Dropped kerb access to parking
+  dk: {
+    name: "droppedKerbAccess",
+    description: "Dropped kerb access to parking",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/parking/properties/droppedKerbAccess",
+    ],
+  },
+
+  // Private right of way
+  rw: {
+    name: "privateRightOfWay",
+    description: "Private right of way",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/rightsAndInformalArrangements/properties/rightsOrArrangements/properties/privateRightOfWay",
+    ],
+  },
+
+  // Storm, fire or flood damage
+  sd: {
+    name: "stormFireFloodDamage",
+    description: "Storm, fire or flood damage",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/environmentalIssues/properties/stormFireFloodDamage",
+    ],
+  },
+
+  // Solar panel lease costs
+  lc: {
+    name: "solarLeaseCosts",
+    description: "Solar panel lease costs",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/electricity/properties/solarPanels/oneOf/1/properties/panelsOwnedOutright/oneOf/1/properties/associatedCost",
+    ],
+  },
+
+  // Warranties and guarantees upfront
+  wg: {
+    name: "warrantiesGuarantees",
+    description: "Warranties and guarantees upfront Y/N for SEF25",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/guaranteesWarrantiesAndIndemnityInsurances",
+    ],
+  },
+
+  // Insurance claims upfront
+  ic: {
+    name: "insuranceClaims",
+    description: "Insurance claims upfront for SEF25",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/insurance",
+    ],
+  },
+
+  // Neighbour development upfront
+  nd: {
+    name: "neighbourDevelopment",
+    description: "Neighbour development upfront for SEF25",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/notices/properties/neighbourDevelopment",
+    ],
+  },
+
+  // Other material issue upfront
+  mi: {
+    name: "otherMaterialIssue",
+    description: "Other material issue upfront for SEF25",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/additionalInformation/properties/otherMaterialIssue",
+    ],
+  },
+
+  // Title restrictions for freehold
+  tr: {
+    name: "titleRestrictions",
+    description: "Title restrictions for freehold properties",
+    refType: "sef25Ref",
+    paths: [
+      "/properties/propertyPack/properties/ownership/properties/ownershipsToBeTransferred/items/oneOf/0/properties/titleRestrictions",
+    ],
+  },
+
+  // Alterations and changes
+  ac: {
+    name: "alterationsAndChanges",
+    description: "Selected alterations and changes fields for SEF25",
+    refType: "sef25Ref",
+    preserveDiscriminators: true,
+    paths: [
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/extension/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/extension/oneOf/1/properties/details",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/extension/oneOf/1/properties/planningPermission/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/extension/oneOf/1/properties/buildingRegApproval/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/loftConversion/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/loftConversion/oneOf/1/properties/details",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/loftConversion/oneOf/1/properties/planningPermission/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/loftConversion/oneOf/1/properties/buildingRegApproval/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/garageConversion/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/garageConversion/oneOf/1/properties/details",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/garageConversion/oneOf/1/properties/planningPermission/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/garageConversion/oneOf/1/properties/buildingRegApproval/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/removalOfInternalWalls/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/removalOfInternalWalls/oneOf/1/properties/details",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/removalOfInternalWalls/oneOf/1/properties/planningPermission/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/removalOfInternalWalls/oneOf/1/properties/buildingRegApproval/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/changeOfUse/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/changeOfUse/oneOf/1/properties/details",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/changeOfUse/oneOf/1/properties/planningPermission/properties/yesNo",
+      "/properties/propertyPack/properties/alterationsAndChanges/properties/changeOfUse/oneOf/1/properties/buildingRegApproval/properties/yesNo",
+    ],
+  },
+
+  // TA6 edition 6 compatibility for shared MI/NTS validation
+  ta: {
+    name: "ta6Ed6Compatibility",
+    description:
+      "Compatibility enum ranges for validating shared PDTF state containing TA6 edition 6 answers",
+    refType: "ta6ed6CompatRef",
+    paths: [
+      "/properties/propertyPack/properties/parking",
+      "/properties/propertyPack/properties/heating",
+      "/properties/propertyPack/properties/rightsAndInformalArrangements",
+      "/properties/propertyPack/properties/legalBoundaries",
+    ],
+  },
 };
 
-// Function to extract properties at specific paths with nts2Ref
-function extractPathsWithNts2Ref(schema, paths) {
+// Function to extract properties at specific paths with given ref type
+function extractPathsWithRef(
+  schema,
+  paths,
+  refConfig,
+  preserveDiscriminators = false
+) {
   const result = {};
 
   paths.forEach((path) => {
     try {
       const value = jp.get(schema, path);
-      if (value && hasNts2Ref(value)) {
+      if (value && hasRef(value, refConfig)) {
         // Set the value at the same path in result
-        jp.set(result, path, extractNts2Properties(value));
+        jp.set(result, path, extractRefProperties(value, refConfig));
+        if (preserveDiscriminators) {
+          addAncestorDiscriminators(result, schema, path);
+        }
       }
     } catch (err) {
       console.warn(`Path not found: ${path}`);
@@ -171,11 +380,31 @@ function extractPathsWithNts2Ref(schema, paths) {
   return result;
 }
 
-// Check if an object or its descendants have nts2Ref
-function hasNts2Ref(obj) {
+function addAncestorDiscriminators(result, schema, path) {
+  const parts = path.split("/").filter(Boolean);
+
+  for (let index = 1; index <= parts.length; index += 1) {
+    const ancestorPath = `/${parts.slice(0, index).join("/")}`;
+
+    try {
+      const schemaNode = jp.get(schema, ancestorPath);
+      if (!schemaNode?.discriminator) continue;
+
+      const resultNode = jp.get(result, ancestorPath);
+      if (resultNode && typeof resultNode === "object") {
+        resultNode.discriminator = schemaNode.discriminator;
+      }
+    } catch (err) {
+      // Ancestor was not materialised by this selected path.
+    }
+  }
+}
+
+// Check if an object or its descendants have the specified ref
+function hasRef(obj, refConfig) {
   let found = false;
   traverse(obj).forEach(function (element) {
-    if (element && element.nts2Ref) {
+    if (element && element[refConfig.ref]) {
       found = true;
       this.stop();
     }
@@ -183,16 +412,16 @@ function hasNts2Ref(obj) {
   return found;
 }
 
-// Extract only NTS2-specific properties (with nts2Ref)
-function extractNts2Properties(obj, parentKey) {
+// Extract only ref-specific properties
+function extractRefProperties(obj, refConfig, parentKey) {
   const result = {};
 
-  // Copy nts2-specific metadata at current level
-  if (obj.nts2Ref) result.ntsRef = obj.nts2Ref;
-  if (obj.nts2Required) result.required = obj.nts2Required;
-  if (obj.nts2Title) result.title = obj.nts2Title;
-  if (obj.nts2Description) result.description = obj.nts2Description;
-  if (obj.nts2Enum) result.enum = obj.nts2Enum;
+  // Copy ref-specific metadata at current level
+  if (obj[refConfig.ref]) result[refConfig.outputRef] = obj[refConfig.ref];
+  if (obj[refConfig.required]) result.required = obj[refConfig.required];
+  if (obj[refConfig.title]) result.title = obj[refConfig.title];
+  if (obj[refConfig.description]) result.description = obj[refConfig.description];
+  if (obj[refConfig.enumKey]) result.enum = obj[refConfig.enumKey];
 
   // Handle discriminator
   if (obj.discriminator) {
@@ -204,11 +433,11 @@ function extractNts2Properties(obj, parentKey) {
     result.properties = {};
     Object.keys(obj.properties).forEach((key) => {
       const prop = obj.properties[key];
-      if (hasNts2Ref(prop)) {
-        result.properties[key] = extractNts2Properties(prop, key);
+      if (hasRef(prop, refConfig)) {
+        result.properties[key] = extractRefProperties(prop, refConfig, key);
       }
     });
-    // Only keep properties if we found some with nts2Ref
+    // Only keep properties if we found some with ref
     if (Object.keys(result.properties).length === 0) {
       delete result.properties;
     }
@@ -216,8 +445,8 @@ function extractNts2Properties(obj, parentKey) {
 
   // Handle arrays
   if (obj.items) {
-    if (hasNts2Ref(obj.items)) {
-      result.items = extractNts2Properties(obj.items);
+    if (hasRef(obj.items, refConfig)) {
+      result.items = extractRefProperties(obj.items, refConfig);
     }
   }
 
@@ -225,8 +454,8 @@ function extractNts2Properties(obj, parentKey) {
   if (obj.oneOf) {
     // Always preserve the full array structure and order
     const processedOneOf = obj.oneOf.map((schema, index) => {
-      if (hasNts2Ref(schema)) {
-        const extracted = extractNts2Properties(schema);
+      if (hasRef(schema, refConfig)) {
+        const extracted = extractRefProperties(schema, refConfig);
         // For oneOf schemas, we need to preserve discriminator enum values
         if (obj.discriminator && schema.properties) {
           const propName = obj.discriminator.propertyName;
@@ -234,7 +463,7 @@ function extractNts2Properties(obj, parentKey) {
             if (!extracted.properties) extracted.properties = {};
             extracted.properties[propName] = {
               enum:
-                schema.properties[propName].nts2Enum ||
+                schema.properties[propName][refConfig.enumKey] ||
                 schema.properties[propName].enum,
             };
           }
@@ -258,7 +487,7 @@ function extractNts2Properties(obj, parentKey) {
         }
         return extracted;
       } else {
-        // If this branch doesn't have nts2Ref, preserve the base discriminator enum
+        // If this branch doesn't have ref, preserve the base discriminator enum
         if (obj.discriminator && schema.properties) {
           const propName = obj.discriminator.propertyName;
           if (schema.properties[propName]) {
@@ -281,7 +510,7 @@ function extractNts2Properties(obj, parentKey) {
     // If parentKey is set, and this object has extension metadata, return a stub for the parent
     if (
       parentKey &&
-      (result.ntsRef || result.required || result.discriminator)
+      (result[refConfig.outputRef] || result.required || result.discriminator)
     ) {
       // This is an extension property inside a oneOf branch
       // Return a stub for the parent property with metadata and oneOf structure
@@ -311,16 +540,16 @@ function extractNts2Properties(obj, parentKey) {
 }
 
 // Add required array at parent levels if needed
-function addRequiredArrays(overlay, schema) {
+function addRequiredArrays(overlay, schema, refConfig) {
   traverse(overlay).forEach(function (node) {
     if (node && node.properties) {
       const schemaPath = "/" + this.path.join("/");
       try {
         const schemaNode = jp.get(schema, schemaPath);
-        if (schemaNode && schemaNode.nts2Required) {
+        if (schemaNode && schemaNode[refConfig.required]) {
           // Filter to only include properties that exist in this overlay
           const overlayProps = Object.keys(node.properties);
-          const requiredProps = schemaNode.nts2Required.filter((prop) =>
+          const requiredProps = schemaNode[refConfig.required].filter((prop) =>
             overlayProps.includes(prop)
           );
           if (requiredProps.length > 0) {
@@ -335,15 +564,57 @@ function addRequiredArrays(overlay, schema) {
   return overlay;
 }
 
+// Annotate intermediate nodes with refs from the source schema
+// This ensures every level of the overlay tree carries an ntsRef
+function addIntermediateRefs(overlay, schema, refConfig) {
+  traverse(overlay).forEach(function (node) {
+    if (node && typeof node === "object" && !Array.isArray(node) && node.properties) {
+      // Skip if this node already has a ref
+      if (node[refConfig.outputRef]) return;
+
+      const schemaPath = "/" + this.path.join("/");
+      try {
+        const schemaNode = jp.get(schema, schemaPath);
+        if (!schemaNode) return;
+        // When the output key differs from the source key (e.g. sef25Ref -> ntsRef),
+        // prefer the schema's existing outputRef on intermediate parents so we
+        // don't clobber legitimate NTS refs when the extension is later merged.
+        if (
+          refConfig.ref !== refConfig.outputRef &&
+          schemaNode[refConfig.outputRef]
+        ) {
+          node[refConfig.outputRef] = schemaNode[refConfig.outputRef];
+        } else if (schemaNode[refConfig.ref]) {
+          node[refConfig.outputRef] = schemaNode[refConfig.ref];
+        }
+      } catch (err) {
+        // Path doesn't exist in schema, skip
+      }
+    }
+  });
+  return overlay;
+}
+
 // Generate extension overlays
 Object.entries(extensionMappings).forEach(([code, config]) => {
-  console.log(`\nGenerating extension overlay: ${code} (${config.name})`);
+  const refType = config.refType || "nts2Ref";
+  const refConfig = getRefConfig(refType);
+
+  console.log(`\nGenerating extension overlay: ${code} (${config.name}) [${refType}]`);
 
   // Extract the specific paths
-  let overlay = extractPathsWithNts2Ref(combinedSchema, config.paths);
+  let overlay = extractPathsWithRef(
+    combinedSchema,
+    config.paths,
+    refConfig,
+    config.preserveDiscriminators
+  );
 
   // Add required arrays where needed
-  overlay = addRequiredArrays(overlay, combinedSchema);
+  overlay = addRequiredArrays(overlay, combinedSchema, refConfig);
+
+  // Add refs to intermediate nodes in the path hierarchy
+  overlay = addIntermediateRefs(overlay, combinedSchema, refConfig);
 
   // Add schema metadata
   overlay.$schema = "http://json-schema.org/draft-07/schema#";

--- a/src/utils/extractOverlay.js
+++ b/src/utils/extractOverlay.js
@@ -2,9 +2,24 @@ const { dereference } = require("@jdw/jst");
 const traverse = require("traverse");
 const jp = require("jsonpointer");
 const fs = require("fs");
+const path = require("path");
 const merge = require("deepmerge");
 
-const combinedSchema = require("../schemas/v3/combined.json");
+const combinedPath =
+  process.env.COMBINED_PATH ||
+  path.resolve(__dirname, "../schemas/v3/combined.json");
+const outputDir =
+  process.env.OUTPUT_DIR ||
+  path.resolve(__dirname, "../schemas/v3");
+
+if (!fs.existsSync(combinedPath)) {
+  throw new Error(`Combined schema not found: ${combinedPath}`);
+}
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+const combinedSchema = JSON.parse(fs.readFileSync(combinedPath, "utf8"));
 
 const extractFields = [
   "baspi4",
@@ -14,7 +29,9 @@ const extractFields = [
   "ntsl",
   "ntsl2",
   "ta6",
+  "ta6ed6",
   "ta7",
+  "ta7ed5",
   "ta10",
   "lpe1",
   "fme1",
@@ -25,20 +42,35 @@ const extractFields = [
   "rds",
   "oc1",
   "sr24",
+  "sef25",
 ];
+
+const metadataFields = [...extractFields, "ta6ed6Compat"];
 
 const flattenSkeleton = (schema) => {
   if (!schema) return undefined;
-  
+
   // Handle arrays - mark with special notation
   if (schema.type === "array" && schema.items) {
     const itemSchema = flattenSkeleton(schema.items);
     // Use array notation to indicate this is an array
     return [itemSchema];
   }
-  
+
+  // Handle patternProperties (dynamic keys like in offers and enquiries)
+  if (schema.type === "object" && schema.patternProperties) {
+    // Get the schema from the first pattern (usually ".*")
+    const patternKeys = Object.keys(schema.patternProperties);
+    if (patternKeys.length > 0) {
+      const patternSchema = schema.patternProperties[patternKeys[0]];
+      const itemSchema = flattenSkeleton(patternSchema);
+      // Use {*: schema} notation to indicate this is a keyed object
+      return { "*": itemSchema };
+    }
+  }
+
   // Handle primitives - return type indicator
-  if (schema.type && !schema.properties && !schema.oneOf && !schema.items) {
+  if (schema.type && !schema.properties && !schema.oneOf && !schema.items && !schema.patternProperties) {
     // Return a type indicator for primitive types
     if (schema.type === "string") return "string";
     if (schema.type === "number") return "number";
@@ -46,45 +78,60 @@ const flattenSkeleton = (schema) => {
     if (schema.type === "boolean") return "boolean";
     if (schema.type === "null") return "null";
   }
-  
+
   let returnStructure = {};
-  
+
   // Handle object properties
   if (schema.properties) {
     Object.keys(schema.properties).forEach((key) => {
       returnStructure[key] = flattenSkeleton(schema.properties[key]);
     });
   }
-  
-  // Handle oneOf - merge all possible properties
+
+  // Handle oneOf - merge all possible properties (recursively handles nested oneOf)
   if (schema.oneOf) {
     schema.oneOf.forEach((aOneOf) => {
-      if (aOneOf.properties) {
-        Object.entries(aOneOf.properties).forEach(([key, value]) => {
-          // If property already exists and differs, mark as variant
-          const newValue = flattenSkeleton(value);
-          if (returnStructure[key] && JSON.stringify(returnStructure[key]) !== JSON.stringify(newValue)) {
-            // For primitive types, just mark as variant type
-            if (typeof returnStructure[key] === "string" || typeof newValue === "string") {
+      const variantResult = flattenSkeleton(aOneOf);
+      if (variantResult && typeof variantResult === "object" && !Array.isArray(variantResult)) {
+        Object.entries(variantResult).forEach(([key, value]) => {
+          if (key === "_variants") return;
+          if (returnStructure[key] && JSON.stringify(returnStructure[key]) !== JSON.stringify(value)) {
+            if (typeof returnStructure[key] === "string" || typeof value === "string") {
               returnStructure[key] = "variant";
             } else {
-              // For complex types, merge properties
-              returnStructure[key] = { ...returnStructure[key], ...newValue, _variants: true };
+              returnStructure[key] = { ...returnStructure[key], ...value, _variants: true };
             }
           } else {
-            returnStructure[key] = newValue;
+            returnStructure[key] = value;
           }
         });
       }
     });
   }
-  
+
   // Return empty object for objects without properties
   return Object.keys(returnStructure).length > 0 ? returnStructure : {};
 };
 
 const extractOverlay = (sourceSchema, ref) => {
   const refName = `${ref}Ref`;
+  const extendedTagMap = {
+    Type: "type",
+    MinLength: "minLength",
+    MaxLength: "maxLength",
+    Pattern: "pattern",
+    Minimum: "minimum",
+    Maximum: "maximum",
+    MinItems: "minItems",
+    MaxItems: "maxItems",
+    UniqueItems: "uniqueItems",
+    AdditionalProperties: "additionalProperties",
+    Format: "format",
+    MinProperties: "minProperties",
+    MaxProperties: "maxProperties",
+    MultipleOf: "multipleOf",
+    Const: "const",
+  };
   const returnSchema = {
     $schema: "http://json-schema.org/draft-07/schema#",
     $id: `https://trust.propdata.org.uk/schemas/v3/overlays/${ref}.json`,
@@ -95,7 +142,7 @@ const extractOverlay = (sourceSchema, ref) => {
     if (element[refName]) {
       jp.set(returnSchema, `${path}/${refName}`, element[refName]);
 
-      if (element.discriminator) {
+      if (element.discriminator && Array.isArray(element.oneOf)) {
         jp.set(returnSchema, `${path}/discriminator`, element.discriminator);
         const { propertyName } = element.discriminator;
         element.oneOf.forEach((oneOf, index) => {
@@ -122,7 +169,7 @@ const extractOverlay = (sourceSchema, ref) => {
       }
 
       // also handle discriminator properties nested in items
-      if (element.items?.discriminator) {
+      if (element.items?.discriminator && Array.isArray(element.items.oneOf)) {
         jp.set(
           returnSchema,
           `${path}/items/discriminator`,
@@ -172,6 +219,18 @@ const extractOverlay = (sourceSchema, ref) => {
     if (element[refEnum]) {
       jp.set(returnSchema, `${path}/enum`, element[refEnum]);
     }
+
+    const refConst = `${ref}Const`;
+    if (Object.prototype.hasOwnProperty.call(element, refConst)) {
+      jp.set(returnSchema, `${path}/const`, element[refConst]);
+    }
+
+    Object.entries(extendedTagMap).forEach(([suffix, schemaKey]) => {
+      const tagKey = `${ref}${suffix}`;
+      if (Object.prototype.hasOwnProperty.call(element, tagKey)) {
+        jp.set(returnSchema, `${path}/${schemaKey}`, element[tagKey]);
+      }
+    });
   });
   return returnSchema;
 };
@@ -186,28 +245,48 @@ const deleteProperties = (sourceSchema, propertyNames) => {
 };
 
 const overlays = {};
+const overlaysDir = path.join(outputDir, "overlays");
+if (!fs.existsSync(overlaysDir)) {
+  fs.mkdirSync(overlaysDir, { recursive: true });
+}
 
 extractFields.forEach((key) => {
   let overlay = extractOverlay(combinedSchema, key);
   overlays[key] = overlay;
-  const fileName = `../schemas/v3/overlays/${key}.json`;
+  const fileName = path.join(overlaysDir, `${key}.json`);
   fs.writeFileSync(fileName, JSON.stringify(overlay, null, 2));
   console.log(`Overlay ${key} written to ${fileName}`);
 });
 
 const coreSchema = deleteProperties(combinedSchema, [
   "discriminator",
-  ...extractFields.map((item) => `${item}Ref`),
-  ...extractFields.map((item) => `${item}Required`),
-  ...extractFields.map((item) => `${item}Title`),
-  ...extractFields.map((item) => `${item}Enum`),
+  ...metadataFields.map((item) => `${item}Ref`),
+  ...metadataFields.map((item) => `${item}Required`),
+  ...metadataFields.map((item) => `${item}Title`),
+  ...metadataFields.map((item) => `${item}Description`),
+  ...metadataFields.map((item) => `${item}Enum`),
+  ...metadataFields.map((item) => `${item}Type`),
+  ...metadataFields.map((item) => `${item}MinLength`),
+  ...metadataFields.map((item) => `${item}MaxLength`),
+  ...metadataFields.map((item) => `${item}Pattern`),
+  ...metadataFields.map((item) => `${item}Minimum`),
+  ...metadataFields.map((item) => `${item}Maximum`),
+  ...metadataFields.map((item) => `${item}MinItems`),
+  ...metadataFields.map((item) => `${item}MaxItems`),
+  ...metadataFields.map((item) => `${item}UniqueItems`),
+  ...metadataFields.map((item) => `${item}AdditionalProperties`),
+  ...metadataFields.map((item) => `${item}Format`),
+  ...metadataFields.map((item) => `${item}MinProperties`),
+  ...metadataFields.map((item) => `${item}MaxProperties`),
+  ...metadataFields.map((item) => `${item}MultipleOf`),
+  ...metadataFields.map((item) => `${item}Const`),
 ]);
 
 fs.writeFileSync(
-  "../schemas/v3/pdtf-transaction.json",
+  path.join(outputDir, "pdtf-transaction.json"),
   JSON.stringify(coreSchema, null, 2)
 );
-console.log("Core schema written to ../schemas/v3/pdtf-transaction.json");
+console.log(`Core schema written to ${path.join(outputDir, "pdtf-transaction.json")}`);
 
 const skeletonSchema = deleteProperties(coreSchema, [
   "$schema",
@@ -226,10 +305,10 @@ const skeletonSchema = deleteProperties(coreSchema, [
 const skeletonSchemaFlattened = flattenSkeleton(skeletonSchema);
 
 fs.writeFileSync(
-  "../schemas/v3/skeleton.json",
+  path.join(outputDir, "skeleton.json"),
   JSON.stringify(skeletonSchemaFlattened, null, 2)
 );
-console.log("Flat Skeleton schema written to ../schemas/v3/skeleton.json");
+console.log(`Flat Skeleton schema written to ${path.join(outputDir, "skeleton.json")}`);
 
 // Generate compact skeleton format for better token efficiency
 const toCompact = (obj, indent = "") => {
@@ -237,7 +316,7 @@ const toCompact = (obj, indent = "") => {
     // Skip type indicators entirely
     return "";
   }
-  
+
   if (Array.isArray(obj)) {
     if (obj.length === 0) return "[]";
     // Array with content
@@ -247,16 +326,25 @@ const toCompact = (obj, indent = "") => {
     }
     return `[\n${inner}\n${indent}]`;
   }
-  
+
   if (obj && typeof obj === "object") {
     const keys = Object.keys(obj);
     if (keys.length === 0) return "";
-    
+
+    // Check if this is a keyed object (has "*" key)
+    if (keys.length === 1 && keys[0] === "*") {
+      const inner = toCompact(obj["*"], indent);
+      if (inner === "" || inner === "{*}") {
+        return "{*}"; // Keyed object of primitives (or nested keyed objects with no structure)
+      }
+      return `{*}\n${inner}`;
+    }
+
     // Process each key
     const lines = [];
     keys.forEach(k => {
       const val = toCompact(obj[k], indent + "  ");
-      
+
       if (val === "") {
         // Leaf node - just show the property name
         lines.push(`${indent}  ${k}`);
@@ -266,16 +354,19 @@ const toCompact = (obj, indent = "") => {
       } else if (val.startsWith("[")) {
         // Array with nested content - simple concatenation
         lines.push(`${indent}  ${k}${val}`);
+      } else if (val.startsWith("{*}")) {
+        // Keyed object property - simple concatenation
+        lines.push(`${indent}  ${k}${val}`);
       } else {
         // Object property - show name on its own line, content below
         lines.push(`${indent}  ${k}`);
         lines.push(val);
       }
     });
-    
+
     return lines.length > 0 ? lines.join("\n") : "";
   }
-  
+
   return "";
 };
 
@@ -284,7 +375,7 @@ const innerContent = toCompact(skeletonSchemaFlattened, "");
 const compactSkeleton = innerContent ? innerContent : "";
 
 fs.writeFileSync(
-  "../schemas/v3/compactSkeleton.txt",
+  path.join(outputDir, "compactSkeleton.txt"),
   compactSkeleton
 );
-console.log("Compact Skeleton written to ../schemas/v3/compactSkeleton.txt");
+console.log(`Compact Skeleton written to ${path.join(outputDir, "compactSkeleton.txt")}`);

--- a/src/utils/pathSkeleton.js
+++ b/src/utils/pathSkeleton.js
@@ -6,7 +6,7 @@ const combinedSchema = require("../schemas/v3/combined.json");
 // Extract fields that have overlay-specific properties
 const extractFields = [
   "baspi4", "baspi5", "nts", "nts2", "ntsl", "ntsl2",
-  "ta6", "ta7", "ta10", "lpe1", "fme1", "piq",
+  "ta6", "ta7", "ta7ed5", "ta10", "lpe1", "fme1", "piq",
   "con29R", "con29DW", "llc1", "rds", "oc1", "sr24",
 ];
 


### PR DESCRIPTION
**Package:** `@pdtf/schemas`
**Version change:** `3.5.0` → `3.6.0`)
**Branch:** `next` (tracking `schema/next`)
**Base:** `schema/master`
**Files changed:** 78 files (+36,994 / -2,823 lines)
**Date prepared:** 2026-06-04

---

## Executive Summary

This release is a major expansion of the PDTF schema system across three parallel workstreams:

1. **New Law Society form overlays** — full coverage of TA6 6th Edition and TA7 5th Edition, bringing schema support in line with the current published forms.
2. **SEF25 Seller Enquiry Form overlay** — a new top-level overlay plus 12 modular extensions implementing the Connells Seller Enquiry Form 2025 requirements.
3. **Core transaction schema additions** — new top-level data sections (`offers`, `enquiries`, `buyerCircumstances`, FENSA certificates, external IDs, source of funds) that broaden the schema's coverage of the end-to-end transaction lifecycle.

Alongside these additions, the release includes substantial test coverage, tooling improvements, and documentation updates. No breaking changes to the existing `master`-stable surface are introduced; all changes are additive or internally corrective on the `next` pre-release line.

---

## 1. New Law Society Form Overlays

### 1.1 TA6 6th Edition (`src/schemas/v3/overlays/ta6ed6.json`) — **NEW FILE (6,539 lines)**

The TA6 (Property Information Form) 6th Edition overlay is a complete, standalone annotation layer for the new edition of the Law Society seller information form. It uses the same discriminator/oneOf overlay pattern as existing form overlays and annotates every question with a `ta6ed6Ref` property (e.g. `"ta6ed6Ref": "1.4"`) to allow downstream systems to map schema paths back to printed question numbers.

**Key structural decisions:**

- **Seller's capacity discriminator** (`sellersCapacity.capacity`) — the overlay enforces three distinct branches depending on whether the seller is a legal owner, personal representative/trustee, or company officer. The company branch conditionally requires `companyName`, `companyNumber`, and `countryOfIncorporation`.
- **Off-mains drainage nesting** — correctly modelled as a nested `oneOf` within the water and drainage section, updated in a subsequent fix commit after UI testing surfaced incorrect field nesting.
- **Alteration sections** — each alteration type (extension, loft conversion, garage conversion, outbuilding, etc.) uses a discriminated `planningPermission`/`buildingRegApproval` sub-structure rather than simple yes/no fields.
- **Japanese knotweed** — includes a conditional `managementPlanInPlace` → `attachments` requirement chain.
- **EV charging point, central heating, solar panels, FENSA** — all explicitly annotated per the Edition 6 question numbering, including previously absent fields such as `centralHeatingFuel`.
- **Radon** — `radonTest` allows `"Not known"` (a TA6 Ed6 change from Ed4); `greenDealScheme` is no longer required.

**Review notes:**
- The overlay is intentionally large: every form question is mapped. Reviewers should spot-check the section numbers against the printed TA6 6th Edition form to confirm accuracy of `ta6ed6Ref` values.
- A `changeOfUse` field was initially included in `required` and was subsequently removed (correct: it does not appear in Edition 6).

---

### 1.2 TA7 5th Edition (`src/schemas/v3/overlays/ta7ed5.json`) — **NEW FILE (1,551 lines)**

The TA7 (Leasehold Information Form) 5th Edition overlay annotates leasehold-specific data under `ownership.ownershipsToBeTransferred`. It branches on `ownershipType` (Freehold / Managed Freehold-Commonhold / Leasehold) and applies `ta7ed5Ref` annotations only to the leasehold branch.

**Key structural decisions:**

- **Leasehold information** — ground rent, service charge, building insurance, managing agent, and freeholder details are all annotated with edition-5 question references.
- **Tenant's collector discriminator** (`collectsGroundRent`, `collectsBuildingInsurancePremiums`) — a `collector` enum superset was added to fix discriminator validation failures surfaced during UI testing.
- **Address blocks** — `line2`, `line3`, and `town` in compact contact/landlord address blocks intentionally omit `ta7ed5Ref` annotations (they are optional continuation fields, not numbered questions).
- **`hasTenantCompanyDissolved`** — a new discriminator/oneOf structure was added.
- **`lastDecoratedPeriod` properties** — annotated in `combined.json` to support ta7ed5 extraction.

**Review notes:**
- `ta7ed5Ref` annotations on address line fields were narrowed after review; the final state intentionally omits refs from `line2`/`line3`/`town` in compact forms — this is correct per the form.

---

### 1.3 Fixes to Existing TA6 Overlay (`src/schemas/v3/overlays/ta6.json`) — **MODIFIED**

- Sections 4.7a and 4.7b (insurance claims): `details` field removed from the required array and its `ta6Ref` removed. The `attachments` field ref was renumbered accordingly. This aligns the overlay with the actual TA6 4th Edition form where `details` is not a distinct required sub-field in these blocks.
- `specialistIssues` section: added a missing `ta6Ref: "7.8"` annotation at the parent object level.

---

## 2. SEF25 Seller Enquiry Form Overlay

### 2.1 Main SEF25 Overlay (`src/schemas/v3/overlays/sef25.json`) — **NEW FILE (1,653 lines)**

The `sef25` overlay implements the Connells Seller Enquiry Form 2025 requirements as a composable layer on top of the NTS base overlay. It annotates existing schema paths with `sef25Ref` codes (e.g. `"sef25Ref": "T1.1"`) and adds conditional `required` constraints where SEF25 mandates information that NTS leaves optional.

**Sections covered:**

| SEF25 Section | Property Path | Notes |
|---|---|---|
| T1 – Title Restrictions | `ownership.ownershipsToBeTransferred[].titleRestrictions` | Freehold only; `details` required when Yes |
| K1 – Parking | `parking.droppedKerbAccess` | Required by SEF25; Not in NTS |
| P1 – Parking Permit Cost | `parking.controlledParking.costOfPermit/Frequency` | Required when permit parking applicable |
| W1/M1 – Water & Drainage | `waterAndDrainage` | Adds `sef25Required` where NTS does not mandate |
| N1 – Neighbour Development | `neighbourDevelopment` | Adds `sef25Required`; `sef25Ref` on yesNo via nts overlay |
| Various | Insurance, material issues, warranties | Required earlier in flow than standard NTS |

**Key design choices:**

- SEF25 overlays use the same `sef25Ref`/`sef25Required`/`sef25Title` annotation convention as NTS2/NTS use `ntsRef`/`ntsRequired`.
- The `sef25` overlay is intended to be composed with `nts2023` or `nts2025` as the base — it does not stand alone.
- Fields that are already required by an NTS overlay do not duplicate the `required` constraint in SEF25 (to avoid redundancy and conflicts).
- A `dc` (disputes & complaints) extension was initially created but subsequently removed — it was determined not to be in scope for the SEF25 requirements.

---

### 2.2 SEF25 Extension Overlays — **12 NEW + 1 UPDATED + existing NTS2 UPDATED**

The extension overlay system has been extended from NTS2 to also cover SEF25. New modular extensions are in `src/schemas/v3/overlays/extensions/`:

**Newly added extensions:**

| File | Code | Description |
|---|---|---|
| `ac.json` | Alterations & Changes | Discriminated extension/loft/garage/outbuilding blocks with planning/building reg sub-questions |
| `dk.json` | Dropped Kerb | Dropped kerb access to parking (Yes/No) |
| `ic.json` | Insurance Claims | Insurance claims upfront disclosure |
| `lc.json` | Solar Lease Costs | Solar panel lease cost details |
| `mi.json` | Material Issue | Other material issue upfront |
| `nd.json` | Neighbour Development | Neighbour development disclosure |
| `pc.json` | Parking Permit Cost | Parking permit cost and frequency |
| `ph.json` | Property Hazards | Four hazard yes/no questions (asbestos, Japanese knotweed, radon, contaminated land) |
| `rw.json` | Private Right of Way | Private right of way details |
| `sc.json` | Supply Costs | Private water and sewerage associated costs |
| `sd.json` | Storm/Fire/Flood Damage | Storm, fire or flood damage disclosure |
| `ta.json` | TA Extension | TA-specific extension overlay |
| `tr.json` | Title Restrictions | Freehold title restrictions |
| `wg.json` | Warranties & Guarantees | Seven warranty categories (damp, double glazing, electrical, heating, roofing, structural, other) |

**Updated existing NTS2 extensions:** `as`, `dr`, `er`, `fd`, `hi`, `hs`, `jk`, `la`, `ma`, `mc`, `oa`, `oc`, `sb`, `sf`, `sl`, `tf` — these received minor updates (primarily adding `type: "string"` annotations, tightening `minLength`, and correcting `required` scoping that was previously applied at the wrong nesting level).

**Notable `ac.json` detail:** The alterations/changes extension is the most complex of the new additions. Each alteration type uses a discriminated `oneOf` pattern with `null` as the first branch (for "No" / unanswered) and a structured branch requiring `planningPermission`/`buildingRegApproval` discriminator sub-objects. A follow-up commit specifically addressed discriminator preservation across the extension extraction process.

---

### 2.3 Extension Overlay Extractor (`src/utils/extractExtensionOverlays.js`) — **MODIFIED**

The utility that extracts extension overlays from `combined.json` has been updated to support multiple `refType` values (previously only `nts2Ref`; now also `sef25Ref`). A `getRefConfig()` function maps each ref type to the correct annotation key names:

- `nts2Ref` → outputs as `ntsRef` (legacy mapping, preserved for backwards compatibility)
- `sef25Ref` → also outputs as `ntsRef` (SEF25 extensions appear as NTS refs in the extracted output)
- Other ref types → derived by replacing the `Ref` suffix

This means the extension overlay extraction pipeline is now ref-type-agnostic and can accommodate future form standards without further changes to the extractor's core logic.

---

## 3. Core Transaction Schema Additions

### 3.1 New Top-Level Sections (`src/schemas/v3/pdtf-transaction.json`) — **SIGNIFICANTLY MODIFIED (+5,239 lines)**

The main transaction schema has been extended with several new data domains:

#### `offers` (keyed object with `patternProperties`)
A new `offers` section enables structured capture of buyer offers against a transaction. Each offer is keyed by an offer ID and includes:
- `priceQualifier` (e.g. "Freehold", "Leasehold")
- `offerDate`, `offerPrice`
- `buyerCircumstances` (see below)
- `externalIds` (cross-system reference IDs)
- A discriminator on `buyerId` to link offers to transaction participants

#### `buyerCircumstances` (nested within offers)
Rich buyer qualification data for conveyancing and lender compatibility:
- `intendedUse` (residential / buy-to-let / etc.)
- `firstTimeBuyer`, `rightToBuy`, `ltdCompanyPurchase`
- `numberOfOwners`, `numberOfExpats`
- `giftedEquity`, `numberOfGiftedDeposits`
- `sourceOfFunds` (proof-of-funds type)
- Conditional structure for lender compatibility metadata and conveyancing quote inputs

#### `enquiries` (keyed object with `patternProperties`)
A new `enquiries` section provides a schema for structured conveyancing enquiries exchanged between parties:
- Keyed by enquiry ID
- Includes `externalIds` for cross-system referencing
- Supports reply threading and status tracking

#### `outstandingMortgage` (under `ownership`)
Added to the ownership block to capture details of any outstanding mortgage on the property — relevant for seller disclosure and financial due diligence.

#### `fensaCertificates` (under `doubleGlazing`)
An array of FENSA certificate records capturing double glazing installation certification. The array is permitted to be empty (i.e., `fensaCertificates: []` is valid when no certificates exist).

#### `sourceOfFunds` (under participant verification)
Added to participant verification to capture the source of funds type for AML (Anti-Money Laundering) compliance purposes.

#### `externalIds` (`patternProperties` on enquiries and offers)
A generic external ID map using `patternProperties` to allow arbitrary system-specific cross-referencing without polluting the main schema namespace.

---

## 4. BASPI Overlay Updates (`baspi4.json`, `baspi5.json`) — **MODIFIED**

Both BASPI overlays have been updated to add a **Buyer participant branch** to the `participants` discriminator. Previously the participant `oneOf` only modelled non-Seller and Seller roles; the Buyer role is now explicitly enumerated as a separate branch.

The `Company Director`/`Company Secretary` seller capacity branch was also tightened to conditionally require `sellersCapacityDetails` and `attachments` when the seller is acting in a company capacity.

---

## 5. Verified Claims: `terms_of_use` (`src/schemas/verifiedClaims/pdtf-verified-claims.json`) — **MODIFIED**

A `terms_of_use` object has been added to the verified claims schema as a PDTF-specific extension to the OpenID4VP `verified_claims` structure:

```json
"terms_of_use": {
  "confidentiality_level": "public" | "restricted" | "confidential",
  "allowed_roles": ["Estate Agent", "Seller's Conveyancer", ...]
}
```

This enables granular access control on verified claims:
- **`public`** — government/official data, freely shareable
- **`restricted`** — transaction participants only
- **`confidential`** — explicit role-based access; `allowed_roles` must be specified

The field is optional (not in `required`) and uses `additionalProperties: false` to prevent arbitrary extension.

---

## 6. Test Coverage (`src/tests/v3/`) — **7 NEW TEST FILES**

| File | Lines | Coverage |
|---|---|---|
| `ta6ed6.test.js` | 2,374 | TA6 Ed6 overlay path and validation |
| `ta7ed5.test.js` | 600 | TA7 Ed5 overlay path and validation |
| `enquiries.test.js` | 1,096 | Conveyancing enquiries schema |
| `offers.test.js` | 823 | Offer keyed object and buyerCircumstances |
| `buyerCircumstances.test.js` | 543 | Buyer circumstances conditional logic |
| `extensionOverlays.test.js` | 1,313 | NTS2 + SEF25 extension overlay extraction |
| `oneOfCoverage.test.js` | 203 | oneOf branch coverage verification |
| `patternProperties.test.js` | 688 | External IDs patternProperties validation |
| `verifiedClaimsValidator.test.js` | 67 | terms_of_use field validation |

The existing `transactionSchema.test.js` was also extended (+192 lines) to cover the new schema sections.

Total new test lines: **~7,707**

---

## 7. Tooling & Infrastructure

### `package.json`
- Two new npm scripts:
  - `extract-overlays` — runs `extractOverlay.js` to regenerate form overlays from `combined.json`
  - `extract-extension-overlays` — runs `extractExtensionOverlays.js` to regenerate extension overlays

### `.gitignore`
- `.npmrc` added to prevent accidental commit of npm auth tokens (a `.npmrc` containing a leaked token was committed and then removed in a subsequent fix commit during development).

### `AGENTS.md` / `CLAUDE.md`
- `AGENTS.md` added (1 line — agent instructions for AI-assisted development workflows).
- `CLAUDE.md` updated with current project guidance.

### `index.js` — **MODIFIED (+223 lines)**
The main package entry point has been updated to export and register the new overlays (`ta6ed6`, `ta7ed5`, `sef25`) and all new extension overlays so they are available via `getTransactionSchema()`.

---

## 8. Documentation

### `README.md` — **SIGNIFICANTLY UPDATED (+226 lines)**
- Version updated from `3.4.0` to `3.5.0 (3.6.0-45 pre-release)`.
- Extension overlay section updated to document both NTS2 and SEF25 extension families with full tables.
- New usage example showing SEF25 extension composition: `["nts2023", "sc", "pc", "ph", "dk", "rw", "sd", "lc", "wg", "ic", "nd", "mi", "tr"]`.
- Verified claims section extended with full `terms_of_use` documentation and confidentiality level guidance.

### `docs/sef25-extensions-ui-spec.md` — **NEW FILE (355 lines)**
A UI specification document describing the SEF25 extension overlay structure for frontend implementers. Covers pre-existing overlays, new overlays, discriminator logic, and field ordering.

---

## 9. Breaking Changes Assessment

> **Correction of earlier assessment:** This branch contains several breaking changes to the `pdtf-transaction.json` core schema that affect consumers of the existing `master`-stable surface. These are detailed below by severity.

### 9.1 Hard Breaking — Data Type Changes

These changes alter the JSON type of existing properties. Any stored data in the old type, or any code that writes/reads the old type, will fail validation or behave incorrectly against the updated schema.

#### `mpan` — `integer` → `string`
**Path:** `propertyPack.utilities.electricity.*.mpan`

The Meter Point Administration Number changed from `integer` to `string`. The commit rationale is correct (MPANs can have leading zeros and non-numeric characters), but this is a breaking change for any consumer that stored or transmitted MPANs as numbers.

```diff
- "type": "integer"
+ "type": "string"
```

#### `mprn` — `integer` → `string`
**Path:** `propertyPack.utilities.gas.*.mprn`

Same change as MPAN above. The Meter Point Reference Number is now typed as a `string`.

#### `confirmation.response` — `string` enum `["true","false"]` → `boolean`
**Path:** `propertyPack.*.sellerDeclaration.confirmation.response`

The seller declaration confirmation field changed from a string-encoded boolean (`"true"` / `"false"`) to a native JSON `boolean`. Consumers storing `"true"` or `"false"` as strings will fail validation and need data migration.

```diff
- "type": "string",
- "enum": ["true", "false"]
+ "type": "boolean"
```

---

### 9.2 Hard Breaking — Structural Property Changes

These changes alter the shape of existing objects in a non-backwards-compatible way.

#### `collectsGroundRent` — `string` → `{ collector: string, otherCollector?: string }`
**Path:** `propertyPack.ownership.ownershipsToBeTransferred[*].leaseholdInformation.groundRent.collectsGroundRent`

Previously a plain string enum (`"Landlord"`, `"Management Company"`, etc.), this is now an **object** with a `collector` sub-property and a conditional `otherCollector` field when `collector === "Other"`. This is a structural breaking change: existing data storing a string value will fail to validate and any code writing `collectsGroundRent: "Landlord"` will need to be updated to `collectsGroundRent: { collector: "Landlord" }`.

```diff
- "collectsGroundRent": "Landlord"
+ "collectsGroundRent": { "collector": "Landlord" }
```

#### `collectsBuildingInsurancePremiums` — same structural change
**Path:** `propertyPack.ownership.ownershipsToBeTransferred[*].leaseholdInformation.buildingInsurance.collectsBuildingInsurancePremiums`

Identical structural change: was a string enum, is now an object with a `collector` sub-property plus conditional `otherCollector` branch. The enum values were also reordered (`"Freeholder"` moved after `"Managing Agent"`, `"Not applicable"` added mid-list) — the reordering itself may break consumers that depend on stable ordinal positions.

---

### 9.3 Moderate Breaking — Enum Changes on Existing Fields

These add values to existing string enums. While widening an enum is technically non-breaking for a *schema validator*, it is breaking for any consumer that uses an exhaustive switch/match on the enum values (treating unexpected values as errors).

#### `hasTenantCompanyDissolved` — added `"Not applicable"`
**Path:** `propertyPack.ownership.ownershipsToBeTransferred[*].leaseholdInformation.hasTenantCompanyDissolved`

Was `["Yes", "No"]`. Now `["Yes", "No", "Not applicable"]`.

#### `isManagingAgentEmployed` — added `"Not applicable"`
**Path:** `propertyPack.ownership.ownershipsToBeTransferred[*].leaseholdInformation.isManagingAgentEmployed`

Was `["Yes", "No"]`. Now `["Yes", "No", "Not applicable"]`.

#### `collectsBuildingInsurancePremiums` collector enum — reordered, `"Not applicable"` position changed
The ordering of values in the collector enum changed between branches of the discriminator oneOf. Consumers relying on enum ordinal positions (e.g. rendering option lists in a fixed order) will observe reordered options.

---

### 9.4 Structural Breaking — Participants Discriminator Refactored

**Path:** `participants.items.oneOf`

In `master`, the participants `oneOf` has **two branches**:
- Branch 0: All non-Seller roles including `"Buyer"` (11 values in a single enum)
- Branch 1: `"Seller"` role

In `next`, it has **three branches**:
- Branch 0: All non-Seller, non-Buyer roles (10 values)
- Branch 1: `"Buyer"` role — now its own dedicated branch with `offerId` property
- Branch 2: `"Seller"` role

Validation of existing `Buyer` participant objects still passes, but the branch index has changed. Any consumer that resolves the discriminator branch by index (e.g. `schema.items.oneOf[0]`) will receive the wrong branch. Any consumer that inspects the schema to enumerate "Buyer-specific properties" (e.g. for UI generation) will now find them in a different location.

---

### 9.5 Soft Breaking — Deprecated Property Rename

#### `annualCostOfPermit` → `costOfPermit` + `costOfPermitFrequency`
**Path:** `propertyPack.parking.controlledParking.annualCostOfPermit`

`annualCostOfPermit` has been deprecated: it is retained in the schema but its `title` is now prefixed with `"(deprecated, retained for backwards compatibility — use costOfPermit + costOfPermitFrequency)"`. The two new canonical fields (`costOfPermit` and `costOfPermitFrequency`) are what BASPI5 and SEF25 overlays now require.

This is intentionally non-breaking for validators (old data still validates) but represents a property rename in the data model that consumers and data producers should migrate to.

---

### 9.6 Non-Breaking Corrections (Informational)

The following changes are technically non-breaking but relevant for completeness:

- **TA6 4th Edition overlay** — `details` removed from `required` in insurance claim sections 4.7a/4.7b. Consumers that relied on `details` being required will no longer see a validation error if it is absent. This is a bug fix, not a regression.
- **`changeOfUse`** — The property was restructured (moved within the alteration sections to align with the new TA6 Ed6 discriminator pattern) but is still present and accessible at the same logical path.
- All new overlays (`ta6ed6`, `ta7ed5`, `sef25`, extension overlays) are purely additive — they do not affect consumers that do not request them.

---

## 10. Items for Reviewer Attention

The following areas warrant specific scrutiny during peer review:

1. **Breaking changes migration plan** — The type changes (MPAN/MPRN integer→string, confirmation boolean, `collectsGroundRent`/`collectsBuildingInsurancePremiums` object restructure) require a documented migration path for existing data and consumers before this branch can be merged to `master` as a stable release. Confirm whether these are intentional semantic corrections or unintentional regressions.

2. **TA6 Ed6 question numbering** — The `ta6ed6Ref` values in `ta6ed6.json` should be spot-checked against the published Law Society TA6 6th Edition form. Any question renumbering in the printed form will not be caught by automated tests.

3. **SEF25 `sef25Required` scoping** — Several fix commits adjusted where `sef25Required` annotations live (overlay vs. extension). Reviewers should verify that the final state does not double-declare `required` for fields already covered by NTS overlays.

4. **`associatedCost` discriminator** — There were multiple iterations on the `associatedCost` frequency discriminator (flat shape → frequency discriminator → reverted → re-added lenient version). The final published shape should be confirmed as the intended approach before merge to master.

5. **SEF25 fields in core schema output** — Two commits fixed `sef25` fields leaking into the core (non-overlay) schema output. Reviewers should verify that `combined.json` and `pdtf-transaction.json` do not contain `sef25*` annotation keys outside of the overlay system.

6. **`.npmrc` token handling** — A leaked npm auth token was committed and removed during development. Confirm that git history on this branch does not contain the token in a way that would be published if the branch is merged and the repo is public.

7. **`terms_of_use` in verified claims** — The field is not in `required`. Confirm this is intentional (backwards compatibility with existing verified claims without the field).

8. **`fensaCertificates` empty array** — Confirm that allowing an empty `fensaCertificates: []` is correct for the FENSA use case rather than omitting the field entirely.

---

## Appendix: Files Changed at a Glance

| Category | Files |
|---|---|
| **New form overlays** | `ta6ed6.json`, `ta7ed5.json`, `sef25.json` |
| **New extension overlays** | `ac`, `dk`, `ic`, `lc`, `mi`, `nd`, `pc`, `ph`, `rw`, `sc`, `sd`, `ta`, `tr`, `wg` |
| **Updated extension overlays** | `as`, `dr`, `er`, `fd`, `hi`, `hs`, `jk`, `la`, `ma`, `mc`, `oa`, `oc`, `sb`, `sf`, `sl`, `tf` |
| **Updated existing overlays** | `ta6.json`, `baspi4.json`, `baspi5.json`, `fme1.json`, `lpe1.json`, `nts.json`, `nts2.json`, `ntsl.json`, `ntsl2.json`, `piq.json`, `rds.json`, `ta7.json`, `ta10.json` |
| **Core schema** | `pdtf-transaction.json`, `combined.json`, `skeleton.json`, `compactSkeleton.txt` |
| **Verified claims** | `pdtf-verified-claims.json` |
| **Tests** | 7 new test files, 1 extended |
| **Utilities** | `extractExtensionOverlays.js`, `extractOverlay.js`, `pathSkeleton.js` |
| **Docs** | `README.md`, `docs/sef25-extensions-ui-spec.md` |
| **Package** | `package.json`, `package-lock.json`, `.gitignore` |
| **Examples** | 5 v3 example files updated |